### PR TITLE
Add options.emitRedirects to @curi/core

### DIFF
--- a/documentation-website/src/client/Packages/Core.js
+++ b/documentation-website/src/client/Packages/Core.js
@@ -69,6 +69,12 @@ const router = curi(history, routes, options);`}
                 that will be used to encode the string created when generating a
                 pathname from a route and its params.
               </li>
+              <li>
+                emitRedirects - When <IJS>false</IJS> (default is <IJS>true</IJS>),
+                response objects with the <IJS>redirectTo</IJS> property will not
+                be emitted to response handlers (but they will still trigger
+                automatic redirects).
+              </li>
             </ul>
           </Subsection>
         </Section>

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `options.emitRedirects` (default `true`). When `false`, a response with a `redirectTo` property will not be emitted to subscribers. Instead, the automatic redirect will occur and the result of that navigation will emitted.
+
 ## 1.0.0-beta.23
 
 * Refer to Curi as a router, not just "config" (`CuriConfig` is now `CuriRouter`, etc.).

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -33,7 +33,8 @@ function createRouter(
     addons: userAddons = [],
     sideEffects = [],
     cache,
-    pathnameOptions
+    pathnameOptions,
+    emitRedirects = true
   } = options as RouterOptions;
 
   const beforeSideEffects: Array<ResponseHandler> = [];
@@ -159,8 +160,11 @@ function createRouter(
     if (cache) {
       cache.set(response);
     }
-    emit(response, action);
-    previous = [response, action, curi];
+
+    if (!response.redirectTo || emitRedirects) {
+      emit(response, action);
+      previous = [response, action, curi];
+    }
 
     if (response.redirectTo) {
       history.replace(response.redirectTo);

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -30,6 +30,7 @@ export interface RouterOptions {
   sideEffects?: Array<SideEffect>;
   cache?: Cache;
   pathnameOptions?: PathFunctionOptions;
+  emitRedirects?: boolean;
 }
 
 export interface CuriRouter {

--- a/packages/core/tests/curi.spec.ts
+++ b/packages/core/tests/curi.spec.ts
@@ -330,6 +330,62 @@ describe('curi', () => {
           router.respond(responseHandler);
         });
       });
+
+      describe('emitRedirects', () => {
+        it('emits redirects by default', done => {
+          const routes = [
+            {
+              name: 'Start',
+              path: '',
+              match: {
+                response: ({ set }) => {
+                  set.redirect('/other');
+                }
+              }
+            },
+            {
+              name: 'Other',
+              path: 'other'
+            }
+          ];
+          const router = curi(history, routes);
+
+          let firstCall = true;;
+          router.respond(r => {
+            if (firstCall) {
+              expect(r.name).toBe('Start');
+              firstCall = false;
+              done();
+            }
+          });
+        });
+
+        it('does not emit redirects when emitRedirects = false', done => {
+          const routes = [
+            {
+              name: 'Start',
+              path: '',
+              match: {
+                response: ({ set }) => {
+                  set.redirect('/other');
+                }
+              }
+            },
+            {
+              name: 'Other',
+              path: 'other'
+            }
+          ];
+
+          const router = curi(history, routes, {
+            emitRedirects: false
+          });
+          router.respond(r => {
+            expect(r.name).toBe('Other');
+            done();
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
#### Existing Behavior

Currently, when you call `set.redirect` in `match.response`, the resulting response object will be emitted to all response handlers and then Curi will automatically redirect to the new location.

#### New Behavior

This PR adds a new option, `emitRedirects`, which defaults to `true`, but when it is is `false`, will not emit the redirect response.

```js
{
  name: 'Profile',
  path: 'u/:id',
  match: {
    response: ({ route, set, addons }) => {
      // synchronous API to verify if user can view page
      if(!user.canViewProfile(route.params.id) {
        set.redirect(addons.pathname('Home'));
      } else {
        set.body(Profile);
      }
    }
  }
}
```

#### Why?

The benefit of not emitting the response is that you do not have to care about what to render for that response.
```jsx
function render(response) {
  if (response.redirectTo) {
    // what should you render when redirecting?
  }
  return (
    <div>
      <response.body />
    </div>
  );
}
```

This option is `true` by default because emitting all responses is the expected behavior. This is especially true on the server, where you would want to return a `301/302` response for redirects.