### PR TITLE
<Curious> resp handler not called on mount

### DIFF
--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* `<Curious>` does not initially call response handler (prevents extra render).
 * `<CuriBase render>` passes a single `CuriProps` object to the `render` function instead of three arguments.
 
 ## 1.0.0-alpha.3

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* `<Curious>` does not initially call response handler (prevents extra render).
 * `<CuriBase render>` passes a single `CuriProps` object to the `render` function instead of three arguments.
 
 ## 1.0.0-beta.18

--- a/packages/react/src/Curious.tsx
+++ b/packages/react/src/Curious.tsx
@@ -63,7 +63,8 @@ export default class Curious extends React.Component<
       this.stopResponding = router.respond(
         (response: Response, navigation: Navigation) => {
           this.setState({ response, navigation });
-        }
+        },
+        { initial: false }
       );
     }
   }

--- a/packages/react/tests/Curious.spec.tsx
+++ b/packages/react/tests/Curious.spec.tsx
@@ -147,6 +147,23 @@ describe("<Curious>", () => {
       );
     });
 
+    it("prevents extra setState/render when mounting", done => {
+      const fn = jest.fn(() => {
+        return null;
+      });
+      router.respond(
+        (response, navigation) => {
+          // initial render
+          const wrapper = mount(<Curious responsive={true} render={fn} />, {
+            context: { curi: { router, response, navigation } }
+          });
+          expect(fn.mock.calls.length).toBe(1);
+          done();
+        },
+        { once: true }
+      );
+    });
+
     it("warns when trying to change the responsive prop", done => {
       const oError = console.error;
       console.error = jest.fn();


### PR DESCRIPTION
Skip calling the response handler when a <Curious> component is mounted so that there isn't a double render.