### PR TITLE
Add router.current method

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Expose the last generated `response` and `action` through `current` function.
 * (Internal) Set `previous` before emitting so nested response handlers are called with newest response.
 * Add `options.emitRedirects` (default `true`). When `false`, a response with a `redirectTo` property will not be emitted to subscribers. Instead, the automatic redirect will occur and the result of that navigation will emitted.
 

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -33,6 +33,11 @@ export interface RouterOptions {
   emitRedirects?: boolean;
 }
 
+export interface CurrentResponse {
+  response: Response;
+  action: Action;
+}
+
 export interface CuriRouter {
   refresh: (routeArray: Array<RouteDescriptor>) => void;
   respond: (
@@ -41,4 +46,5 @@ export interface CuriRouter {
   ) => RemoveResponseHandler;
   addons: Addons;
   history: History;
+  current(): CurrentResponse;
 }

--- a/packages/core/tests/curi.spec.ts
+++ b/packages/core/tests/curi.spec.ts
@@ -389,7 +389,50 @@ describe("curi", () => {
     });
   });
 
-  describe("refresh", () => {
+  describe('current', () => {
+    it('initial value is an object with null response and action properties', () => {
+      const router = curi(history, []);
+      expect(router.current()).toMatchObject({
+        response: null,
+        action: null
+      });
+    });
+
+    it('response and action are the last resolved response and navigation action', () => {
+      const router = curi(history, [{ name: 'Home', path: '' }]);
+      router.respond(
+        (response, action) => {
+          expect(router.current()).toMatchObject({
+            response,
+            action
+          });
+        },
+        { once: true }
+      );
+    });
+
+    it('updates properties when a new response is resolved', done => {
+      const router = curi(history, [
+        { name: 'Home', path: '' },
+        { name: 'About', path: 'about' }
+      ]);
+      let calls = 0;
+      router.respond((response, action) => {
+        calls++;
+        expect(router.current()).toMatchObject({
+          response,
+          action
+        });
+        if (calls === 2) {
+          done();
+        } else {
+          router.history.push('/about');
+        }
+      });
+    });
+  });
+
+  describe('refresh', () => {
     const err = console.error;
 
     beforeEach(() => {

--- a/packages/core/types/curi.d.ts
+++ b/packages/core/types/curi.d.ts
@@ -1,5 +1,5 @@
-import { History } from '@hickory/root';
-import { RouteDescriptor } from './types/route';
+import { History } from "@hickory/root";
+import { RouteDescriptor } from "./types/route";
 import { CuriRouter, RouterOptions } from './types/curi';
 declare function createRouter(history: History, routeArray: Array<RouteDescriptor>, options?: RouterOptions): CuriRouter;
 export default createRouter;

--- a/packages/core/types/types/curi.d.ts
+++ b/packages/core/types/types/curi.d.ts
@@ -23,9 +23,14 @@ export interface RouterOptions {
     pathnameOptions?: PathFunctionOptions;
     emitRedirects?: boolean;
 }
+export interface CurrentResponse {
+    response: Response;
+    action: Action;
+}
 export interface CuriRouter {
     refresh: (routeArray: Array<RouteDescriptor>) => void;
     respond: (fn: ResponseHandler, options?: RespondOptions) => RemoveResponseHandler;
     addons: Addons;
     history: History;
+    current(): CurrentResponse;
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `<Curious>` sets initial `response`/`action` when responsive.
+
 ## 1.0.0-alpha.2
 
 * Use `@curi/react` `v1.0.0-beta.17`.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `<Curious>` sets initial `response`/`action` when responsive.
+
 ## 1.0.0-beta.17
 
 * `<Curious>` warns if trying to pass a new `router` prop.

--- a/packages/react/src/Curious.tsx
+++ b/packages/react/src/Curious.tsx
@@ -28,6 +28,7 @@ export default class Curious extends React.Component<
   CuriousState
 > {
   stopResponding: () => void;
+  isResponsive: boolean;
 
   static contextTypes = {
     curi: PropTypes.shape({
@@ -39,7 +40,22 @@ export default class Curious extends React.Component<
 
   constructor(props: CuriousProps, context: CuriContext) {
     super(props, context);
-    this.state = { response: undefined, action: undefined };
+
+    this.isResponsive = !!(this.props.responsive || this.props.router);
+    if (this.isResponsive) {
+      let response: Response;
+      let action: Action;
+
+      if (this.props.router) {
+        const initial = this.props.router.current();
+        response = initial.response;
+        action = initial.action;
+      } else {
+        response = this.context.curi.response;
+        action = this.context.curi.action;
+      }
+      this.state = { response, action };
+    }
   }
 
   componentDidMount() {
@@ -74,15 +90,8 @@ export default class Curious extends React.Component<
   render() {
     const { curi } = this.context;
     const router = this.props.router || curi.router;
-    // when "responsive", try to use the state, fall back to context
-    // if available (useful for initial render)
-    const isResponsive = this.props.responsive || this.props.router;
-    const response = isResponsive
-      ? this.state.response || (curi && curi.response)
-      : curi.response;
-    const action = isResponsive
-      ? this.state.action || (curi && curi.action)
-      : curi.action;
+    const response = this.isResponsive ? this.state.response : curi.response;
+    const action = this.isResponsive ? this.state.action : curi.action;
     return this.props.render({ router, response, action });
   }
 }

--- a/packages/react/types/Curious.d.ts
+++ b/packages/react/types/Curious.d.ts
@@ -20,6 +20,7 @@ export interface CuriousState {
 }
 export default class Curious extends React.Component<CuriousProps, CuriousState> {
     stopResponding: () => void;
+    isResponsive: boolean;
     static contextTypes: {
         curi: PropTypes.Requireable<any>;
     };


### PR DESCRIPTION
While `router.respond` (even with `{ once: true }`) is a convenient way to do something once a response is emitted, it is also asynchronous. Sometimes you want to know what the current response is synchronously. The new method `current` returns an object with the `response` and `action` properties.

```js
const router = curi(history, routes);
const tooSoon = router.current();
// tooSoon.response === null
// tooSoon.action === null

router.respond((response, action) => {
  const justRight = router.current();
  // justRight.response === response;
  // justRight.action === action;
});
```