### PR TITLE
Add initial option to router.respond

### DIFF
--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -87,16 +87,16 @@ function createRouter(
       );
     }
 
-    const { once = false } = options || {};
+    const { once = false, initial = true } = options || {};
 
     if (once) {
-      if (mostRecent.response) {
+      if (mostRecent.response && initial) {
         fn.call(null, mostRecent.response, mostRecent.navigation, curi);
       } else {
         oneTimers.push(fn);
       }
     } else {
-      if (mostRecent.response) {
+      if (mostRecent.response && initial) {
         fn.call(null, mostRecent.response, mostRecent.navigation, curi);
       }
 

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -17,6 +17,7 @@ export type ResponseHandler = (
 ) => void;
 export interface RespondOptions {
   once?: boolean;
+  initial?: boolean;
 }
 export type RemoveResponseHandler = () => void;
 

--- a/packages/core/types/types/curi.d.ts
+++ b/packages/core/types/types/curi.d.ts
@@ -10,6 +10,7 @@ export interface Navigation {
 export declare type ResponseHandler = (response: Response, navigation?: Navigation, router?: CuriRouter) => void;
 export interface RespondOptions {
     once?: boolean;
+    initial?: boolean;
 }
 export declare type RemoveResponseHandler = () => void;
 export interface SideEffect {


### PR DESCRIPTION
This can be used to register a response handler, but wait until the next response is emitted before it is called (instead of calling it immediately if there is a response).

##### Use case

The `<Curious>` component gets its initial `response` and `navigation` values by calling `router.current`. In its `componentDidMount` lifecycle method, it subscribes to the router so that it can update its `state` when new responses are emitted. However, it also calls `setState` immediately, which triggers an extra render. With `{ initial: false }`, `<Curious>` will not call `setState` until a new `response` is emitted.