### PR TITLE
Pass an object to response handlers

### DIFF
--- a/documentation-website/src/client/Examples/misc/ServerRendering.js
+++ b/documentation-website/src/client/Examples/misc/ServerRendering.js
@@ -22,13 +22,14 @@ export default ({ name }) => (
   const router = curi(history, routes);
 
   // 3. Wait for the response to be generated
-  router.respond((response, navigation) => {
+  router.respond(({ response, navigation }) => {
     // 4. Generate the HTML markup by rendering a <CuriBase> and
     // passing it the response
     const markup = renderToString(
       <CuriBase
         response={response}
         router={router}
+        navigation={navigation}
         render={renderFunction}
       />
     );

--- a/documentation-website/src/client/Examples/misc/SideEffect.js
+++ b/documentation-website/src/client/Examples/misc/SideEffect.js
@@ -22,7 +22,7 @@ export default ({ name }) => (
       <p>
         A side effect function just does something using its arguments. It is a
         response handler, but unlike ones assigned using{" "}
-        <IJS>router.response</IJS>, side effects cannot be removed.
+        <IJS>router.respond</IJS>, side effects cannot be removed.
       </p>
 
       <p>

--- a/documentation-website/src/client/Guides/GettingStarted.js
+++ b/documentation-website/src/client/Guides/GettingStarted.js
@@ -4,6 +4,7 @@ import { Link } from "@curi/react";
 import BaseGuide from "./base/BaseGuide";
 import { InlineJS as IJS, PrismBlock } from "../components/PrismBlocks";
 import { Section, Subsection } from "../components/Sections";
+import { Note } from "../components/Messages";
 
 export default ({ name }) => (
   <BaseGuide>
@@ -161,12 +162,18 @@ const router = curi(history, routes);
         against all of your routes. When it finds one that matches, it uses that
         route object to create a response object. You can subscribe to a Curi
         router with a response handler function. When a new response is created,
-        your response handler function will be called with the response object
-        and an object with additional navigation data.
+        your response handler function will be passed an object that contains a
+        response object, an object with additional navigation data, and your
+        router.
       </p>
+      <Note>
+        Response handlers are passed the router so you can define them in a
+        separate module from the <IJS>router.respond</IJS> call and still
+        reference the router.
+      </Note>
       <PrismBlock lang="javascript">
         {`const router = curi(history, routes);
-router.response((response, navigation) => {
+router.respond(({ response, navigation, router }) => {
   // whenever the location changes, this function is called
   // you can use this function to re-render your application
   // using the new response object
@@ -176,21 +183,22 @@ router.response((response, navigation) => {
 
       <p>
         Responses are generated asynchronously. A Curi router has a{" "}
-        <IJS>response</IJS> function that you can use to register a function to
-        be called whenever a new response is generated.
+        <IJS>respond</IJS> function that you can use to register a response
+        handler function, which will be called whenever a new response is
+        generated.
       </p>
       <PrismBlock lang="javascript">
         {`const router = curi(history, routes);
 // wait to render until a response is generated
-router.respond((response, navigation) => {
-  // now we can render using the response
+router.respond(({ response, navigation, router }) => {
+  // now we can render using the response,
+  // navigation, and router
 });`}
       </PrismBlock>
       <p>
-        Your location-based rendering will be centered around these response
-        objects, so you should be familiar with the different properties that
-        will be available to you. We will get into more details about responses
-        in the{" "}
+        Your rendering will be centered around these response objects, so you
+        should be familiar with the different properties that will be available
+        to you. We will get into more details about responses in the{" "}
         <Link to="Guide" params={{ slug: "responses" }}>
           Rendering with Responses
         </Link>{" "}

--- a/documentation-website/src/client/Guides/MigrateReactRouterv3.js
+++ b/documentation-website/src/client/Guides/MigrateReactRouterv3.js
@@ -351,7 +351,7 @@ const router = create1router(history, routes);`}
         we should usually just wait for our initial response to be ready.
       </p>
       <PrismBlock lang="javascript">
-        {`router.respond((response, navigation) => {
+        {`router.respond(({ response, navigation }) => {
   // now our first response has resolved, so we
   // know that we will render with an actual response
 });`}
@@ -413,7 +413,7 @@ const router = create1router(history, routes);`}
           application.
         </p>
         <PrismBlock lang="jsx">
-          {`router.respond((response, navigation) => {
+          {`router.respond(({ response, navigation }) => {
   ReactDOM.render((
     <CuriBase
       response={response}

--- a/documentation-website/src/client/Guides/ReactBasics.js
+++ b/documentation-website/src/client/Guides/ReactBasics.js
@@ -153,7 +153,7 @@ const routes = [
             re-call <IJS>ReactDOM.render</IJS>.
           </p>
           <PrismBlock lang="jsx">
-            {`router.respond((response, navigation) => {
+            {`router.respond(({ response, navigation }) => {
   ReactDOM.render((
     <CuriBase
       router={router}

--- a/documentation-website/src/client/Guides/UsingSideEffects.js
+++ b/documentation-website/src/client/Guides/UsingSideEffects.js
@@ -24,7 +24,7 @@ export default ({ name }) => (
     </p>
 
     <PrismBlock lang="javascript">
-      {`function logResponse(response) {
+      {`function logResponse({ response }) {
   // call your logging API to record the response
 }`}
     </PrismBlock>
@@ -88,8 +88,9 @@ export default ({ name }) => (
         object.
       </p>
       <PrismBlock lang="javascript">
-        {`function mySideEffect(response, navigation) {
+        {`function mySideEffect({ response, navigation }) {
   console.log('Navigating to', response.location);
+  console.log('Navigation action:', navigation.action);
 }
 
 const router = curi(history, routes, {
@@ -108,7 +109,7 @@ const router = curi(history, routes, {
   const logger = setupMyLogger(options);
 
   // and return the actual side effect function
-  return sideEffect(response, navigation) {
+  return sideEffect({ response }) {
     logger(response);
   }
 }`}

--- a/documentation-website/src/client/Packages/Core.js
+++ b/documentation-website/src/client/Packages/Core.js
@@ -100,7 +100,7 @@ const router = curi(history, routes, options);`}
               resolved.
             </p>
             <PrismBlock lang="javascript">
-              {`router.respond((response) => {
+              {`router.respond(({ response }) => {
   // render the application based on the response
 });`}
             </PrismBlock>
@@ -132,7 +132,7 @@ const tooSoon = router.current();
 // tooSoon.response === null
 // tooSoon.navigation === null
 
-router.respond((response, navigation) => {
+router.respond(({ response, navigation }) => {
   const justRight = router.current();
   // justRight.response === response
   // justRight.navigation === navigation

--- a/documentation-website/src/client/Packages/ReactPkg.js
+++ b/documentation-website/src/client/Packages/ReactPkg.js
@@ -38,10 +38,11 @@ export default ({ name, version, globalName }) => (
         <PrismBlock lang="jsx">
           {`const router = curi(history, routes);
 
-router.respond((response) => {
+router.respond(({ response, navigation }) => {
   ReactDOM.render((
     <CuriBase
       response={response}
+      navigation={navigation}
       router={router}
       render={({ response }) => {
         return response.body ? <response.body /> : null;

--- a/documentation-website/src/client/Packages/Svelte.js
+++ b/documentation-website/src/client/Packages/Svelte.js
@@ -79,7 +79,7 @@ const store = new Store({
         response is emitted.
       </p>
       <PrismBlock lang="javascript">
-        {`router.respond((response, navigation) => {
+        {`router.respond(({ response, navigation }) => {
   store.set({ curi: { response, navigation } });
 });`}
       </PrismBlock>

--- a/documentation-website/src/client/Tutorials/04-Router.js
+++ b/documentation-website/src/client/Tutorials/04-Router.js
@@ -94,14 +94,15 @@ const router = curi(history, routes);`}
         created.
       </p>
       <p>
-        What does a response handler function look like? It can take two
-        arguments. The first will be the <IJS>response</IJS> object generated
-        for the new location. The second is the <IJS>navigation</IJS> object,
-        which has properties related to the last navigation (the navigation's{" "}
-        <IJS>action</IJS> string and the <IJS>previous</IJS> response object).
+        What does a response handler function look like? It receives an object
+        with three properties: <IJS>response</IJS>, <IJS>navigation</IJS>, and{" "}
+        <IJS>router</IJS>. The <IJS>response</IJS> contains information about
+        the route that matched the new location, the <IJS>navigation</IJS>{" "}
+        contains navigation data that doesn't belong in a <IJS>response</IJS>,
+        and the <IJS>router</IJS> is your Curi router.
       </p>
       <PrismBlock lang="javascript">
-        {`function responseLogger(response, navigation) {
+        {`function responseLogger({ response, navigation }) {
   console.log("RESPONSE:", response);
   console.log("NAVIGATION", navigation)
 }
@@ -112,7 +113,7 @@ router.respond(responseLogger);`}
         responding to new responses.
       </p>
       <PrismBlock lang="javascript">
-        {`function responseLogger(response, navigation) {
+        {`function responseLogger() {
   console.log("I will be called for every response until I unsubscribe");
 }
 const stopResponding = router.respond(responseLogger);
@@ -122,17 +123,17 @@ stopResponding();
 // after unsubscribing, any new navigation will not be logged`}
       </PrismBlock>
       <p>
-        While most response handlers should be subscribers (that is to say, you
-        want them to be called every time a new response is generated), you
-        might sometimes want to only call a response handler once. For example,
-        a response handler might be a "ready" function that you only want called
-        once you know that a response exists. To do that, you can use the second
-        argument to <IJS>router.respond</IJS>, which is an options object. When
-        the <IJS>once</IJS> object is <IJS>true</IJS>, then that response
-        handler will only be called one time.
+        By default, response handlers are subscribers (that is to say, they will
+        be called every time a new response is generated). You might sometimes
+        want to only call a response handler once. For example, a response
+        handler might be a "ready" function that you only want called once you
+        know that an initial response exists. To do that, you can use the second
+        argument to <IJS>router.respond</IJS>, which is an <IJS>options</IJS>{" "}
+        object. When the <IJS>once</IJS> object is <IJS>true</IJS>, then that
+        response handler will only be called one time.
       </p>
       <PrismBlock lang="javascript">
-        {`function responseLogger(response, navigation) {
+        {`function responseLogger() {
   console.log("I will only be called once");
 }
 router.respond(responseLogger, { once: true });`}

--- a/documentation-website/src/client/Tutorials/05-ReactPages.js
+++ b/documentation-website/src/client/Tutorials/05-ReactPages.js
@@ -148,7 +148,7 @@ import { CuriBase } from '@curi/react';
 
 // ...
 
-router.respond((response, navigation) => {
+router.respond(({ response, navigation }) => {
   ReactDOM.render((
     <CuriBase
       router={router}
@@ -454,7 +454,7 @@ export default function({ response }) {
 import renderFunction from './render';
 
 let root = document.getElementById('root');
-router.respond((response, navigation) => {
+router.respond(({ response, navigation }) => {
   ReactDOM.render((
     <CuriBase
       router={router}

--- a/documentation-website/src/client/Tutorials/05-VuePages.js
+++ b/documentation-website/src/client/Tutorials/05-VuePages.js
@@ -214,7 +214,7 @@ Vue.use(CuriPlugin, { router });`}
         {`// src/index.js
 import app from './components/app';
 
-router.respond(response => {
+router.respond(() => {
   const vm = new Vue({
     el: '#root',
     template: '<app />',

--- a/documentation-website/src/client/components/Banner/GenericBanner.js
+++ b/documentation-website/src/client/components/Banner/GenericBanner.js
@@ -21,7 +21,7 @@ const router = curi(history, routes);
 
 // subscribe to the router object with a function
 // that will be called whenever the location changes
-router.respond((response, navigation) => {
+router.respond(() => {
   // handle any rendering inside of this function
 });`}
   </PrismBlock>

--- a/documentation-website/src/client/components/Banner/ReactBanner.js
+++ b/documentation-website/src/client/components/Banner/ReactBanner.js
@@ -8,7 +8,7 @@ import ReactDOM from 'react-dom';
 
 import Browser from '@hickory/browser';
 import curi from '@curi/core';
-import { CuriBase } from '@curi/react';
+import { ResponsiveBase } from '@curi/react';
 
 // create your history object
 const history = Browser();
@@ -26,10 +26,9 @@ const router = curi(history, routes);
 const root = document.getElementById('root');
 // subscribe to the router object with a function
 // that will be called whenever the location changes
-router.respond((response) => {
+router.respond(() => {
   ReactDOM.render((
-    <CuriBase
-      response={response}
+    <ResponsiveBase
       router={router}
       render={({ response }) => {
         return <response.body />;

--- a/documentation-website/src/client/components/Banner/SvelteBanner.js
+++ b/documentation-website/src/client/components/Banner/SvelteBanner.js
@@ -32,7 +32,7 @@ const root = document.getElementById('root');
 
 // setup a subscriber that will update the store when
 // the location changes.
-router.respond((response, navigation) => {
+router.respond(({ response, navigation }) => {
   store.set({ curi: { response, navigation } });
 });
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Pass a `ResponseHandlerProps` object to response handlers. This object has `response`, `navigation`, and `router` properties.
+* Pass a `Emitted` object to response handlers. This object has `response`, `navigation`, and `router` properties.
 
 ## 1.0.0-beta.25
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Pass a `Emitted` object to response handlers. This object has `response`, `navigation`, and `router` properties.
+* Pass an `Emitted` object to response handlers. This object has `response`, `navigation`, and `router` properties.
 
 ## 1.0.0-beta.25
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Pass a `ResponseHandlerProps` object to response handlers. This object has `response`, `navigation`, and `router` properties.
+
 ## 1.0.0-beta.25
 
 * Add `initial` property to response handler options (default is `true`). When `false`, the response handler will not be called until a new response is emitted.

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -19,6 +19,7 @@ import {
   RouterOptions,
   SideEffect,
   ResponseHandler,
+  ResponseHandlerProps,
   RespondOptions,
   RemoveResponseHandler,
   Cache,
@@ -91,13 +92,13 @@ function createRouter(
 
     if (once) {
       if (mostRecent.response && initial) {
-        fn.call(null, mostRecent.response, mostRecent.navigation, curi);
+        fn.call(null, { ...mostRecent, router });
       } else {
         oneTimers.push(fn);
       }
     } else {
       if (mostRecent.response && initial) {
-        fn.call(null, mostRecent.response, mostRecent.navigation, curi);
+        fn.call(null, { ...mostRecent, router });
       }
 
       const newLength = responseHandlers.push(fn);
@@ -108,24 +109,25 @@ function createRouter(
   }
 
   function emit(response: Response, navigation: Navigation): void {
+    const handlerProps: ResponseHandlerProps = { response, navigation, router };
     beforeSideEffects.forEach(fn => {
-      fn(response, navigation, curi);
+      fn(handlerProps);
     });
 
     responseHandlers.forEach(fn => {
       if (fn != null) {
-        fn(response, navigation, curi);
+        fn(handlerProps);
       }
     });
     // calling one time responseHandlers after regular responseHandlers
     // ensures that those are called prior to the one time fns
     while (oneTimers.length) {
       const fn = oneTimers.pop();
-      fn(response, navigation, curi);
+      fn(handlerProps);
     }
 
     afterSideEffects.forEach(fn => {
-      fn(response, navigation, curi);
+      fn(handlerProps);
     });
   }
 
@@ -181,7 +183,7 @@ function createRouter(
   setupRoutesAndAddons(routeArray);
   history.respondWith(navigationHandler);
 
-  const curi: CuriRouter = {
+  const router: CuriRouter = {
     addons: registeredAddons,
     history,
     respond,
@@ -194,7 +196,7 @@ function createRouter(
     }
   };
 
-  return curi;
+  return router;
 }
 
 export default createRouter;

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -19,7 +19,7 @@ import {
   RouterOptions,
   SideEffect,
   ResponseHandler,
-  ResponseHandlerProps,
+  Emitted,
   RespondOptions,
   RemoveResponseHandler,
   Cache,
@@ -109,25 +109,25 @@ function createRouter(
   }
 
   function emit(response: Response, navigation: Navigation): void {
-    const handlerProps: ResponseHandlerProps = { response, navigation, router };
+    const resp: Emitted = { response, navigation, router };
     beforeSideEffects.forEach(fn => {
-      fn(handlerProps);
+      fn(resp);
     });
 
     responseHandlers.forEach(fn => {
       if (fn != null) {
-        fn(handlerProps);
+        fn(resp);
       }
     });
     // calling one time responseHandlers after regular responseHandlers
     // ensures that those are called prior to the one time fns
     while (oneTimers.length) {
       const fn = oneTimers.pop();
-      fn(handlerProps);
+      fn(resp);
     }
 
     afterSideEffects.forEach(fn => {
-      fn(handlerProps);
+      fn(resp);
     });
   }
 

--- a/packages/core/src/route.ts
+++ b/packages/core/src/route.ts
@@ -1,17 +1,10 @@
-import { HickoryLocation, ToArgument } from '@hickory/root';
-import PathToRegexp from 'path-to-regexp';
+import { HickoryLocation, ToArgument } from "@hickory/root";
+import PathToRegexp from "path-to-regexp";
 
-import once from './utils/once';
+import once from "./utils/once";
 
-import {
-  RouteDescriptor,
-  InternalRoute,
-  EveryMatchFn,
-  InitialMatchFn,
-  ResponseMatchFn
-} from './types/route';
-import { ResponseProps } from './types/response';
-import { Key } from 'path-to-regexp';
+import { RouteDescriptor, InternalRoute } from "./types/route";
+import { Key } from "path-to-regexp";
 
 const createRoute = (options: RouteDescriptor): InternalRoute => {
   const {

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -10,11 +10,14 @@ export interface Navigation {
   previous: Response;
 }
 
-export type ResponseHandler = (
-  response: Response,
-  navigation?: Navigation,
-  router?: CuriRouter
-) => void;
+export interface ResponseHandlerProps {
+  response: Response;
+  navigation: Navigation;
+  router: CuriRouter;
+}
+
+export type ResponseHandler = (props?: ResponseHandlerProps) => void;
+
 export interface RespondOptions {
   once?: boolean;
   initial?: boolean;

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -10,13 +10,13 @@ export interface Navigation {
   previous: Response;
 }
 
-export interface ResponseHandlerProps {
+export interface Emitted {
   response: Response;
   navigation: Navigation;
   router: CuriRouter;
 }
 
-export type ResponseHandler = (props?: ResponseHandlerProps) => void;
+export type ResponseHandler = (props?: Emitted) => void;
 
 export interface RespondOptions {
   once?: boolean;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -16,7 +16,7 @@ export {
   CuriRouter,
   RouterOptions,
   ResponseHandler,
-  ResponseHandlerProps,
+  Emitted,
   RemoveResponseHandler,
   SideEffect,
   Cache,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -16,6 +16,7 @@ export {
   CuriRouter,
   RouterOptions,
   ResponseHandler,
+  ResponseHandlerProps,
   RemoveResponseHandler,
   SideEffect,
   Cache,

--- a/packages/core/tests/path.spec.ts
+++ b/packages/core/tests/path.spec.ts
@@ -1,124 +1,124 @@
-import 'jest';
-import curi from '../src/curi';
-import InMemory from '@hickory/in-memory';
+import "jest";
+import curi from "../src/curi";
+import InMemory from "@hickory/in-memory";
 
-describe('route.pathOptions matching', () => {
-  describe('default options', () => {
-    it('sensitive = false', done => {
-      const history = InMemory({ locations: ['/Here'] });
+describe("route.pathOptions matching", () => {
+  describe("default options", () => {
+    it("sensitive = false", done => {
+      const history = InMemory({ locations: ["/Here"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'here'
+          name: "Test",
+          path: "here"
         },
         {
-          name: 'Not Found',
-          path: '(.*)'
+          name: "Not Found",
+          path: "(.*)"
         }
       ];
       const router = curi(history, routes);
-      router.respond(response => {
-        expect(response.name).toBe('Test');
+      router.respond(({ response }) => {
+        expect(response.name).toBe("Test");
         done();
       });
     });
 
-    it('strict = false', done => {
-      const history = InMemory({ locations: ['/here/'] });
+    it("strict = false", done => {
+      const history = InMemory({ locations: ["/here/"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'here'
+          name: "Test",
+          path: "here"
         },
         {
-          name: 'Not Found',
-          path: '(.*)'
+          name: "Not Found",
+          path: "(.*)"
         }
       ];
       const router = curi(history, routes);
-      router.respond(response => {
-        expect(response.name).toBe('Test');
+      router.respond(({ response }) => {
+        expect(response.name).toBe("Test");
         done();
       });
     });
 
-    it('end = true', done => {
-      const history = InMemory({ locations: ['/here/again'] });
+    it("end = true", done => {
+      const history = InMemory({ locations: ["/here/again"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'here'
+          name: "Test",
+          path: "here"
         },
         {
-          name: 'Not Found',
-          path: '(.*)'
+          name: "Not Found",
+          path: "(.*)"
         }
       ];
       const router = curi(history, routes);
-      router.respond(response => {
-        expect(response.name).toBe('Not Found');
+      router.respond(({ response }) => {
+        expect(response.name).toBe("Not Found");
         done();
       });
     });
   });
 
-  describe('user provided options', () => {
-    it('sensitive = true', done => {
-      const history = InMemory({ locations: ['/Here'] });
+  describe("user provided options", () => {
+    it("sensitive = true", done => {
+      const history = InMemory({ locations: ["/Here"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'here',
+          name: "Test",
+          path: "here",
           pathOptions: { sensitive: true }
         },
         {
-          name: 'Not Found',
-          path: '(.*)'
+          name: "Not Found",
+          path: "(.*)"
         }
       ];
       const router = curi(history, routes);
-      router.respond(response => {
-        expect(response.name).toBe('Not Found');
+      router.respond(({ response }) => {
+        expect(response.name).toBe("Not Found");
         done();
       });
     });
 
-    it('strict = true', done => {
-      const history = InMemory({ locations: ['/here/'] });
+    it("strict = true", done => {
+      const history = InMemory({ locations: ["/here/"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'here',
+          name: "Test",
+          path: "here",
           pathOptions: { strict: true }
         },
         {
-          name: 'Not Found',
-          path: '(.*)'
+          name: "Not Found",
+          path: "(.*)"
         }
       ];
       const router = curi(history, routes);
-      router.respond(response => {
-        expect(response.name).toBe('Not Found');
+      router.respond(({ response }) => {
+        expect(response.name).toBe("Not Found");
         done();
       });
     });
 
-    it('end = false', done => {
-      const history = InMemory({ locations: ['/here/again'] });
+    it("end = false", done => {
+      const history = InMemory({ locations: ["/here/again"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'here',
+          name: "Test",
+          path: "here",
           pathOptions: { end: false }
         },
         {
-          name: 'Not Found',
-          path: '(.*)'
+          name: "Not Found",
+          path: "(.*)"
         }
       ];
       const router = curi(history, routes);
-      router.respond(response => {
-        expect(response.name).toBe('Test');
+      router.respond(({ response }) => {
+        expect(response.name).toBe("Test");
         done();
       });
     });

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -1,210 +1,208 @@
-import 'jest';
-import curi from '../src/curi';
-import InMemory from '@hickory/in-memory';
+import "jest";
+import curi from "../src/curi";
+import InMemory from "@hickory/in-memory";
 
-describe('route matching/response generation', () => {
-  describe('route matching', () => {
-    it('ignores leading slash on the pathname', done => {
-      const history = InMemory({ locations: ['/test'] });
+describe("route matching/response generation", () => {
+  describe("route matching", () => {
+    it("ignores leading slash on the pathname", done => {
+      const history = InMemory({ locations: ["/test"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'test'
+          name: "Test",
+          path: "test"
         }
       ];
       const router = curi(history, routes);
-      router.respond(response => {
-        expect(response.name).toBe('Test');
+      router.respond(({ response }) => {
+        expect(response.name).toBe("Test");
         done();
       });
     });
 
-    it('does exact matching', done => {
-      const history = InMemory({ locations: ['/test/leftovers'] });
+    it("does exact matching", done => {
+      const history = InMemory({ locations: ["/test/leftovers"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'test'
+          name: "Test",
+          path: "test"
         },
         {
-          name: 'Not Found',
-          path: '(.*)'
+          name: "Not Found",
+          path: "(.*)"
         }
       ];
       const router = curi(history, routes);
-      router.respond(response => {
-        expect(response.name).toBe('Not Found');
+      router.respond(({ response }) => {
+        expect(response.name).toBe("Not Found");
         done();
       });
     });
 
-    describe('nested routes', () => {
-      it('includes parent if partials if a child matches', done => {
-        const history = InMemory({ locations: ['/ND/Fargo'] });
+    describe("nested routes", () => {
+      it("includes parent if partials if a child matches", done => {
+        const history = InMemory({ locations: ["/ND/Fargo"] });
         const routes = [
           {
-            name: 'State',
-            path: ':state',
+            name: "State",
+            path: ":state",
             children: [
               {
-                name: 'City',
-                path: ':city'
+                name: "City",
+                path: ":city"
               }
             ]
           }
         ];
         const router = curi(history, routes);
-        router.respond(response => {
-          expect(response.name).toBe('City');
-          expect(response.partials).toEqual(['State']);
+        router.respond(({ response }) => {
+          expect(response.name).toBe("City");
+          expect(response.partials).toEqual(["State"]);
           done();
         });
       });
 
-      it('does non-end parent matching when there are child routes, even if pathOptions.end=true', done => {
-        const history = InMemory({ locations: ['/ND/Fargo'] });
+      it("does non-end parent matching when there are child routes, even if pathOptions.end=true", done => {
+        const history = InMemory({ locations: ["/ND/Fargo"] });
         const routes = [
           {
-            name: 'State',
-            path: ':state',
+            name: "State",
+            path: ":state",
             pathOptions: { end: true },
             children: [
               {
-                name: 'City',
-                path: ':city'
+                name: "City",
+                path: ":city"
               }
             ]
           }
         ];
         const router = curi(history, routes);
-        router.respond(response => {
-          expect(response.name).toBe('City');
-          expect(response.partials).toEqual(['State']);
+        router.respond(({ response }) => {
+          expect(response.name).toBe("City");
+          expect(response.partials).toEqual(["State"]);
           done();
         });
       });
 
-      it('skips parent match if no children match', done => {
-        const history = InMemory({ locations: ['/MT/Bozeman'] });
+      it("skips parent match if no children match", done => {
+        const history = InMemory({ locations: ["/MT/Bozeman"] });
         const routes = [
           {
-            name: 'State',
-            path: ':state',
+            name: "State",
+            path: ":state",
             children: [
               {
-                name: 'Wat',
-                path: 'wat'
+                name: "Wat",
+                path: "wat"
               }
             ]
           },
           {
-            name: 'Not Found',
-            path: '(.*)'
+            name: "Not Found",
+            path: "(.*)"
           }
         ];
         const router = curi(history, routes);
-        router.respond(response => {
-          expect(response.name).toBe('Not Found');
+        router.respond(({ response }) => {
+          expect(response.name).toBe("Not Found");
           expect(response.partials).toEqual([]);
           done();
         });
       });
     });
 
-    it('matches partial routes if route.pathOptions.end=false', done => {
-      const history = InMemory({ locations: ['/SD/Sioux City'] });
+    it("matches partial routes if route.pathOptions.end=false", done => {
+      const history = InMemory({ locations: ["/SD/Sioux City"] });
       const routes = [
         {
-          name: 'State',
-          path: ':state',
+          name: "State",
+          path: ":state",
           pathOptions: { end: false }
         },
         {
-          name: 'Not Found',
-          path: '(.*)'
+          name: "Not Found",
+          path: "(.*)"
         }
       ];
       const router = curi(history, routes);
-      router.respond(response => {
-        expect(response.name).toBe('State');
+      router.respond(({ response }) => {
+        expect(response.name).toBe("State");
         done();
       });
     });
   });
 
-  describe('response', () => {
-    it('if either initial or every response fns have uncaught errors, error is passed to response fn', done => {
+  describe("response", () => {
+    it("if either initial or every response fns have uncaught errors, error is passed to response fn", done => {
       const routes = [
         {
-          name: 'Contact',
-          path: 'contact',
+          name: "Contact",
+          path: "contact",
           match: {
             every: () => {
-              return Promise.reject('This is an error');
+              return Promise.reject("This is an error");
             },
             response: ({ error }) => {
-              expect(error).toBe('This is an error');
+              expect(error).toBe("This is an error");
+              done();
             }
           }
         }
       ];
       const history = InMemory({
-        locations: ['/contact']
+        locations: ["/contact"]
       });
       const router = curi(history, routes);
-      router.respond(response => {
-        done();
-      });
     });
 
-    describe('properties', () => {
-      describe('key', () => {
-        it('is the key property from the location', done => {
+    describe("properties", () => {
+      describe("key", () => {
+        it("is the key property from the location", done => {
           const routes = [];
-          const history = InMemory({ locations: ['/other-page'] });
+          const history = InMemory({ locations: ["/other-page"] });
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.key).toBe(history.location.key);
             done();
           });
         });
       });
 
-      describe('location', () => {
-        it('is the location used to match routes', done => {
+      describe("location", () => {
+        it("is the location used to match routes", done => {
           const routes = [];
-          const history = InMemory({ locations: ['/other-page'] });
+          const history = InMemory({ locations: ["/other-page"] });
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.location).toBe(history.location);
             done();
           });
         });
       });
 
-      describe('body', () => {
+      describe("body", () => {
         it("is undefined if it isn't set in match.response", done => {
-          const history = InMemory({ locations: ['/test'] });
+          const history = InMemory({ locations: ["/test"] });
           const routes = [
             {
-              name: 'Test',
-              path: 'test'
+              name: "Test",
+              path: "test"
             }
           ];
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.body).toBeUndefined();
             done();
           });
         });
 
-        it('is the value set with set.body', done => {
-          const history = InMemory({ locations: ['/test'] });
-          const body = () => 'anybody out there?';
+        it("is the value set with set.body", done => {
+          const history = InMemory({ locations: ["/test"] });
+          const body = () => "anybody out there?";
           const routes = [
             {
-              name: 'Test',
-              path: 'test',
+              name: "Test",
+              path: "test",
               match: {
                 response: ({ set }) => {
                   set.body(body);
@@ -213,47 +211,47 @@ describe('route matching/response generation', () => {
             }
           ];
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.body).toBe(body);
             done();
           });
         });
       });
 
-      describe('status', () => {
-        it('is 200 if a route matches', done => {
+      describe("status", () => {
+        it("is 200 if a route matches", done => {
           const routes = [
             {
-              name: 'Contact',
-              path: 'contact',
+              name: "Contact",
+              path: "contact",
               children: [
-                { name: 'Email', path: 'email' },
-                { name: 'Phone', path: 'phone' }
+                { name: "Email", path: "email" },
+                { name: "Phone", path: "phone" }
               ]
             }
           ];
-          const history = InMemory({ locations: ['/contact'] });
+          const history = InMemory({ locations: ["/contact"] });
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.status).toBe(200);
             done();
           });
         });
 
-        it('is 404 if no routes match', done => {
+        it("is 404 if no routes match", done => {
           const routes = [
             {
-              name: 'Contact',
-              path: 'contact',
+              name: "Contact",
+              path: "contact",
               children: [
-                { name: 'Email', path: 'email' },
-                { name: 'Phone', path: 'phone' }
+                { name: "Email", path: "email" },
+                { name: "Phone", path: "phone" }
               ]
             }
           ];
-          const history = InMemory({ locations: ['/other-page'] });
+          const history = InMemory({ locations: ["/other-page"] });
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.status).toBe(404);
             done();
           });
@@ -262,8 +260,8 @@ describe('route matching/response generation', () => {
         it("is the value set by calling status in the matching route's match.response function", done => {
           const routes = [
             {
-              name: 'A Route',
-              path: '',
+              name: "A Route",
+              path: "",
               match: {
                 response: ({ set }) => {
                   set.status(451);
@@ -271,30 +269,30 @@ describe('route matching/response generation', () => {
               }
             }
           ];
-          const history = InMemory({ locations: ['/'] });
+          const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.status).toBe(451);
             done();
           });
         });
 
-        it('is set by calling set.redirect in the matching match.response', done => {
+        it("is set by calling set.redirect in the matching match.response", done => {
           const routes = [
             {
-              name: '302 Route',
-              path: '',
+              name: "302 Route",
+              path: "",
               match: {
                 response: ({ set }) => {
-                  set.redirect('/somewhere', 302);
+                  set.redirect("/somewhere", 302);
                 }
               }
             }
           ];
-          const history = InMemory({ locations: ['/'] });
+          const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
           let firstCall = true;
-          router.respond(response => {
+          router.respond(({ response }) => {
             if (firstCall) {
               expect(response.status).toBe(302);
               firstCall = false;
@@ -303,22 +301,22 @@ describe('route matching/response generation', () => {
           });
         });
 
-        it('is set to 301 by default when calling set.redirect in match.response', done => {
+        it("is set to 301 by default when calling set.redirect in match.response", done => {
           const routes = [
             {
-              name: '301 Route',
-              path: '',
+              name: "301 Route",
+              path: "",
               match: {
                 response: ({ set }) => {
-                  set.redirect('/somewhere');
+                  set.redirect("/somewhere");
                 }
               }
             }
           ];
-          const history = InMemory({ locations: ['/'] });
+          const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
           let firstCall = true;
-          router.respond(response => {
+          router.respond(({ response }) => {
             if (firstCall) {
               expect(response.status).toBe(301);
               firstCall = false;
@@ -328,219 +326,219 @@ describe('route matching/response generation', () => {
         });
       });
 
-      describe('data', () => {
-        it('is undefined by default', done => {
+      describe("data", () => {
+        it("is undefined by default", done => {
           const routes = [
             {
-              name: 'A Route',
-              path: ''
+              name: "A Route",
+              path: ""
             }
           ];
-          const history = InMemory({ locations: ['/'] });
+          const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.data).toBeUndefined();
             done();
           });
         });
 
-        it('is the value set by calling set.data in match.response', done => {
+        it("is the value set by calling set.data in match.response", done => {
           const routes = [
             {
-              name: 'A Route',
-              path: '',
+              name: "A Route",
+              path: "",
               match: {
                 response: ({ set }) => {
-                  set.data({ test: 'value' });
+                  set.data({ test: "value" });
                 }
               }
             }
           ];
-          const history = InMemory({ locations: ['/'] });
+          const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
-          router.respond(response => {
-            expect(response.data).toMatchObject({ test: 'value' });
+          router.respond(({ response }) => {
+            expect(response.data).toMatchObject({ test: "value" });
             done();
           });
         });
       });
 
-      describe('title', () => {
-        it('is an empty string when there is no matched route', done => {
+      describe("title", () => {
+        it("is an empty string when there is no matched route", done => {
           const routes = [
             {
-              name: 'State',
-              path: ':state'
+              name: "State",
+              path: ":state"
             }
           ];
-          const history = InMemory({ locations: ['/'] });
+          const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
 
-          router.respond(response => {
-            expect(response.title).toBe('');
+          router.respond(({ response }) => {
+            expect(response.title).toBe("");
             done();
           });
         });
 
-        it('is an empty string if the matched route does not have a title property', done => {
+        it("is an empty string if the matched route does not have a title property", done => {
           const routes = [
             {
-              name: 'State',
-              path: ':state'
+              name: "State",
+              path: ":state"
             }
           ];
-          const history = InMemory({ locations: ['/AZ'] });
+          const history = InMemory({ locations: ["/AZ"] });
           const router = curi(history, routes);
 
-          router.respond(response => {
-            expect(response.title).toBe('');
+          router.respond(({ response }) => {
+            expect(response.title).toBe("");
             done();
           });
         });
 
-        it('is the value set by calling set.title in match.response', done => {
+        it("is the value set by calling set.title in match.response", done => {
           const routes = [
             {
-              name: 'State',
-              path: ':state',
+              name: "State",
+              path: ":state",
               match: {
                 response: ({ set }) => {
-                  set.title('A State');
+                  set.title("A State");
                 }
               }
             }
           ];
-          const history = InMemory({ locations: ['/VA'] });
+          const history = InMemory({ locations: ["/VA"] });
           const router = curi(history, routes);
 
-          router.respond(response => {
-            expect(response.title).toBe('A State');
+          router.respond(({ response }) => {
+            expect(response.title).toBe("A State");
             done();
           });
         });
       });
 
-      describe('name', () => {
-        it('is the name of the best matching route', done => {
+      describe("name", () => {
+        it("is the name of the best matching route", done => {
           const Route = {
-            name: 'A Route',
-            path: 'a-route'
+            name: "A Route",
+            path: "a-route"
           };
-          const history = InMemory({ locations: ['/a-route'] });
+          const history = InMemory({ locations: ["/a-route"] });
           const router = curi(history, [Route]);
-          router.respond(response => {
-            expect(response.name).toBe('A Route');
+          router.respond(({ response }) => {
+            expect(response.name).toBe("A Route");
             done();
           });
         });
 
-        it('is undefined if no routes match', done => {
+        it("is undefined if no routes match", done => {
           const Route = {
-            name: 'A Route',
-            path: 'a-route'
+            name: "A Route",
+            path: "a-route"
           };
-          const history = InMemory({ locations: ['/'] });
+          const history = InMemory({ locations: ["/"] });
           const router = curi(history, [Route]);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.name).toBeUndefined();
             done();
           });
         });
       });
 
-      describe('partials', () => {
-        it('is set using the names of all partially matching routes', done => {
-          const history = InMemory({ locations: ['/TX/Austin'] });
+      describe("partials", () => {
+        it("is set using the names of all partially matching routes", done => {
+          const history = InMemory({ locations: ["/TX/Austin"] });
           const routes = [
             {
-              name: 'State',
-              path: ':state',
+              name: "State",
+              path: ":state",
               children: [
                 {
-                  name: 'City',
-                  path: ':city'
+                  name: "City",
+                  path: ":city"
                 }
               ]
             }
           ];
           const router = curi(history, routes);
-          router.respond(response => {
-            expect(response.partials).toEqual(['State']);
+          router.respond(({ response }) => {
+            expect(response.partials).toEqual(["State"]);
             done();
           });
         });
       });
 
-      describe('params', () => {
-        it('includes params from partially matched routes', done => {
-          const history = InMemory({ locations: ['/MT/Bozeman'] });
+      describe("params", () => {
+        it("includes params from partially matched routes", done => {
+          const history = InMemory({ locations: ["/MT/Bozeman"] });
           const routes = [
             {
-              name: 'State',
-              path: ':state',
+              name: "State",
+              path: ":state",
               children: [
                 {
-                  name: 'City',
-                  path: ':city'
+                  name: "City",
+                  path: ":city"
                 }
               ]
             }
           ];
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.params).toEqual({
-              state: 'MT',
-              city: 'Bozeman'
+              state: "MT",
+              city: "Bozeman"
             });
             done();
           });
         });
 
-        it('overwrites param name conflicts', done => {
-          const history = InMemory({ locations: ['/1/2'] });
+        it("overwrites param name conflicts", done => {
+          const history = InMemory({ locations: ["/1/2"] });
           const routes = [
             {
-              name: 'One',
-              path: ':id',
-              children: [{ name: 'Two', path: ':id' }]
+              name: "One",
+              path: ":id",
+              children: [{ name: "Two", path: ":id" }]
             }
           ];
           const router = curi(history, routes);
-          router.respond(response => {
-            expect(response.params['id']).toBe('2');
+          router.respond(({ response }) => {
+            expect(response.params["id"]).toBe("2");
             done();
           });
         });
 
-        describe('parsing params', () => {
-          it('uses route.params to parse params', done => {
-            const history = InMemory({ locations: ['/123'] });
+        describe("parsing params", () => {
+          it("uses route.params to parse params", done => {
+            const history = InMemory({ locations: ["/123"] });
             const routes = [
               {
-                name: 'number',
-                path: ':num',
+                name: "number",
+                path: ":num",
                 params: {
                   num: n => parseInt(n, 10)
                 }
               }
             ];
             const router = curi(history, routes);
-            router.respond(response => {
+            router.respond(({ response }) => {
               expect(response.params).toEqual({ num: 123 });
               done();
             });
           });
 
-          it('parses params from parent routes', done => {
-            const history = InMemory({ locations: ['/123/456'] });
+          it("parses params from parent routes", done => {
+            const history = InMemory({ locations: ["/123/456"] });
             const routes = [
               {
-                name: 'first',
-                path: ':first',
+                name: "first",
+                path: ":first",
                 children: [
                   {
-                    name: 'second',
-                    path: ':second',
+                    name: "second",
+                    path: ":second",
                     params: {
                       second: n => parseInt(n, 10)
                     }
@@ -552,7 +550,7 @@ describe('route matching/response generation', () => {
               }
             ];
             const router = curi(history, routes);
-            router.respond(response => {
+            router.respond(({ response }) => {
               expect(response.params).toEqual({
                 first: 123,
                 second: 456
@@ -561,52 +559,52 @@ describe('route matching/response generation', () => {
             });
           });
 
-          it('uses string for any params not in route.params', done => {
-            const history = InMemory({ locations: ['/123/456'] });
+          it("uses string for any params not in route.params", done => {
+            const history = InMemory({ locations: ["/123/456"] });
             const routes = [
               {
-                name: 'combo',
-                path: ':first/:second',
+                name: "combo",
+                path: ":first/:second",
                 params: {
                   first: n => parseInt(n, 10)
                 }
               }
             ];
             const router = curi(history, routes);
-            router.respond(response => {
+            router.respond(({ response }) => {
               expect(response.params).toEqual({
                 first: 123,
-                second: '456'
+                second: "456"
               });
               done();
             });
           });
 
-          it('falls back to string value if param parser throws', done => {
+          it("falls back to string value if param parser throws", done => {
             const originalError = console.error;
             const errorMock = jest.fn();
             console.error = errorMock;
 
-            const history = InMemory({ locations: ['/123'] });
+            const history = InMemory({ locations: ["/123"] });
             const routes = [
               {
-                name: 'number',
-                path: ':num',
+                name: "number",
+                path: ":num",
                 params: {
                   num: n => {
-                    throw new Error('This will fail.');
+                    throw new Error("This will fail.");
                   }
                 }
               }
             ];
             const router = curi(history, routes);
-            router.respond(response => {
+            router.respond(({ response }) => {
               expect(response.params).toEqual({
-                num: '123'
+                num: "123"
               });
               expect(errorMock.mock.calls.length).toBe(1);
               expect(errorMock.mock.calls[0][0].message).toBe(
-                'This will fail.'
+                "This will fail."
               );
               console.error = originalError;
               done();
@@ -615,14 +613,14 @@ describe('route matching/response generation', () => {
         });
       });
 
-      describe('error', () => {
-        it('is undefined for good responses', done => {
-          const routes = [{ name: 'Contact', path: 'contact' }];
+      describe("error", () => {
+        it("is undefined for good responses", done => {
+          const routes = [{ name: "Contact", path: "contact" }];
           const history = InMemory({
-            locations: ['/contact']
+            locations: ["/contact"]
           });
           const router = curi(history, routes);
-          router.respond(response => {
+          router.respond(({ response }) => {
             expect(response.error).toBeUndefined();
             done();
           });
@@ -631,43 +629,43 @@ describe('route matching/response generation', () => {
         it("is set by calling the error method from a matched route's match.response function", done => {
           const routes = [
             {
-              name: 'A Route',
-              path: '',
+              name: "A Route",
+              path: "",
               match: {
                 response: ({ set }) => {
-                  set.error('woops');
+                  set.error("woops");
                 }
               }
             }
           ];
-          const history = InMemory({ locations: ['/'] });
+          const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
-          router.respond(response => {
-            expect(response.error).toBe('woops');
+          router.respond(({ response }) => {
+            expect(response.error).toBe("woops");
             done();
           });
         });
       });
 
-      describe('redirectTo', () => {
+      describe("redirectTo", () => {
         it("is sets by calling the redirect function in a matching route's match.response function", done => {
           const routes = [
             {
-              name: 'A Route',
-              path: '',
+              name: "A Route",
+              path: "",
               match: {
                 response: ({ set }) => {
-                  set.redirect('/somewhere', 301);
+                  set.redirect("/somewhere", 301);
                 }
               }
             }
           ];
-          const history = InMemory({ locations: ['/'] });
+          const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
           let firstCall = true;
-          router.respond(response => {
+          router.respond(({ response }) => {
             if (firstCall) {
-              expect(response.redirectTo).toBe('/somewhere');
+              expect(response.redirectTo).toBe("/somewhere");
               firstCall = false;
               done();
             }
@@ -677,9 +675,9 @@ describe('route matching/response generation', () => {
     });
   });
 
-  describe('the match functions', () => {
-    describe('initial', () => {
-      it('will only be called once', done => {
+  describe("the match functions", () => {
+    describe("initial", () => {
+      it("will only be called once", done => {
         /*
          * This test is a bit odd to read, but it verifies that the
          * match.initial function is only called once (while the
@@ -689,11 +687,11 @@ describe('route matching/response generation', () => {
         let everyCount = 0;
         const initial = () => Promise.resolve(initialCount++);
         const every = () => Promise.resolve(everyCount++);
-        const history = InMemory({ locations: ['/test'] });
+        const history = InMemory({ locations: ["/test"] });
         const routes = [
           {
-            name: 'Test',
-            path: ':test',
+            name: "Test",
+            path: ":test",
             match: { initial, every }
           }
         ];
@@ -704,7 +702,7 @@ describe('route matching/response generation', () => {
             firstCall = false;
             expect(initialCount).toBe(1);
             expect(everyCount).toBe(1);
-            history.push('/another-one');
+            history.push("/another-one");
           } else {
             expect(initialCount).toBe(1);
             expect(everyCount).toBe(2);
@@ -714,38 +712,33 @@ describe('route matching/response generation', () => {
       });
     });
 
-    describe('every', () => {
-      it('receives the route props from the matching route', done => {
+    describe("every", () => {
+      it("receives the route props from the matching route", done => {
         const spy = jest.fn(route => {
           expect(route).toMatchObject({
-            params: { anything: 'hello' },
+            params: { anything: "hello" },
             location: {
-              pathname: '/hello',
-              query: 'one=two'
+              pathname: "/hello",
+              query: "one=two"
             },
-            name: 'Catch All'
+            name: "Catch All"
           });
+          done();
         });
 
         const CatchAll = {
-          name: 'Catch All',
-          path: ':anything',
+          name: "Catch All",
+          path: ":anything",
           match: { every: spy }
         };
 
-        const history = InMemory({ locations: ['/hello?one=two'] });
+        const history = InMemory({ locations: ["/hello?one=two"] });
         const router = curi(history, [CatchAll]);
-        router.respond(
-          response => {
-            done();
-          },
-          { once: true }
-        );
       });
     });
 
-    describe('response', () => {
-      it('is not called if the navigation has been cancelled', done => {
+    describe("response", () => {
+      it("is not called if the navigation has been cancelled", done => {
         const responseSpy = jest.fn();
         let firstHasResolved = false;
         const everySpy = jest.fn(() => {
@@ -759,16 +752,16 @@ describe('route matching/response generation', () => {
 
         const routes = [
           {
-            name: 'First',
-            path: 'first',
+            name: "First",
+            path: "first",
             match: {
               every: everySpy,
               response: responseSpy
             }
           },
           {
-            name: 'Second',
-            path: 'second',
+            name: "Second",
+            path: "second",
             match: {
               // re-use the every spy so that this route's response
               // fn isn't call until after the first route's every
@@ -784,95 +777,80 @@ describe('route matching/response generation', () => {
           }
         ];
 
-        const history = InMemory({ locations: ['/first'] });
+        const history = InMemory({ locations: ["/first"] });
         const router = curi(history, routes);
-        history.push('/second');
+        history.push("/second");
       });
 
-      describe('error', () => {
-        it('receives the error rejected by match.initial', done => {
+      describe("error", () => {
+        it("receives the error rejected by match.initial", done => {
           const spy = jest.fn(({ error }) => {
-            expect(error).toBe('rejected by initial');
+            expect(error).toBe("rejected by initial");
+            done();
           });
 
           const CatchAll = {
-            name: 'Catch All',
-            path: ':anything',
+            name: "Catch All",
+            path: ":anything",
             match: {
-              initial: () => Promise.reject('rejected by initial'),
+              initial: () => Promise.reject("rejected by initial"),
               response: spy
             }
           };
 
-          const history = InMemory({ locations: ['/hello?one=two'] });
+          const history = InMemory({ locations: ["/hello?one=two"] });
           const router = curi(history, [CatchAll]);
-          router.respond(
-            response => {
-              done();
-            },
-            { once: true }
-          );
         });
 
-        it('receives the error rejected by match.every', done => {
+        it("receives the error rejected by match.every", done => {
           const spy = jest.fn(({ error }) => {
-            expect(error).toBe('rejected by every');
+            expect(error).toBe("rejected by every");
+            done();
           });
 
           const CatchAll = {
-            name: 'Catch All',
-            path: ':anything',
+            name: "Catch All",
+            path: ":anything",
             match: {
-              every: () => Promise.reject('rejected by every'),
+              every: () => Promise.reject("rejected by every"),
               response: spy
             }
           };
 
-          const history = InMemory({ locations: ['/hello?one=two'] });
+          const history = InMemory({ locations: ["/hello?one=two"] });
           const router = curi(history, [CatchAll]);
-          router.respond(
-            response => {
-              done();
-            },
-            { once: true }
-          );
         });
       });
 
-      describe('resolved', () => {
-        describe('initial', () => {
-          it('receives the data resolved by match.initial', done => {
+      describe("resolved", () => {
+        describe("initial", () => {
+          it("receives the data resolved by match.initial", done => {
             const spy = jest.fn(({ resolved }) => {
-              expect(resolved.initial).toMatchObject({ test: 'ing' });
+              expect(resolved.initial).toMatchObject({ test: "ing" });
+              done();
             });
 
             const CatchAll = {
-              name: 'Catch All',
-              path: ':anything',
+              name: "Catch All",
+              path: ":anything",
               match: {
-                initial: () => Promise.resolve({ test: 'ing' }),
+                initial: () => Promise.resolve({ test: "ing" }),
                 response: spy
               }
             };
 
-            const history = InMemory({ locations: ['/hello?one=two'] });
+            const history = InMemory({ locations: ["/hello?one=two"] });
             const router = curi(history, [CatchAll]);
-            router.respond(
-              response => {
-                done();
-              },
-              { once: true }
-            );
           });
 
-          it('re-use the Promise returned by initial on subsequent matches', done => {
-            const history = InMemory({ locations: ['/test'] });
+          it("re-use the Promise returned by initial on subsequent matches", done => {
+            const history = InMemory({ locations: ["/test"] });
             let hasFinished = false;
             let random;
             const routes = [
               {
-                name: 'Test',
-                path: ':test',
+                name: "Test",
+                path: ":test",
                 match: {
                   initial: () => {
                     return Promise.resolve(Math.random());
@@ -892,117 +870,97 @@ describe('route matching/response generation', () => {
             const router = curi(history, routes);
             router.respond(
               () => {
-                history.push('/another-one');
+                history.push("/another-one");
               },
               { once: true }
             );
           });
 
-          it('resolved.initial is undefined if there is no match.initial function', done => {
+          it("resolved.initial is undefined if there is no match.initial function", done => {
             const spy = jest.fn(({ resolved }) => {
               expect(resolved.initial).toBeUndefined();
+              done();
             });
 
             const CatchAll = {
-              name: 'Catch All',
-              path: ':anything',
+              name: "Catch All",
+              path: ":anything",
               match: {
                 response: spy
               }
             };
 
-            const history = InMemory({ locations: ['/hello?one=two'] });
+            const history = InMemory({ locations: ["/hello?one=two"] });
             const router = curi(history, [CatchAll]);
-            router.respond(
-              response => {
-                done();
-              },
-              { once: true }
-            );
           });
         });
 
-        describe('every', () => {
-          it('receives the data resolved by match.every', done => {
+        describe("every", () => {
+          it("receives the data resolved by match.every", done => {
             const spy = jest.fn(({ resolved }) => {
-              expect(resolved.every).toMatchObject({ test: 'ing' });
+              expect(resolved.every).toMatchObject({ test: "ing" });
+              done();
             });
 
             const CatchAll = {
-              name: 'Catch All',
-              path: ':anything',
+              name: "Catch All",
+              path: ":anything",
               match: {
-                every: () => Promise.resolve({ test: 'ing' }),
+                every: () => Promise.resolve({ test: "ing" }),
                 response: spy
               }
             };
 
-            const history = InMemory({ locations: ['/hello?one=two'] });
+            const history = InMemory({ locations: ["/hello?one=two"] });
             const router = curi(history, [CatchAll]);
-            router.respond(
-              response => {
-                done();
-              },
-              { once: true }
-            );
           });
 
-          it('resolved.every is undefined if there is no match.every function', done => {
+          it("resolved.every is undefined if there is no match.every function", done => {
             const spy = jest.fn(({ resolved }) => {
               expect(resolved.every).toBeUndefined();
+              done();
             });
 
             const CatchAll = {
-              name: 'Catch All',
-              path: ':anything',
+              name: "Catch All",
+              path: ":anything",
               match: {
                 response: spy
               }
             };
 
-            const history = InMemory({ locations: ['/hello?one=two'] });
+            const history = InMemory({ locations: ["/hello?one=two"] });
             const router = curi(history, [CatchAll]);
-            router.respond(
-              response => {
-                done();
-              },
-              { once: true }
-            );
           });
         });
       });
 
-      describe('route', () => {
-        it('receives the route props', done => {
+      describe("route", () => {
+        it("receives the route props", done => {
           const spy = jest.fn(({ route }) => {
             expect(route).toMatchObject({
-              params: { anything: 'hello' },
+              params: { anything: "hello" },
               location: {
-                pathname: '/hello',
-                query: 'one=two'
+                pathname: "/hello",
+                query: "one=two"
               }
             });
+            done();
           });
 
           const CatchAll = {
-            name: 'Catch All',
-            path: ':anything',
+            name: "Catch All",
+            path: ":anything",
             match: { response: spy }
           };
 
-          const history = InMemory({ locations: ['/hello?one=two'] });
+          const history = InMemory({ locations: ["/hello?one=two"] });
           const router = curi(history, [CatchAll]);
-          router.respond(
-            response => {
-              done();
-            },
-            { once: true }
-          );
         });
       });
 
-      describe('set', () => {
-        it('receives the response set functions', done => {
+      describe("set", () => {
+        it("receives the response set functions", done => {
           const spy = jest.fn(({ set }) => {
             expect(set).toMatchObject(
               expect.objectContaining({
@@ -1013,70 +971,60 @@ describe('route matching/response generation', () => {
                 error: expect.any(Function)
               })
             );
+            done();
           });
 
           const CatchAll = {
-            name: 'Catch All',
-            path: ':anything',
+            name: "Catch All",
+            path: ":anything",
             match: { response: spy }
           };
 
-          const history = InMemory({ locations: ['/hello?one=two'] });
+          const history = InMemory({ locations: ["/hello?one=two"] });
           const router = curi(history, [CatchAll]);
-          router.respond(
-            response => {
-              done();
-            },
-            { once: true }
-          );
         });
       });
 
-      describe('addons', () => {
-        it('receives the registered addons object', done => {
+      describe("addons", () => {
+        it("receives the registered addons object", done => {
           const spy = jest.fn(({ addons }) => {
-            expect(typeof addons.pathname).toBe('function');
+            expect(typeof addons.pathname).toBe("function");
+            done();
           });
 
           const CatchAll = {
-            name: 'Catch All',
-            path: ':anything',
+            name: "Catch All",
+            path: ":anything",
             match: { response: spy }
           };
 
-          const history = InMemory({ locations: ['/hello?one=two'] });
+          const history = InMemory({ locations: ["/hello?one=two"] });
           const router = curi(history, [CatchAll]);
-          router.respond(
-            response => {
-              done();
-            },
-            { once: true }
-          );
         });
 
-        it('can use registered addons', done => {
+        it("can use registered addons", done => {
           const routes = [
             {
-              name: 'Old',
-              path: 'old/:id',
+              name: "Old",
+              path: "old/:id",
               match: {
                 response: ({ route, set, addons }) => {
-                  const pathname = addons.pathname('New', route.params);
+                  const pathname = addons.pathname("New", route.params);
                   set.redirect(pathname);
                 }
               }
             },
             {
-              name: 'New',
-              path: 'new/:id'
+              name: "New",
+              path: "new/:id"
             }
           ];
-          const history = InMemory({ locations: ['/old/1'] });
+          const history = InMemory({ locations: ["/old/1"] });
           const router = curi(history, routes);
           let firstCall = true;
-          router.respond(response => {
+          router.respond(({ response }) => {
             if (firstCall) {
-              expect(response.redirectTo).toBe('/new/1');
+              expect(response.redirectTo).toBe("/new/1");
               firstCall = false;
               done();
             }

--- a/packages/core/types/route.d.ts
+++ b/packages/core/types/route.d.ts
@@ -1,3 +1,3 @@
-import { RouteDescriptor, InternalRoute } from './types/route';
+import { RouteDescriptor, InternalRoute } from "./types/route";
 declare const createRoute: (options: RouteDescriptor) => InternalRoute;
 export default createRoute;

--- a/packages/core/types/types/curi.d.ts
+++ b/packages/core/types/types/curi.d.ts
@@ -7,12 +7,12 @@ export interface Navigation {
     action: Action;
     previous: Response;
 }
-export interface ResponseHandlerProps {
+export interface Emitted {
     response: Response;
     navigation: Navigation;
     router: CuriRouter;
 }
-export declare type ResponseHandler = (props?: ResponseHandlerProps) => void;
+export declare type ResponseHandler = (props?: Emitted) => void;
 export interface RespondOptions {
     once?: boolean;
     initial?: boolean;

--- a/packages/core/types/types/curi.d.ts
+++ b/packages/core/types/types/curi.d.ts
@@ -7,7 +7,12 @@ export interface Navigation {
     action: Action;
     previous: Response;
 }
-export declare type ResponseHandler = (response: Response, navigation?: Navigation, router?: CuriRouter) => void;
+export interface ResponseHandlerProps {
+    response: Response;
+    navigation: Navigation;
+    router: CuriRouter;
+}
+export declare type ResponseHandler = (props?: ResponseHandlerProps) => void;
 export interface RespondOptions {
     once?: boolean;
     initial?: boolean;

--- a/packages/core/types/types/index.d.ts
+++ b/packages/core/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { AddonRegister, AddonGet, Addon, Addons } from "./addon";
 export { Route, RouteDescriptor, ParamParser, ParamParsers, RouteProps, ResponseSetters, ResponseBuilder, EveryMatchFn, InitialMatchFn, ResponseMatchFn } from "./route";
 export { Response, RawParams, Params } from "./response";
-export { CuriRouter, RouterOptions, ResponseHandler, ResponseHandlerProps, RemoveResponseHandler, SideEffect, Cache, Navigation } from "./curi";
+export { CuriRouter, RouterOptions, ResponseHandler, Emitted, RemoveResponseHandler, SideEffect, Cache, Navigation } from "./curi";

--- a/packages/core/types/types/index.d.ts
+++ b/packages/core/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { AddonRegister, AddonGet, Addon, Addons } from "./addon";
 export { Route, RouteDescriptor, ParamParser, ParamParsers, RouteProps, ResponseSetters, ResponseBuilder, EveryMatchFn, InitialMatchFn, ResponseMatchFn } from "./route";
 export { Response, RawParams, Params } from "./response";
-export { CuriRouter, RouterOptions, ResponseHandler, RemoveResponseHandler, SideEffect, Cache, Navigation } from "./curi";
+export { CuriRouter, RouterOptions, ResponseHandler, ResponseHandlerProps, RemoveResponseHandler, SideEffect, Cache, Navigation } from "./curi";

--- a/packages/mobx/CHANGELOG.md
+++ b/packages/mobx/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* (Internal) Response handler receives `ResponseHandlerProps` object.
+* (Internal) Response handler receives `Emitted` object.
 
 ## 1.0.0-alpha.1
 

--- a/packages/mobx/CHANGELOG.md
+++ b/packages/mobx/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* (Internal) Response handler receives `ResponseHandlerProps` object.
+
 ## 1.0.0-alpha.1
 
 * Switch from `action` to `navigation` (which contains an `action` as well as the previous `response`).

--- a/packages/mobx/src/index.ts
+++ b/packages/mobx/src/index.ts
@@ -1,6 +1,11 @@
 import { observable, action as mobxAction } from "mobx";
 
-import { CuriRouter, Response, Navigation } from "@curi/core";
+import {
+  CuriRouter,
+  ResponseHandlerProps,
+  Response,
+  Navigation
+} from "@curi/core";
 
 export default class CuriStore {
   router: CuriRouter;
@@ -12,7 +17,7 @@ export default class CuriStore {
     this.response = null;
     this.navigation = null;
 
-    router.respond((response: Response, navigation: Navigation) => {
+    router.respond(({ response, navigation }: ResponseHandlerProps) => {
       this.update(response, navigation);
     });
   }

--- a/packages/mobx/src/index.ts
+++ b/packages/mobx/src/index.ts
@@ -1,11 +1,6 @@
 import { observable, action as mobxAction } from "mobx";
 
-import {
-  CuriRouter,
-  ResponseHandlerProps,
-  Response,
-  Navigation
-} from "@curi/core";
+import { CuriRouter, Emitted, Response, Navigation } from "@curi/core";
 
 export default class CuriStore {
   router: CuriRouter;
@@ -17,7 +12,7 @@ export default class CuriStore {
     this.response = null;
     this.navigation = null;
 
-    router.respond(({ response, navigation }: ResponseHandlerProps) => {
+    router.respond(({ response, navigation }: Emitted) => {
       this.update(response, navigation);
     });
   }

--- a/packages/mobx/tests/mobx.spec.ts
+++ b/packages/mobx/tests/mobx.spec.ts
@@ -36,7 +36,7 @@ describe("@curi/mobx", () => {
     it("updates response/navigation when a new response is emitted", done => {
       history.replace("/one");
       let firstResponse;
-      router.respond((response, navigation) => {
+      router.respond(({ response, navigation }) => {
         if (!firstResponse) {
           firstResponse = response;
         } else {

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* (Internal) Router's response handler receives `ResponseHandlerProps` object.
+
 ## 1.0.0-alpha.4
 
 * Add a `<ResponsiveBase>` component. This is just a `<CuriBase>` wrapped in a `<Curious>`.

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* (Internal) Router's response handler receives `ResponseHandlerProps` object.
+* (Internal) Router's response handler receives `Emitted` object.
 
 ## 1.0.0-alpha.4
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* (Internal) Router's response handler receives `ResponseHandlerProps` object.
+
 ## 1.0.0-beta.19
 
 * Add a `<ResponsiveBase>` component. This is just a `<CuriBase>` wrapped in a `<Curious>`.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* (Internal) Router's response handler receives `ResponseHandlerProps` object.
+* (Internal) Router's response handler receives `Emitted` object.
 
 ## 1.0.0-beta.19
 

--- a/packages/react/src/CuriBase.tsx
+++ b/packages/react/src/CuriBase.tsx
@@ -1,9 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { CuriRouter, Response, Navigation } from "@curi/core";
-import { CuriContext, CuriProps } from "./interface";
+import {
+  CuriRouter,
+  ResponseHandlerProps,
+  Response,
+  Navigation
+} from "@curi/core";
+import { CuriContext } from "./interface";
 
-export type CuriRenderFn = (props: CuriProps) => React.ReactElement<any>;
+export type CuriRenderFn = (
+  props: ResponseHandlerProps
+) => React.ReactElement<any>;
 
 export interface CuriBaseProps {
   router: CuriRouter;

--- a/packages/react/src/CuriBase.tsx
+++ b/packages/react/src/CuriBase.tsx
@@ -1,16 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import {
-  CuriRouter,
-  ResponseHandlerProps,
-  Response,
-  Navigation
-} from "@curi/core";
-import { CuriContext } from "./interface";
+import { CuriRouter, Response, Navigation } from "@curi/core";
+import { CuriProps, CuriContext } from "./interface";
 
-export type CuriRenderFn = (
-  props: ResponseHandlerProps
-) => React.ReactElement<any>;
+export type CuriRenderFn = (props: CuriProps) => React.ReactElement<any>;
 
 export interface CuriBaseProps {
   router: CuriRouter;

--- a/packages/react/src/CuriBase.tsx
+++ b/packages/react/src/CuriBase.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { CuriRouter, Response, Navigation } from "@curi/core";
-import { CuriProps, CuriContext } from "./interface";
-
-export type CuriRenderFn = (props: CuriProps) => React.ReactElement<any>;
+import { CuriContext, CuriRenderFn } from "./interface";
 
 export interface CuriBaseProps {
   router: CuriRouter;

--- a/packages/react/src/Curious.tsx
+++ b/packages/react/src/Curious.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import PropTypes from "prop-types";
 import warning from "warning";
 
-import { CuriProps, CuriContext } from "./interface";
-import { CuriRouter, Response, Navigation } from "@curi/core";
+import { CuriRenderFn, CuriContext } from "./interface";
+import { CuriRouter, Emitted, Response, Navigation } from "@curi/core";
 
 export interface CuriousProps {
-  render(p: CuriProps): React.ReactElement<any>;
+  render: CuriRenderFn;
   router?: CuriRouter;
   responsive?: boolean;
 }

--- a/packages/react/src/Curious.tsx
+++ b/packages/react/src/Curious.tsx
@@ -3,18 +3,17 @@ import PropTypes from "prop-types";
 import warning from "warning";
 
 import { CuriContext } from "./interface";
-import { CuriRouter, Response, Navigation } from "@curi/core";
+import {
+  CuriRouter,
+  ResponseHandlerProps,
+  Response,
+  Navigation
+} from "@curi/core";
 
 export interface CuriousProps {
-  render(p: CuriousRenderProps): React.ReactElement<any>;
+  render(p: ResponseHandlerProps): React.ReactElement<any>;
   router?: CuriRouter;
   responsive?: boolean;
-}
-
-export interface CuriousRenderProps {
-  router: CuriRouter;
-  response: Response;
-  navigation: Navigation;
 }
 
 export interface CuriousState {
@@ -61,7 +60,7 @@ export default class Curious extends React.Component<
     if (this.props.responsive || this.props.router) {
       const router = this.props.router || this.context.curi.router;
       this.stopResponding = router.respond(
-        (response: Response, navigation: Navigation) => {
+        ({ response, navigation }: ResponseHandlerProps) => {
           this.setState({ response, navigation });
         },
         { initial: false }

--- a/packages/react/src/Curious.tsx
+++ b/packages/react/src/Curious.tsx
@@ -2,16 +2,11 @@ import React from "react";
 import PropTypes from "prop-types";
 import warning from "warning";
 
-import { CuriContext } from "./interface";
-import {
-  CuriRouter,
-  ResponseHandlerProps,
-  Response,
-  Navigation
-} from "@curi/core";
+import { CuriProps, CuriContext } from "./interface";
+import { CuriRouter, Response, Navigation } from "@curi/core";
 
 export interface CuriousProps {
-  render(p: ResponseHandlerProps): React.ReactElement<any>;
+  render(p: CuriProps): React.ReactElement<any>;
   router?: CuriRouter;
   responsive?: boolean;
 }
@@ -60,7 +55,7 @@ export default class Curious extends React.Component<
     if (this.props.responsive || this.props.router) {
       const router = this.props.router || this.context.curi.router;
       this.stopResponding = router.respond(
-        ({ response, navigation }: ResponseHandlerProps) => {
+        ({ response, navigation }: Emitted) => {
           this.setState({ response, navigation });
         },
         { initial: false }

--- a/packages/react/src/ResponsiveBase.tsx
+++ b/packages/react/src/ResponsiveBase.tsx
@@ -3,7 +3,7 @@ import CuriBase from "./CuriBase";
 import Curious from "./Curious";
 
 import { CuriRouter } from "@curi/core";
-import { CuriRenderFn } from "./CuriBase";
+import { CuriRenderFn } from "./interface";
 
 export interface ResponsiveProps {
   router: CuriRouter;

--- a/packages/react/src/ResponsiveBase.tsx
+++ b/packages/react/src/ResponsiveBase.tsx
@@ -3,7 +3,6 @@ import CuriBase from "./CuriBase";
 import Curious from "./Curious";
 
 import { CuriRouter } from "@curi/core";
-import { CuriProps } from "./interface";
 import { CuriRenderFn } from "./CuriBase";
 
 export interface ResponsiveProps {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,8 +1,8 @@
 export { ActiveProps } from "./Active";
 export { BlockProps } from "./Block";
 export { CuriBaseProps } from "./CuriBase";
-export { CuriousProps, CuriousRenderProps } from "./Curious";
-export { CuriProps, CuriContext } from "./interface";
+export { CuriousProps } from "./Curious";
+export { CuriContext } from "./interface";
 export { LinkProps, LinkState, ActiveLink } from "./Link";
 export { ResponsiveProps } from "./ResponsiveBase";
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,7 +2,7 @@ export { ActiveProps } from "./Active";
 export { BlockProps } from "./Block";
 export { CuriBaseProps } from "./CuriBase";
 export { CuriousProps } from "./Curious";
-export { CuriContext } from "./interface";
+export { CuriContext, CuriRenderFn } from "./interface";
 export { LinkProps, LinkState, ActiveLink } from "./Link";
 export { ResponsiveProps } from "./ResponsiveBase";
 

--- a/packages/react/src/interface.ts
+++ b/packages/react/src/interface.ts
@@ -1,11 +1,5 @@
-import { CuriRouter, Response, Navigation } from "@curi/core";
+import { ResponseHandlerProps } from "@curi/core";
 
 export interface CuriContext {
-  curi: CuriProps;
-}
-
-export interface CuriProps {
-  router: CuriRouter;
-  response: Response;
-  navigation: Navigation;
+  curi: ResponseHandlerProps;
 }

--- a/packages/react/src/interface.ts
+++ b/packages/react/src/interface.ts
@@ -1,7 +1,8 @@
+import React from "react";
 import { Emitted } from "@curi/core";
 
-export type CuriProps = Emitted;
-
 export interface CuriContext {
-  curi: CuriProps;
+  curi: Emitted;
 }
+
+export type CuriRenderFn = (props: Emitted) => React.ReactElement<any>;

--- a/packages/react/src/interface.ts
+++ b/packages/react/src/interface.ts
@@ -1,5 +1,7 @@
-import { ResponseHandlerProps } from "@curi/core";
+import { Emitted } from "@curi/core";
+
+export type CuriProps = Emitted;
 
 export interface CuriContext {
-  curi: ResponseHandlerProps;
+  curi: CuriProps;
 }

--- a/packages/react/tests/CuriBase.spec.tsx
+++ b/packages/react/tests/CuriBase.spec.tsx
@@ -58,7 +58,7 @@ describe("<CuriBase>", () => {
         "data",
         "title"
       ];
-      router.respond((response, navigation) => {
+      router.respond(({ response, navigation }) => {
         const wrapper = shallow(
           <CuriBase
             response={response}

--- a/packages/react/tests/Curious.spec.tsx
+++ b/packages/react/tests/Curious.spec.tsx
@@ -96,7 +96,7 @@ describe("<Curious>", () => {
 
     it("passes response/navigation/router from context on initial render", () => {
       router.respond(
-        (response, navigation) => {
+        ({ response, navigation }) => {
           // initial render
           const wrapper = mount(
             <Curious
@@ -123,7 +123,7 @@ describe("<Curious>", () => {
 
     it("re-calls render when responses are emitted", done => {
       router.respond(
-        (response, navigation) => {
+        ({ response, navigation }) => {
           // initial render
           const wrapper = mount(
             <Curious
@@ -152,7 +152,7 @@ describe("<Curious>", () => {
         return null;
       });
       router.respond(
-        (response, navigation) => {
+        ({ response, navigation }) => {
           // initial render
           const wrapper = mount(<Curious responsive={true} render={fn} />, {
             context: { curi: { router, response, navigation } }
@@ -168,7 +168,7 @@ describe("<Curious>", () => {
       const oError = console.error;
       console.error = jest.fn();
       router.respond(
-        (response, navigation) => {
+        ({ response, navigation }) => {
           // initial render
           const wrapper = mount(
             <Curious
@@ -196,7 +196,7 @@ describe("<Curious>", () => {
       it("subscribes using router prop without responsive prop", done => {
         let renderCount = 0;
         router.respond(
-          response => {
+          ({ response }) => {
             // initial render
             const wrapper = mount(
               <Curious
@@ -238,7 +238,7 @@ describe("<Curious>", () => {
         const firstRouter = curi(history, routes);
         const secondRouter = curi(history, routes);
         firstRouter.respond(
-          response => {
+          ({ response }) => {
             // initial render
             const wrapper = mount(
               <Curious

--- a/packages/react/tests/ResponsiveBase.spec.tsx
+++ b/packages/react/tests/ResponsiveBase.spec.tsx
@@ -27,7 +27,7 @@ describe("<ResponsiveBase>", () => {
       });
 
       router.respond(
-        response => {
+        () => {
           const wrapper = mount(<ResponsiveBase router={router} render={fn} />);
           history.push("/about");
           pushedHistory = true;
@@ -52,7 +52,7 @@ describe("<ResponsiveBase>", () => {
 
       const router = curi(history, routes);
       router.respond(
-        (response, navigation) => {
+        () => {
           const wrapper = mount(<ResponsiveBase router={router} render={fn} />);
         },
         { once: true }
@@ -79,7 +79,7 @@ describe("<ResponsiveBase>", () => {
       };
 
       router.respond(
-        (response, navigation) => {
+        ({ response, navigation }) => {
           emittedResponse = response;
           emittedNavigation = navigation;
           const wrapper = mount(

--- a/packages/react/types/CuriBase.d.ts
+++ b/packages/react/types/CuriBase.d.ts
@@ -1,9 +1,9 @@
 /// <reference types="react" />
 import React from "react";
 import PropTypes from "prop-types";
-import { CuriRouter, Response, Navigation } from "@curi/core";
-import { CuriContext, CuriProps } from "./interface";
-export declare type CuriRenderFn = (props: CuriProps) => React.ReactElement<any>;
+import { CuriRouter, ResponseHandlerProps, Response, Navigation } from "@curi/core";
+import { CuriContext } from "./interface";
+export declare type CuriRenderFn = (props: ResponseHandlerProps) => React.ReactElement<any>;
 export interface CuriBaseProps {
     router: CuriRouter;
     render: CuriRenderFn;

--- a/packages/react/types/CuriBase.d.ts
+++ b/packages/react/types/CuriBase.d.ts
@@ -1,9 +1,8 @@
 /// <reference types="react" />
 import React from "react";
 import PropTypes from "prop-types";
-import { CuriRouter, Emitted, Response, Navigation } from "@curi/core";
-import { CuriContext } from "./interface";
-export declare type CuriRenderFn = (props: Emitted) => React.ReactElement<any>;
+import { CuriRouter, Response, Navigation } from "@curi/core";
+import { CuriContext, CuriRenderFn } from "./interface";
 export interface CuriBaseProps {
     router: CuriRouter;
     render: CuriRenderFn;

--- a/packages/react/types/CuriBase.d.ts
+++ b/packages/react/types/CuriBase.d.ts
@@ -1,9 +1,9 @@
 /// <reference types="react" />
 import React from "react";
 import PropTypes from "prop-types";
-import { CuriRouter, ResponseHandlerProps, Response, Navigation } from "@curi/core";
+import { CuriRouter, Emitted, Response, Navigation } from "@curi/core";
 import { CuriContext } from "./interface";
-export declare type CuriRenderFn = (props: ResponseHandlerProps) => React.ReactElement<any>;
+export declare type CuriRenderFn = (props: Emitted) => React.ReactElement<any>;
 export interface CuriBaseProps {
     router: CuriRouter;
     render: CuriRenderFn;

--- a/packages/react/types/Curious.d.ts
+++ b/packages/react/types/Curious.d.ts
@@ -1,10 +1,10 @@
 /// <reference types="react" />
 import React from "react";
 import PropTypes from "prop-types";
-import { CuriContext } from "./interface";
-import { CuriRouter, Emitted, Response, Navigation } from "@curi/core";
+import { CuriRenderFn, CuriContext } from "./interface";
+import { CuriRouter, Response, Navigation } from "@curi/core";
 export interface CuriousProps {
-    render(p: Emitted): React.ReactElement<any>;
+    render: CuriRenderFn;
     router?: CuriRouter;
     responsive?: boolean;
 }

--- a/packages/react/types/Curious.d.ts
+++ b/packages/react/types/Curious.d.ts
@@ -2,9 +2,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { CuriContext } from "./interface";
-import { CuriRouter, ResponseHandlerProps, Response, Navigation } from "@curi/core";
+import { CuriRouter, Emitted, Response, Navigation } from "@curi/core";
 export interface CuriousProps {
-    render(p: ResponseHandlerProps): React.ReactElement<any>;
+    render(p: Emitted): React.ReactElement<any>;
     router?: CuriRouter;
     responsive?: boolean;
 }

--- a/packages/react/types/Curious.d.ts
+++ b/packages/react/types/Curious.d.ts
@@ -2,16 +2,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { CuriContext } from "./interface";
-import { CuriRouter, Response, Navigation } from "@curi/core";
+import { CuriRouter, ResponseHandlerProps, Response, Navigation } from "@curi/core";
 export interface CuriousProps {
-    render(p: CuriousRenderProps): React.ReactElement<any>;
+    render(p: ResponseHandlerProps): React.ReactElement<any>;
     router?: CuriRouter;
     responsive?: boolean;
-}
-export interface CuriousRenderProps {
-    router: CuriRouter;
-    response: Response;
-    navigation: Navigation;
 }
 export interface CuriousState {
     response: Response;

--- a/packages/react/types/ResponsiveBase.d.ts
+++ b/packages/react/types/ResponsiveBase.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 import React from "react";
 import { CuriRouter } from "@curi/core";
-import { CuriRenderFn } from "./CuriBase";
+import { CuriRenderFn } from "./interface";
 export interface ResponsiveProps {
     router: CuriRouter;
     render: CuriRenderFn;

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -2,7 +2,7 @@ export { ActiveProps } from "./Active";
 export { BlockProps } from "./Block";
 export { CuriBaseProps } from "./CuriBase";
 export { CuriousProps } from "./Curious";
-export { CuriContext } from "./interface";
+export { CuriContext, CuriRenderFn } from "./interface";
 export { LinkProps, LinkState, ActiveLink } from "./Link";
 export { ResponsiveProps } from "./ResponsiveBase";
 import Active from "./Active";

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -1,8 +1,8 @@
 export { ActiveProps } from "./Active";
 export { BlockProps } from "./Block";
 export { CuriBaseProps } from "./CuriBase";
-export { CuriousProps, CuriousRenderProps } from "./Curious";
-export { CuriProps, CuriContext } from "./interface";
+export { CuriousProps } from "./Curious";
+export { CuriContext } from "./interface";
 export { LinkProps, LinkState, ActiveLink } from "./Link";
 export { ResponsiveProps } from "./ResponsiveBase";
 import Active from "./Active";

--- a/packages/react/types/interface.d.ts
+++ b/packages/react/types/interface.d.ts
@@ -1,9 +1,4 @@
-import { CuriRouter, Response, Navigation } from "@curi/core";
+import { ResponseHandlerProps } from "@curi/core";
 export interface CuriContext {
-    curi: CuriProps;
-}
-export interface CuriProps {
-    router: CuriRouter;
-    response: Response;
-    navigation: Navigation;
+    curi: ResponseHandlerProps;
 }

--- a/packages/react/types/interface.d.ts
+++ b/packages/react/types/interface.d.ts
@@ -1,4 +1,4 @@
-import { ResponseHandlerProps } from "@curi/core";
+import { Emitted } from "@curi/core";
 export interface CuriContext {
-    curi: ResponseHandlerProps;
+    curi: Emitted;
 }

--- a/packages/react/types/interface.d.ts
+++ b/packages/react/types/interface.d.ts
@@ -1,4 +1,7 @@
+/// <reference types="react" />
+import React from 'react';
 import { Emitted } from "@curi/core";
 export interface CuriContext {
     curi: Emitted;
 }
+export declare type CuriRenderFn = (props: Emitted) => React.ReactElement<any>;

--- a/packages/redux/CHANGELOG.md
+++ b/packages/redux/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* (Internal) Router resposne handler receives `ResponseHandlerProps` object.
+* (Internal) Router resposne handler receives `Emitted` object.
 
 ## 1.0.0-beta.3
 

--- a/packages/redux/CHANGELOG.md
+++ b/packages/redux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* (Internal) Router resposne handler receives `ResponseHandlerProps` object.
+
 ## 1.0.0-beta.3
 
 * Switch from `action` to `navigation` (which contains an `action` as well as the previous `response`).

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -1,9 +1,4 @@
-import {
-  CuriRouter,
-  ResponseHandlerProps,
-  Response,
-  Navigation
-} from "@curi/core";
+import { CuriRouter, Emitted, Response, Navigation } from "@curi/core";
 import { Store, Action } from "redux";
 
 export const LOCATION_CHANGE = "@@curi/LOCATION_CHANGE";
@@ -55,7 +50,7 @@ export const syncResponses = (store: Store<any>, router: CuriRouter): void => {
     router
   });
 
-  router.respond(({ response, navigation }: ResponseHandlerProps) => {
+  router.respond(({ response, navigation }: Emitted) => {
     store.dispatch({
       type: LOCATION_CHANGE,
       response,

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -1,4 +1,9 @@
-import { CuriRouter, Response, Navigation } from "@curi/core";
+import {
+  CuriRouter,
+  ResponseHandlerProps,
+  Response,
+  Navigation
+} from "@curi/core";
 import { Store, Action } from "redux";
 
 export const LOCATION_CHANGE = "@@curi/LOCATION_CHANGE";
@@ -50,7 +55,7 @@ export const syncResponses = (store: Store<any>, router: CuriRouter): void => {
     router
   });
 
-  router.respond((response, navigation) => {
+  router.respond(({ response, navigation }: ResponseHandlerProps) => {
     store.dispatch({
       type: LOCATION_CHANGE,
       response,

--- a/packages/side-effects/side-effect-scroll/CHANGELOG.md
+++ b/packages/side-effects/side-effect-scroll/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Side effect receives `ResponseHandlerProps`.
+
 ## 1.0.0-beta.7
 
 * Expect a `Navigation` instead of an `Action`.

--- a/packages/side-effects/side-effect-scroll/CHANGELOG.md
+++ b/packages/side-effects/side-effect-scroll/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Side effect receives `ResponseHandlerProps`.
+* Side effect receives `Emitted`.
 
 ## 1.0.0-beta.7
 

--- a/packages/side-effects/side-effect-scroll/src/index.ts
+++ b/packages/side-effects/side-effect-scroll/src/index.ts
@@ -1,7 +1,7 @@
-import { ResponseHandler, Response, Navigation } from "@curi/core";
+import { ResponseHandler, ResponseHandlerProps } from "@curi/core";
 
 function createScrollSideEffect(): ResponseHandler {
-  return function(response: Response, navigation: Navigation): void {
+  return function({ response, navigation }: ResponseHandlerProps): void {
     if (navigation.action === "POP") {
       return;
     }

--- a/packages/side-effects/side-effect-scroll/src/index.ts
+++ b/packages/side-effects/side-effect-scroll/src/index.ts
@@ -1,7 +1,7 @@
-import { ResponseHandler, ResponseHandlerProps } from "@curi/core";
+import { ResponseHandler, Emitted } from "@curi/core";
 
 function createScrollSideEffect(): ResponseHandler {
-  return function({ response, navigation }: ResponseHandlerProps): void {
+  return function({ response, navigation }: Emitted): void {
     if (navigation.action === "POP") {
       return;
     }

--- a/packages/side-effects/side-effect-scroll/tests/createScrollSideEffect.spec.ts
+++ b/packages/side-effects/side-effect-scroll/tests/createScrollSideEffect.spec.ts
@@ -1,6 +1,6 @@
 import "jest";
 import createScrollSideEffect from "../src";
-import { Response } from "@curi/core";
+import { ResponseHandlerProps } from "@curi/core";
 
 jest.useFakeTimers();
 
@@ -28,10 +28,13 @@ describe("createScrollSideEffect", () => {
 
   it("does not scroll after POP", () => {
     const sideEffect = createScrollSideEffect();
-    sideEffect(<Response>{ location: {} }, {
-      action: "POP",
-      previous: {} as Response
-    });
+    sideEffect({
+      response: { location: {} },
+      navigation: {
+        action: "POP",
+        previous: {}
+      }
+    } as ResponseHandlerProps);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(0);
@@ -39,10 +42,13 @@ describe("createScrollSideEffect", () => {
 
   it("scrolls to 0 after PUSH", () => {
     const sideEffect = createScrollSideEffect();
-    sideEffect(<Response>{ location: {} }, {
-      action: "PUSH",
-      previous: {} as Response
-    });
+    sideEffect({
+      response: { location: {} },
+      navigation: {
+        action: "PUSH",
+        previous: {}
+      }
+    } as ResponseHandlerProps);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(1);
@@ -50,10 +56,13 @@ describe("createScrollSideEffect", () => {
 
   it("scrolls to 0 after REPLACE", () => {
     const sideEffect = createScrollSideEffect();
-    sideEffect(<Response>{ location: {} }, {
-      action: "REPLACE",
-      previous: {} as Response
-    });
+    sideEffect({
+      response: { location: {} },
+      navigation: {
+        action: "REPLACE",
+        previous: {}
+      }
+    } as ResponseHandlerProps);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(1);
@@ -65,10 +74,13 @@ describe("createScrollSideEffect", () => {
     document.body.appendChild(div);
 
     const sideEffect = createScrollSideEffect();
-    sideEffect(<Response>{ location: { hash: "test" } }, {
-      action: "REPLACE",
-      previous: {} as Response
-    });
+    sideEffect({
+      response: { location: { hash: "test" } },
+      navigation: {
+        action: "REPLACE",
+        previous: {}
+      }
+    } as ResponseHandlerProps);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(0);
@@ -79,10 +91,13 @@ describe("createScrollSideEffect", () => {
 
   it("scrolls to top if there is location.hash but no matching element", () => {
     const sideEffect = createScrollSideEffect();
-    sideEffect(<Response>{ location: { hash: "test" } }, {
-      action: "REPLACE",
-      previous: {} as Response
-    });
+    sideEffect({
+      response: { location: { hash: "test" } },
+      navigation: {
+        action: "REPLACE",
+        previous: {}
+      }
+    } as ResponseHandlerProps);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(1);
@@ -91,10 +106,13 @@ describe("createScrollSideEffect", () => {
 
   it("scrolls to top if location.hash is empty string", () => {
     const sideEffect = createScrollSideEffect();
-    sideEffect(<Response>{ location: { hash: "" } }, {
-      action: "REPLACE",
-      previous: {} as Response
-    });
+    sideEffect({
+      response: { location: { hash: "" } },
+      navigation: {
+        action: "REPLACE",
+        previous: {}
+      }
+    } as ResponseHandlerProps);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(1);

--- a/packages/side-effects/side-effect-scroll/tests/createScrollSideEffect.spec.ts
+++ b/packages/side-effects/side-effect-scroll/tests/createScrollSideEffect.spec.ts
@@ -1,6 +1,6 @@
 import "jest";
 import createScrollSideEffect from "../src";
-import { ResponseHandlerProps } from "@curi/core";
+import { Emitted } from "@curi/core";
 
 jest.useFakeTimers();
 
@@ -34,7 +34,7 @@ describe("createScrollSideEffect", () => {
         action: "POP",
         previous: {}
       }
-    } as ResponseHandlerProps);
+    } as Emitted);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(0);
@@ -48,7 +48,7 @@ describe("createScrollSideEffect", () => {
         action: "PUSH",
         previous: {}
       }
-    } as ResponseHandlerProps);
+    } as Emitted);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(1);
@@ -62,7 +62,7 @@ describe("createScrollSideEffect", () => {
         action: "REPLACE",
         previous: {}
       }
-    } as ResponseHandlerProps);
+    } as Emitted);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(1);
@@ -80,7 +80,7 @@ describe("createScrollSideEffect", () => {
         action: "REPLACE",
         previous: {}
       }
-    } as ResponseHandlerProps);
+    } as Emitted);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(0);
@@ -97,7 +97,7 @@ describe("createScrollSideEffect", () => {
         action: "REPLACE",
         previous: {}
       }
-    } as ResponseHandlerProps);
+    } as Emitted);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(1);
@@ -112,7 +112,7 @@ describe("createScrollSideEffect", () => {
         action: "REPLACE",
         previous: {}
       }
-    } as ResponseHandlerProps);
+    } as Emitted);
 
     jest.runAllTimers();
     expect(mockScroll.mock.calls.length).toBe(1);

--- a/packages/side-effects/side-effect-title/CHANGELOG.md
+++ b/packages/side-effects/side-effect-title/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Side effect receives `ResponseHandlerProps`.
+* Side effect receives `Emitted`.
 
 ## 1.0.0-beta.8
 

--- a/packages/side-effects/side-effect-title/CHANGELOG.md
+++ b/packages/side-effects/side-effect-title/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Side effect receives `ResponseHandlerProps`.
+
 ## 1.0.0-beta.8
 
 * Updated TypeScript type to include `delimiter`.
@@ -26,4 +30,3 @@
 ## 1.0.0-beta.1
 
 * Getting close to where this should be ready for release, so switching to beta version.
-

--- a/packages/side-effects/side-effect-title/src/index.ts
+++ b/packages/side-effects/side-effect-title/src/index.ts
@@ -1,4 +1,4 @@
-import { ResponseHandler, ResponseHandlerProps } from "@curi/core";
+import { ResponseHandler, Emitted } from "@curi/core";
 
 export interface TitleOptions {
   prefix?: string;
@@ -9,7 +9,7 @@ export interface TitleOptions {
 function createTitleSideEffect(options?: TitleOptions): ResponseHandler {
   const { prefix = "", suffix = "", delimiter = "" } = options || {};
 
-  return function({ response }: ResponseHandlerProps) {
+  return function({ response }: Emitted) {
     const parts: Array<string> = [];
     if (prefix !== "") {
       parts.push(prefix, delimiter);

--- a/packages/side-effects/side-effect-title/src/index.ts
+++ b/packages/side-effects/side-effect-title/src/index.ts
@@ -1,4 +1,4 @@
-import { ResponseHandler, Response } from '@curi/core';
+import { ResponseHandler, ResponseHandlerProps } from "@curi/core";
 
 export interface TitleOptions {
   prefix?: string;
@@ -7,18 +7,18 @@ export interface TitleOptions {
 }
 
 function createTitleSideEffect(options?: TitleOptions): ResponseHandler {
-  const { prefix = '', suffix = '', delimiter = '' } = options || {};
+  const { prefix = "", suffix = "", delimiter = "" } = options || {};
 
-  return function(response: Response) {
+  return function({ response }: ResponseHandlerProps) {
     const parts: Array<string> = [];
-    if (prefix !== '') {
+    if (prefix !== "") {
       parts.push(prefix, delimiter);
     }
     parts.push(response.title);
-    if (suffix !== '') {
+    if (suffix !== "") {
       parts.push(delimiter, suffix);
     }
-    document.title = parts.join(' ');
+    document.title = parts.join(" ");
   };
 }
 

--- a/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
+++ b/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
@@ -1,11 +1,11 @@
 import "jest";
 import createTitleSideEffect from "../src";
-import { ResponseHandlerProps } from "@curi/core";
+import { Emitted } from "@curi/core";
 
 describe("createTitleSideEffect", () => {
   const fakeResponse = {
     response: { title: "Test Title; Please Ignore" }
-  } as ResponseHandlerProps;
+  } as Emitted;
 
   it("returned function sets document.title using response.title", () => {
     const sideEffect = createTitleSideEffect();
@@ -15,7 +15,7 @@ describe("createTitleSideEffect", () => {
 
   it("sets document.title to empty string if response has no title", () => {
     const sideEffect = createTitleSideEffect();
-    const fakeResponse = { response: {} } as ResponseHandlerProps;
+    const fakeResponse = { response: {} } as Emitted;
     const queryResponse = sideEffect(fakeResponse);
     expect(document.title).toBe("");
   });

--- a/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
+++ b/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
@@ -1,70 +1,70 @@
-import 'jest';
-import createTitleSideEffect from '../src';
-import { Response } from '@curi/core';
+import "jest";
+import createTitleSideEffect from "../src";
+import { ResponseHandlerProps } from "@curi/core";
 
-describe('createTitleSideEffect', () => {
+describe("createTitleSideEffect", () => {
   const fakeResponse = {
-    title: 'Test Title; Please Ignore'
-  } as Response;
+    response: { title: "Test Title; Please Ignore" }
+  } as ResponseHandlerProps;
 
-  it('returned function sets document.title using response.title', () => {
+  it("returned function sets document.title using response.title", () => {
     const sideEffect = createTitleSideEffect();
     const queryResponse = sideEffect(fakeResponse);
-    expect(document.title).toBe('Test Title; Please Ignore');
+    expect(document.title).toBe("Test Title; Please Ignore");
   });
 
-  it('sets document.title to empty string if response has no title', () => {
+  it("sets document.title to empty string if response has no title", () => {
     const sideEffect = createTitleSideEffect();
-    const fakeResponse = {} as Response;
+    const fakeResponse = { response: {} } as ResponseHandlerProps;
     const queryResponse = sideEffect(fakeResponse);
-    expect(document.title).toBe('');
+    expect(document.title).toBe("");
   });
 
-  describe('prefix', () => {
-    it('prepends the prefix before the title', () => {
-      const sideEffect = createTitleSideEffect({ prefix: 'My Site' });
+  describe("prefix", () => {
+    it("prepends the prefix before the title", () => {
+      const sideEffect = createTitleSideEffect({ prefix: "My Site" });
       const queryResponse = sideEffect(fakeResponse);
-      expect(document.title).toBe('My Site Test Title; Please Ignore');
+      expect(document.title).toBe("My Site Test Title; Please Ignore");
     });
   });
 
-  describe('suffix', () => {
-    it('appends the suffix after the title', () => {
-      const sideEffect = createTitleSideEffect({ suffix: 'My Site' });
+  describe("suffix", () => {
+    it("appends the suffix after the title", () => {
+      const sideEffect = createTitleSideEffect({ suffix: "My Site" });
       const queryResponse = sideEffect(fakeResponse);
-      expect(document.title).toBe('Test Title; Please Ignore My Site');
+      expect(document.title).toBe("Test Title; Please Ignore My Site");
     });
   });
 
-  describe('delimiter', () => {
-    it('it adds delimiter between prefix, response.title, and suffix', () => {
+  describe("delimiter", () => {
+    it("it adds delimiter between prefix, response.title, and suffix", () => {
       const sideEffect = createTitleSideEffect({
-        prefix: 'Prefix',
-        suffix: 'Suffix',
-        delimiter: '|'
+        prefix: "Prefix",
+        suffix: "Suffix",
+        delimiter: "|"
       });
       const queryResponse = sideEffect(fakeResponse);
       expect(document.title).toBe(
-        'Prefix | Test Title; Please Ignore | Suffix'
+        "Prefix | Test Title; Please Ignore | Suffix"
       );
     });
 
-    it('does not prepend delimiter when there is no prefix', () => {
+    it("does not prepend delimiter when there is no prefix", () => {
       const sideEffect = createTitleSideEffect({
-        suffix: 'Suffix',
-        delimiter: '|'
+        suffix: "Suffix",
+        delimiter: "|"
       });
       const queryResponse = sideEffect(fakeResponse);
-      expect(document.title).toBe('Test Title; Please Ignore | Suffix');
+      expect(document.title).toBe("Test Title; Please Ignore | Suffix");
     });
 
-    it('does not append delimiter when there is no suffix', () => {
+    it("does not append delimiter when there is no suffix", () => {
       const sideEffect = createTitleSideEffect({
-        prefix: 'Prefix',
-        delimiter: '|'
+        prefix: "Prefix",
+        delimiter: "|"
       });
       const queryResponse = sideEffect(fakeResponse);
-      expect(document.title).toBe('Prefix | Test Title; Please Ignore');
+      expect(document.title).toBe("Prefix | Test Title; Please Ignore");
     });
   });
 });

--- a/packages/side-effects/side-effect-title/types/index.d.ts
+++ b/packages/side-effects/side-effect-title/types/index.d.ts
@@ -1,4 +1,4 @@
-import { ResponseHandler } from '@curi/core';
+import { ResponseHandler } from "@curi/core";
 export interface TitleOptions {
     prefix?: string;
     suffix?: string;

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* (Internal) `CuriPlugin`'s response handler receives `ResponseHandlerProps`.
+
 ## 1.0.0-beta.15
 
 * Switch from `action` to `navigation` (which contains an `action` as well as the previous `response`).

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* (Internal) `CuriPlugin`'s response handler receives `ResponseHandlerProps`.
+* (Internal) `CuriPlugin`'s response handler receives `Emitted`.
 
 ## 1.0.0-beta.15
 

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -21,7 +21,7 @@ const CuriPlugin: PluginObject<CuriPluginOptions> = {
       data: { response: null, navigation: null }
     });
 
-    options.router.respond((response, navigation) => {
+    options.router.respond(({ response, navigation }) => {
       reactive.response = response;
       reactive.navigation = navigation;
     });

--- a/packages/vue/tests/plugin.spec.ts
+++ b/packages/vue/tests/plugin.spec.ts
@@ -36,7 +36,7 @@ describe("CuriPlugin", () => {
         }
       };
       router.respond(
-        (response, navigation) => {
+        ({ response, navigation }) => {
           Vue.use(CuriPlugin, { router });
 
           const wrapper = shallow(FakeComponent, {
@@ -84,7 +84,7 @@ describe("CuriPlugin", () => {
         let wrapper;
         Vue.use(CuriPlugin, { router });
 
-        router.respond((response, navigation) => {
+        router.respond(() => {
           if (!wrapper) {
             wrapper = shallow(FakeComponent, {
               localVue: Vue
@@ -101,7 +101,7 @@ describe("CuriPlugin", () => {
         let wrapper;
         Vue.use(CuriPlugin, { router });
 
-        router.respond((response, navigation) => {
+        router.respond(() => {
           if (!wrapper) {
             wrapper = mount(
               {


### PR DESCRIPTION
```js
// current
router.respond((response, navigation, router) => {
  // ...
});
// new
router.respond(({ response, navigation, router }) => {
  // ...
});
```
Why? This makes it easier to just specify the properties that are desired. The user should only have to call `router.respond` is to wait for the initial response to be emitted and they shouldn't even have to care about the arguments passed to that callback because packages should handle subscribing to the router for the user (`CuriPlugin` with `@curi/vue`, `<ResponsiveBase>` with `@curi/react`, etc.).