### PR TITLE
Add observe option to router.respond, remove once

### DIFF
--- a/documentation-website/src/client/Examples/misc/ServerRendering.js
+++ b/documentation-website/src/client/Examples/misc/ServerRendering.js
@@ -32,7 +32,7 @@ export default ({ name }) => (
     );
     // 5. Insert the markup into the page's html and send it
     res.send(renderFullPage(markup));
-  }, { once: true });
+  });
 }`}
       </PrismBlock>
 

--- a/documentation-website/src/client/Examples/misc/SideEffect.js
+++ b/documentation-website/src/client/Examples/misc/SideEffect.js
@@ -15,8 +15,9 @@ export default ({ name }) => (
         JavaScript object. Then, any response handler functions are called and
         passed that JavaScript object . Side effects are basically permanent
         response handlers (they cannot be removed). Side effects can either be
-        run before (default) or after subscribed response handlers. They receive
-        the new response and an object with information about the navigation.
+        run before (default) or after response handler that were set using{" "}
+        <IJS>router.respond</IJS>. They receive the new response and an object
+        with information about the navigation.
       </p>
 
       <p>

--- a/documentation-website/src/client/Guides/GettingStarted.js
+++ b/documentation-website/src/client/Guides/GettingStarted.js
@@ -17,10 +17,11 @@ export default ({ name }) => (
       default export from <IJS>@curi/core</IJS>.
     </p>
     <p>
-      In order to re-render your application after navigation, you can subscribe
-      to your router using its <IJS>respond</IJS> method. <IJS>respond</IJS>{" "}
-      takes a callback function that will be passed <IJS>response</IJS> and{" "}
-      <IJS>navigation</IJS> arguments, which you can use to render.
+      In order to re-render your application after navigation, you can observe
+      your router for responses using its <IJS>respond</IJS> method.{" "}
+      <IJS>respond</IJS> takes a callback function that will be passed{" "}
+      <IJS>response</IJS> and <IJS>navigation</IJS> arguments, which you can use
+      to render.
     </p>
 
     <Section title="The History Object" id="history-object">
@@ -160,11 +161,11 @@ const router = curi(history, routes);
         Whenever navigation happens, a new location object is created by
         Hickory. Curi uses that location object's pathname property to match
         against all of your routes. When it finds one that matches, it uses that
-        route object to create a response object. You can subscribe to a Curi
-        router with a response handler function. When a new response is created,
-        your response handler function will be passed an object that contains a
-        response object, an object with additional navigation data, and your
-        router.
+        route object to create a response object. You can give your Curi router
+        response handlers to be called whenever a new response is created. When
+        a new response is created, your response handler function will be passed
+        an object that contains a response object, an object with additional
+        navigation data, and your router.
       </p>
       <Note>
         Response handlers are passed the router so you can define them in a

--- a/documentation-website/src/client/Guides/MigrateReactRouterv3.js
+++ b/documentation-website/src/client/Guides/MigrateReactRouterv3.js
@@ -417,10 +417,8 @@ const router = curi(history, routes);`}
           <IJS>children</IJS> prop.
         </p>
         <p>
-          We will also use <IJS>router.respond</IJS> so that the application is
-          not rendered until the initial response has been emitted. The{" "}
-          <IJS>once</IJS> option is provided because we only need this callback
-          function to be called the first time a <IJS>response</IJS> is emitted.
+          We will also use <IJS>router.respond</IJS> to wait for the initial
+          response to be emitted before rendering.
         </p>
         <PrismBlock lang="jsx">
           {`router.respond(() => {
@@ -429,7 +427,7 @@ const router = curi(history, routes);`}
       {({ response }) => {...}}
     </CuriProvider>
   ), holder);
-}, { once: true });`}
+});`}
         </PrismBlock>
         <p>
           So what should your render function look like? The render function

--- a/documentation-website/src/client/Guides/UsingSideEffects.js
+++ b/documentation-website/src/client/Guides/UsingSideEffects.js
@@ -10,10 +10,9 @@ export default ({ name }) => (
     <h1>{name}</h1>
 
     <p>
-      Curi side effects are essentially permament subscribers (response
-      handlers) to your router. They can be considered slightly more convenient
-      than response handlers since you don't have to subscribe to your router to
-      set them up. However, you also cannot remove them.
+      Curi side effects are essentially permament observers (response handlers)
+      of your router, but you can specify whether they should be run before or
+      after response handlers that were setup using <IJS>router.respond</IJS>.
     </p>
 
     <p>

--- a/documentation-website/src/client/Packages/Core.js
+++ b/documentation-website/src/client/Packages/Core.js
@@ -55,9 +55,7 @@ const router = curi(history, routes, options);`}
                 wish to use should be provided in this array.
               </li>
               <li>
-                <IJS>middleware</IJS> - An array of middleware functions. These
-                are functions that will be able to interact with/modify response
-                objects before they are emitted to subscribed functions.
+                <IJS>sideEffects</IJS> - An array of side-effect objects.
               </li>
               <li>
                 <IJS>cache</IJS> - An object with get/set properties. This
@@ -96,7 +94,7 @@ const router = curi(history, routes, options);`}
             <p>
               If the best-matched route has either a <IJS>match.initial</IJS> or{" "}
               <IJS>match.every</IJS> loading function, the router will not call
-              the subscribed functions until the loading functions have all
+              the response handler functions until the match functions have all
               resolved.
             </p>
             <PrismBlock lang="javascript">
@@ -107,9 +105,13 @@ const router = curi(history, routes, options);`}
 
             <Subsection tag="h6" title="options" id="respond-options">
               <PrismBlock lang="javascript">
-                {`{ once: true } // default false
-// When true, the response handler function will only be called once. When
-// once is true, router.respond does not return an unsubscribe function.`}
+                {`{ observe: true } // default false
+// When true, the response handler function will be called for all future
+// responses that are emitted by the router.
+
+{ initial: false } // default true
+// When false, the response handler will not be called until the
+// next response is emitted.`}
               </PrismBlock>
             </Subsection>
           </Subsection>

--- a/documentation-website/src/client/Packages/ReactPkg.js
+++ b/documentation-website/src/client/Packages/ReactPkg.js
@@ -65,7 +65,7 @@ export default ({ name, version, globalName }) => (
       }}
     </CuriProvider>
   ), holder);
-}, { once: true });`}
+});`}
         </PrismBlock>
         <Section tag="h3" title="Props" id="CuriProvider-props">
           <Subsection tag="h4" title="router" id="CuriProvider-router">

--- a/documentation-website/src/client/Packages/Redux.js
+++ b/documentation-website/src/client/Packages/Redux.js
@@ -32,10 +32,10 @@ export default ({ name, version, globalName }) => (
       <Section tag="h3" title="syncResponses" id="syncResponses">
         <p>
           <IJS>syncResponses</IJS> is responsible for linking your Redux store
-          with your Curi router. It subscribes to location changes emitted from
-          your router with a function that will dispatch a "location changed"
-          event to the Redux store. It will also add your Curi router to the
-          store.
+          with your Curi router. It observes the router with a response handler
+          that will dispatch a "location changed" event to the Redux store
+          whenever a new response is emitted. It will also add your Curi router
+          to the store.
         </p>
         <PrismBlock lang="javascript">
           {`const router = curi(history, routes);

--- a/documentation-website/src/client/Packages/Svelte.js
+++ b/documentation-website/src/client/Packages/Svelte.js
@@ -75,7 +75,7 @@ const store = new Store({
 });`}
       </PrismBlock>
       <p>
-        Add a subscriber to the router to update the store whenever a new
+        Add an observer to the router to update the store whenever a new
         response is emitted.
       </p>
       <PrismBlock lang="javascript">
@@ -86,8 +86,8 @@ const store = new Store({
       <p>
         As far as rendering your application goes, you should should have a base
         component that has any global layout and uses the response to render the
-        correct component(s). Setup a one time subscriber to render this
-        component and make sure to pass the store to the component.
+        correct component(s). Setup a response handler for the initial render of
+        this component and make sure to pass the store to the component.
       </p>
       <PrismBlock lang="html">
         {`<NavLinks />
@@ -104,10 +104,10 @@ const store = new Store({
       <PrismBlock lang="javascript">
         {`import app from './components/app';
 
-// use a one time subscriber for the initial render
+// use a response handler for the initial render
 config.respond(() => {
   view = new app({ target, store });
-}, { once: true });`}
+});`}
       </PrismBlock>
     </Section>
   </BasePackage>

--- a/documentation-website/src/client/Packages/Vue.js
+++ b/documentation-website/src/client/Packages/Vue.js
@@ -170,10 +170,10 @@ export default function renderFunction(h) {
       </PrismBlock>
 
       <p>
-        While the <IJS>CuriPlugin</IJS> subscribes to your router object, you
-        will still need to wait for it to emit its first update before you can
-        render. To do that, you can pass the <IJS>{`{ once: true }`}</IJS>{" "}
-        option to a <IJS>router.respond</IJS> call.
+        While the <IJS>CuriPlugin</IJS> observes your router for new responses,
+        you will still need to wait for it to emit its first response before you
+        can render. This can be done by calling your rendering code in a
+        callback function passed to <IJS>router.respond</IJS>.
       </p>
 
       <PrismBlock lang="javascript">
@@ -192,7 +192,7 @@ router.respond(() => {
       return h(this.$curi.response.body)
     }
   });
-}, { once: true });`}
+});`}
       </PrismBlock>
     </Section>
   </BasePackage>

--- a/documentation-website/src/client/Tutorials/03-Hickory.js
+++ b/documentation-website/src/client/Tutorials/03-Hickory.js
@@ -36,9 +36,9 @@ export default () => (
         browser's forward and back buttons.
       </p>
       <p>
-        Hickory uses a single-subscriber model so that whenever navigation to a
-        new location happens, the subscribed method will be called. Curi will
-        subscribe to your history object to create new responses whenever the
+        Hickory uses a single-observer model so that whenever navigation to a
+        new location happens, the observer method will be called. Curi will
+        observe your history object to create new responses whenever the
         location changes.
       </p>
     </Section>

--- a/documentation-website/src/client/Tutorials/04-Router.js
+++ b/documentation-website/src/client/Tutorials/04-Router.js
@@ -83,15 +83,15 @@ const router = curi(history, routes);`}
       </PrismBlock>
     </Section>
 
-    <Section title="Subscriber Model" id="subscriber" type="aside">
+    <Section title="Observer Model" id="observer" type="aside">
       <p>
         In order to let your application know about location changes, Curi uses
-        a subscriber model. Whenever a location change happens, Curi will create
-        a new response and then emit this response to all of its subscribed
-        functions. These subscribed functions are called response handlers since
-        they handle the new respond. Using <IJS>router.respond</IJS>, we can
-        give Curi a response handler to call when a new response has been
-        created.
+        an observer model to emit responses. A piece of code that wants to know
+        about the current response passes a callback function (referred to here
+        as a response handler) to <IJS>router.respond</IJS>. If a response
+        already exists, then the response handler will be called immediately. If
+        the initial response hasn't resolved, then the response handler will be
+        called once it does.
       </p>
       <p>
         What does a response handler function look like? It receives an object
@@ -102,42 +102,38 @@ const router = curi(history, routes);`}
         and the <IJS>router</IJS> is your Curi router.
       </p>
       <PrismBlock lang="javascript">
-        {`function responseLogger({ response, navigation }) {
-  console.log("RESPONSE:", response);
-  console.log("NAVIGATION", navigation)
+        {`function responseLogger({ response, navigation, router }) {
+  console.log("[response]", response);
+  console.log("[navigation]", navigation);
+  console.log("[router]", router);
 }
 router.respond(responseLogger);`}
       </PrismBlock>
-      <p>
-        <IJS>curi.respond</IJS> will return a function that you can use to stop
-        responding to new responses.
-      </p>
-      <PrismBlock lang="javascript">
-        {`function responseLogger() {
-  console.log("I will be called for every response until I unsubscribe");
-}
-const stopResponding = router.respond(responseLogger);
-// any navigation that happens now will be logged
-// ...
-stopResponding();
-// after unsubscribing, any new navigation will not be logged`}
-      </PrismBlock>
-      <p>
-        By default, response handlers are subscribers (that is to say, they will
-        be called every time a new response is generated). You might sometimes
-        want to only call a response handler once. For example, a response
-        handler might be a "ready" function that you only want called once you
-        know that an initial response exists. To do that, you can use the second
-        argument to <IJS>router.respond</IJS>, which is an <IJS>options</IJS>{" "}
-        object. When the <IJS>once</IJS> object is <IJS>true</IJS>, then that
-        response handler will only be called one time.
-      </p>
-      <PrismBlock lang="javascript">
-        {`function responseLogger() {
-  console.log("I will only be called once");
-}
-router.respond(responseLogger, { once: true });`}
-      </PrismBlock>
+      <Note>
+        By default, the response handler will only be called one time. However,
+        your application should be updated for <em>every</em> response.{" "}
+        <IJS>router.respond</IJS> supports a second argument, which is an
+        options object. One of these options is <IJS>observe</IJS>.{" "}
+        <IJS>observe</IJS> defaults to <IJS>false</IJS>, but when you set it to{" "}
+        <IJS>true</IJS>, the response handler will be called every time a new
+        response is emitted. This will also return a function so that you can
+        stop observing. You probably won't need to use this because the various
+        packages (<IJS>@curi/react</IJS>, <IJS>@curi/vue</IJS>, etc. handle this
+        for you).
+        <PrismBlock lang="javascript">
+          {`function responseLogger() {
+    console.log("I will be called for every response");
+  }
+  const stopResponding = router.respond(
+    responseLogger,
+    { observe: true }
+  );
+  // any navigation that happens now will be logged
+  // ...
+  stopResponding();
+  // after unsubscribing, any new navigation will not be logged`}
+        </PrismBlock>
+      </Note>
     </Section>
 
     <Section title="Review" id="review">

--- a/documentation-website/src/client/Tutorials/05-ReactPages.js
+++ b/documentation-website/src/client/Tutorials/05-ReactPages.js
@@ -129,15 +129,12 @@ import { CuriProvider } from '@curi/react';`}
           </li>
         </ol>
         <p>
-          The <Cmp>CuriProvider</Cmp> will listen for new responses to be
-          emitted by the router, but we should also delay our initial render
-          until we know that the router has emitted its first response. This can
-          be skipped, but we would have to render a loading screen.
-        </p>
-        <p>
-          We will pass the <IJS>{`{ once: true }`}</IJS> option to{" "}
-          <IJS>router.respond</IJS> because the <Cmp>CuriProvider</Cmp> will
-          take over listening for new responses.
+          The <Cmp>CuriProvider</Cmp> will setup a response handler to trigger a
+          re-render when new responses are emitted by the router. We should also
+          delay our initial render until the router has emitted its first
+          response. We can do this by calling <IJS>ReactDOM.render</IJS> in a
+          response handler that is passed to <IJS>router.respond</IJS>. This can
+          be skipped, but then we would have to render a loading screen.
         </p>
         <PrismBlock lang="jsx" data-line="2-4, 9-14, 15">
           {`// src/index.js
@@ -153,7 +150,7 @@ router.respond(() => {
       {() => null}
     </CuriProvider>
   ), document.getElementById('root'));
-}, { once: true });`}
+});`}
         </PrismBlock>
         <Note>
           An invisible but important function of the <Cmp>CuriProvider</Cmp> is
@@ -453,7 +450,7 @@ router.respond(() => {
       {renderFunction}
     </CuriProvider>
   ), root);
-}, { once: true });`}
+});`}
       </PrismBlock>
       <p>
         Now, if we load up our application, we will render our home page (the{" "}

--- a/documentation-website/src/client/Tutorials/05-VuePages.js
+++ b/documentation-website/src/client/Tutorials/05-VuePages.js
@@ -184,25 +184,19 @@ Vue.use(CuriPlugin, { router });`}
       <p>
         Being able to access the Curi router is nice, but what we really need is
         to access the response objects that are emitted by Curi whenever the
-        location changes. We <em>could</em> use the <IJS>router.respond</IJS>{" "}
-        method that we covered in the{" "}
-        <Link to="Tutorial" params={{ name: "04-router" }}>
-          router
-        </Link>{" "}
-        tutorial, but the <IJS>CuriPlugin</IJS> takes care of that step for us.{" "}
-        <IJS>CuriPlugin</IJS> calls <IJS>router.respond</IJS> and in the
-        response handler, it updates the reactive <IJS>response</IJS> and{" "}
-        <IJS>navigation</IJS> properties of <IJS>this.$curi</IJS> whenever a new
-        response is emitted.
+        location changes. The <IJS>CuriPlugin</IJS> takes care of that step for
+        us. <IJS>CuriPlugin</IJS> sets up an observer using{" "}
+        <IJS>router.respond</IJS>. Whenever a new response is emitted, that
+        response handler updates the reactive <IJS>response</IJS> and{" "}
+        <IJS>navigation</IJS> properties of <IJS>this.$curi</IJS>.
       </p>
 
       <p>
-        While we do not have to manually subscribe to all responses, we do need
-        to listen for the first response to be emitted so that we can render the
-        application. The second argument to <IJS>router.respond</IJS> is an
-        options object. If we pass the options <IJS>{`{ once: true }`}</IJS>,
-        then that function will only be called after the initial response is
-        emitted.
+        While we do not have to manually observe the router to be informed of
+        new responses, we do need to listen for the first response to be emitted
+        so that we can render the application. We can do this by passing a
+        response handler that creates our Vue instance to{" "}
+        <IJS>router.respond</IJS>.
       </p>
       <p>
         Inside of the response handler function, we just need to render our root
@@ -220,7 +214,7 @@ router.respond(() => {
     template: '<app />',
     components: { app }
   });
-}, { once: true });`}
+});`}
       </PrismBlock>
     </Section>
 

--- a/documentation-website/src/client/components/Banner/ReactBanner.js
+++ b/documentation-website/src/client/components/Banner/ReactBanner.js
@@ -25,7 +25,7 @@ router.respond(() => {
       }}
     </CuriProvider>
   ), root);
-}, { once: true });`}
+});`}
   </PrismBlock>
 );
 

--- a/documentation-website/src/client/components/Banner/SvelteBanner.js
+++ b/documentation-website/src/client/components/Banner/SvelteBanner.js
@@ -23,12 +23,12 @@ const store = new Store({
 // the location changes.
 router.respond(({ response, navigation }) => {
   store.set({ curi: { response, navigation } });
-});
+}, { observe: true });
 
 // add a one time response handler for the initial render
 router.respond(() => {
   const view = new app({ target, store });
-}, { once: true });`}
+});`}
   </PrismBlock>
 );
 

--- a/documentation-website/src/client/components/Banner/VueBanner.js
+++ b/documentation-website/src/client/components/Banner/VueBanner.js
@@ -25,7 +25,7 @@ router.respond(() => {
     template: '<app />',
     components: { app: App }
   });
-}, { once: true });`}
+});`}
   </PrismBlock>
 );
 

--- a/documentation-website/src/client/scss/messages.scss
+++ b/documentation-website/src/client/scss/messages.scss
@@ -1,12 +1,17 @@
-@import './variables.scss';
+@import "./variables.scss";
 
-.note, .warning {
+.note,
+.warning {
   padding: 10px 5px;
 }
 
 .note {
   background: $gray;
   border: 1px solid $border-gray;
+}
+
+.aside .note {
+  background: $white;
 }
 
 .warning {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Replace `once` option with `observe`, which is `false` by default (reverses previous default behavior).
 * Pass an `Emitted` object to response handlers. This object has `response`, `navigation`, and `router` properties.
 
 ## 1.0.0-beta.25

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -90,18 +90,20 @@ function createRouter(
 
     const { observe = false, initial = true } = options || {};
 
-    if (mostRecent.response && initial) {
-      fn.call(null, { ...mostRecent, router });
-      return;
-    }
-
     if (observe) {
+      if (mostRecent.response && initial) {
+        fn.call(null, { ...mostRecent, router });
+      }
       const newLength = responseHandlers.push(fn);
       return () => {
         responseHandlers[newLength - 1] = null;
       };
     } else {
-      oneTimers.push(fn);
+      if (mostRecent.response && initial) {
+        fn.call(null, { ...mostRecent, router });
+      } else {
+        oneTimers.push(fn);
+      }
     }
   }
 

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -88,23 +88,20 @@ function createRouter(
       );
     }
 
-    const { once = false, initial = true } = options || {};
+    const { observe = false, initial = true } = options || {};
 
-    if (once) {
-      if (mostRecent.response && initial) {
-        fn.call(null, { ...mostRecent, router });
-      } else {
-        oneTimers.push(fn);
-      }
-    } else {
-      if (mostRecent.response && initial) {
-        fn.call(null, { ...mostRecent, router });
-      }
+    if (mostRecent.response && initial) {
+      fn.call(null, { ...mostRecent, router });
+      return;
+    }
 
+    if (observe) {
       const newLength = responseHandlers.push(fn);
       return () => {
         responseHandlers[newLength - 1] = null;
       };
+    } else {
+      oneTimers.push(fn);
     }
   }
 

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -19,7 +19,7 @@ export interface Emitted {
 export type ResponseHandler = (props?: Emitted) => void;
 
 export interface RespondOptions {
-  once?: boolean;
+  observe?: boolean;
   initial?: boolean;
 }
 export type RemoveResponseHandler = () => void;

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -697,18 +697,21 @@ describe("route matching/response generation", () => {
         ];
         const router = curi(history, routes);
         let firstCall = true;
-        router.respond(() => {
-          if (firstCall) {
-            firstCall = false;
-            expect(initialCount).toBe(1);
-            expect(everyCount).toBe(1);
-            history.push("/another-one");
-          } else {
-            expect(initialCount).toBe(1);
-            expect(everyCount).toBe(2);
-            done();
-          }
-        });
+        router.respond(
+          () => {
+            if (firstCall) {
+              firstCall = false;
+              expect(initialCount).toBe(1);
+              expect(everyCount).toBe(1);
+              history.push("/another-one");
+            } else {
+              expect(initialCount).toBe(1);
+              expect(everyCount).toBe(2);
+              done();
+            }
+          },
+          { observe: true }
+        );
       });
     });
 
@@ -868,12 +871,9 @@ describe("route matching/response generation", () => {
               }
             ];
             const router = curi(history, routes);
-            router.respond(
-              () => {
-                history.push("/another-one");
-              },
-              { once: true }
-            );
+            router.respond(() => {
+              history.push("/another-one");
+            });
           });
 
           it("resolved.initial is undefined if there is no match.initial function", done => {

--- a/packages/core/types/types/curi.d.ts
+++ b/packages/core/types/types/curi.d.ts
@@ -14,7 +14,7 @@ export interface Emitted {
 }
 export declare type ResponseHandler = (props?: Emitted) => void;
 export interface RespondOptions {
-    once?: boolean;
+    observe?: boolean;
     initial?: boolean;
 }
 export declare type RemoveResponseHandler = () => void;

--- a/packages/mobx/src/index.ts
+++ b/packages/mobx/src/index.ts
@@ -12,9 +12,12 @@ export default class CuriStore {
     this.response = null;
     this.navigation = null;
 
-    router.respond(({ response, navigation }: Emitted) => {
-      this.update(response, navigation);
-    });
+    router.respond(
+      ({ response, navigation }: Emitted) => {
+        this.update(response, navigation);
+      },
+      { observe: true }
+    );
   }
 
   @mobxAction.bound

--- a/packages/mobx/tests/mobx.spec.ts
+++ b/packages/mobx/tests/mobx.spec.ts
@@ -36,17 +36,20 @@ describe("@curi/mobx", () => {
     it("updates response/navigation when a new response is emitted", done => {
       history.replace("/one");
       let firstResponse;
-      router.respond(({ response, navigation }) => {
-        if (!firstResponse) {
-          firstResponse = response;
-        } else {
-          // cannot compare actual objects since MobX makes responses reactive
-          expect(store.response.name).toBe("One");
-          expect(store.navigation.action).toBe("REPLACE");
-          expect(store.navigation.previous.name).toBe(firstResponse.name);
-          done();
-        }
-      });
+      router.respond(
+        ({ response, navigation }) => {
+          if (!firstResponse) {
+            firstResponse = response;
+          } else {
+            // cannot compare actual objects since MobX makes responses reactive
+            expect(store.response.name).toBe("One");
+            expect(store.navigation.action).toBe("REPLACE");
+            expect(store.navigation.previous.name).toBe(firstResponse.name);
+            done();
+          }
+        },
+        { observe: true }
+      );
     });
   });
 });

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* (Internal) `<CuriProvider>` uses `router.respond(fn, { observe: true })`.
 * Use `react-broadcast` to simulate new context API. This removes the `<ResponsiveBase>` and `<CuriBase>` components in favor of a single `<CuriProvider>`. The `<Curious>` prop also now just expects a `children` render function prop.
 * (Internal) Router's response handler receives `Emitted` object.
 

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -27,23 +27,20 @@ describe("<Link>", () => {
       const history = InMemory();
       const router = curi(history, [{ name: "Test", path: "" }]);
 
-      router.respond(
-        () => {
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Test">
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.findByType(TouchableHighlight);
-          expect(anchor).toBeDefined();
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Test">
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        expect(anchor).toBeDefined();
+        done();
+      });
     });
 
     it("when provided, it renders the component instead of an anchor", done => {
@@ -53,23 +50,20 @@ describe("<Link>", () => {
         <TouchableHighlight style={{ borderColor: "orange" }} {...props} />
       );
 
-      router.respond(
-        () => {
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Test" anchor={StyledAnchor}>
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.find(StyledAnchor);
-          expect(anchor).toBeDefined();
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Test" anchor={StyledAnchor}>
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.find(StyledAnchor);
+        expect(anchor).toBeDefined();
+        done();
+      });
     });
   });
 
@@ -80,26 +74,23 @@ describe("<Link>", () => {
       history.navigate = mockNavigate;
       const routes = [];
       const router = curi(history, routes);
-      router.respond(
-        () => {
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to={null}>
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.findByType(TouchableHighlight);
-          anchor.props.onPress(fakeEvent());
-          expect(mockNavigate.mock.calls[0][0].pathname).toBe(
-            "/the-initial-location"
-          );
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to={null}>
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        anchor.props.onPress(fakeEvent());
+        expect(mockNavigate.mock.calls[0][0].pathname).toBe(
+          "/the-initial-location"
+        );
+        done();
+      });
     });
   });
 
@@ -111,24 +102,21 @@ describe("<Link>", () => {
 
       const router = curi(history, [{ name: "Park", path: "/park/:name" }]);
       const params = { name: "Glacier" };
-      router.respond(
-        () => {
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Park" params={params}>
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.findByType(TouchableHighlight);
-          anchor.props.onPress(fakeEvent());
-          expect(mockNavigate.mock.calls[0][0].pathname).toBe("/park/Glacier");
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Park" params={params}>
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        anchor.props.onPress(fakeEvent());
+        expect(mockNavigate.mock.calls[0][0].pathname).toBe("/park/Glacier");
+        done();
+      });
     });
 
     it("updates location to navigate to when props change", done => {
@@ -138,40 +126,37 @@ describe("<Link>", () => {
 
       const router = curi(history, [{ name: "Park", path: "/park/:name" }]);
 
-      router.respond(
-        () => {
-          const params = { name: "Glacier" };
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Park" params={params}>
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.findByType(TouchableHighlight);
-          anchor.props.onPress(fakeEvent());
-          expect(mockNavigate.mock.calls[0][0].pathname).toBe("/park/Glacier");
+      router.respond(() => {
+        const params = { name: "Glacier" };
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Park" params={params}>
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        anchor.props.onPress(fakeEvent());
+        expect(mockNavigate.mock.calls[0][0].pathname).toBe("/park/Glacier");
 
-          const newParams = { name: "Yellowstone" };
-          tree.update(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Park" params={newParams}>
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          anchor.props.onPress(fakeEvent());
-          expect(mockNavigate.mock.calls[1][0].pathname).toBe(
-            "/park/Yellowstone"
-          );
-          done();
-        },
-        { once: true }
-      );
+        const newParams = { name: "Yellowstone" };
+        tree.update(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Park" params={newParams}>
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        anchor.props.onPress(fakeEvent());
+        expect(mockNavigate.mock.calls[1][0].pathname).toBe(
+          "/park/Yellowstone"
+        );
+        done();
+      });
     });
   });
 
@@ -183,28 +168,25 @@ describe("<Link>", () => {
 
       const router = curi(history, [{ name: "Test", path: "test" }]);
 
-      router.respond(
-        () => {
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Test" details={{ query: "one=two", hash: "hashtag" }}>
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.findByType(TouchableHighlight);
-          anchor.props.onPress(fakeEvent());
-          expect(mockNavigate.mock.calls[0][0]).toMatchObject({
-            pathname: "/test",
-            query: "one=two",
-            hash: "hashtag"
-          });
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Test" details={{ query: "one=two", hash: "hashtag" }}>
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        anchor.props.onPress(fakeEvent());
+        expect(mockNavigate.mock.calls[0][0]).toMatchObject({
+          pathname: "/test",
+          query: "one=two",
+          hash: "hashtag"
+        });
+        done();
+      });
     });
 
     it("providing a pathname in details does not overwrite the generated pathname", done => {
@@ -213,24 +195,21 @@ describe("<Link>", () => {
       history.navigate = mockNavigate;
 
       const router = curi(history, [{ name: "Test", path: "test" }]);
-      router.respond(
-        () => {
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Test" details={{ pathname: "/not-a-test" }}>
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.findByType(TouchableHighlight);
-          anchor.props.onPress(fakeEvent());
-          expect(mockNavigate.mock.calls[0][0].pathname).toBe("/test");
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Test" details={{ pathname: "/not-a-test" }}>
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        anchor.props.onPress(fakeEvent());
+        expect(mockNavigate.mock.calls[0][0].pathname).toBe("/test");
+        done();
+      });
     });
   });
 
@@ -253,62 +232,56 @@ describe("<Link>", () => {
       it("throws on mount", done => {
         const history = InMemory();
         const router = curi(history, [{ name: "Test", path: "test" }]);
-        router.respond(
-          () => {
-            expect(() => {
-              const tree = renderer.create(
-                <CuriProvider router={router}>
-                  {() => (
-                    <Link to="Test" active={{ merge }}>
-                      <Text>Test</Text>
-                    </Link>
-                  )}
-                </CuriProvider>
-              );
-            }).toThrow(
-              'You are attempting to use the "active" prop, but have not included the "active" ' +
-                "addon (@curi/addon-active) in your Curi router."
+        router.respond(() => {
+          expect(() => {
+            const tree = renderer.create(
+              <CuriProvider router={router}>
+                {() => (
+                  <Link to="Test" active={{ merge }}>
+                    <Text>Test</Text>
+                  </Link>
+                )}
+              </CuriProvider>
             );
-            done();
-          },
-          { once: true }
-        );
+          }).toThrow(
+            'You are attempting to use the "active" prop, but have not included the "active" ' +
+              "addon (@curi/addon-active) in your Curi router."
+          );
+          done();
+        });
       });
 
       it("throws if adding active prop on re-render", done => {
         const history = InMemory();
         const router = curi(history, [{ name: "Test", path: "test" }]);
 
-        router.respond(
-          () => {
-            const tree = renderer.create(
+        router.respond(() => {
+          const tree = renderer.create(
+            <CuriProvider router={router}>
+              {() => (
+                <Link to="Test">
+                  <Text>Test</Text>
+                </Link>
+              )}
+            </CuriProvider>
+          );
+          expect(() => {
+            tree.update(
               <CuriProvider router={router}>
                 {() => (
-                  <Link to="Test">
+                  <Link to="Test" active={{ merge }}>
                     <Text>Test</Text>
                   </Link>
                 )}
               </CuriProvider>
             );
-            expect(() => {
-              tree.update(
-                <CuriProvider router={router}>
-                  {() => (
-                    <Link to="Test" active={{ merge }}>
-                      <Text>Test</Text>
-                    </Link>
-                  )}
-                </CuriProvider>
-              );
-            }).toThrow(
-              'You are attempting to use the "active" prop, but have not included the "active" ' +
-                "addon (@curi/addon-active) in your Curi router."
-            );
+          }).toThrow(
+            'You are attempting to use the "active" prop, but have not included the "active" ' +
+              "addon (@curi/addon-active) in your Curi router."
+          );
 
-            done();
-          },
-          { once: true }
-        );
+          done();
+        });
       });
     });
 
@@ -318,27 +291,24 @@ describe("<Link>", () => {
         const router = curi(history, [{ name: "Test", path: "test" }], {
           addons: [createActiveAddon()]
         });
-        router.respond(
-          () => {
-            const tree = renderer.create(
-              <CuriProvider router={router}>
-                {() => (
-                  <Link
-                    to="Test"
-                    style={{ borderColor: "blue" }}
-                    active={{ merge }}
-                  >
-                    <Text>Test</Text>
-                  </Link>
-                )}
-              </CuriProvider>
-            );
-            const anchor = tree.root.findByType(TouchableHighlight);
-            expect(anchor.props.style).toMatchObject({ borderColor: "blue" });
-            done();
-          },
-          { once: true }
-        );
+        router.respond(() => {
+          const tree = renderer.create(
+            <CuriProvider router={router}>
+              {() => (
+                <Link
+                  to="Test"
+                  style={{ borderColor: "blue" }}
+                  active={{ merge }}
+                >
+                  <Text>Test</Text>
+                </Link>
+              )}
+            </CuriProvider>
+          );
+          const anchor = tree.root.findByType(TouchableHighlight);
+          expect(anchor.props.style).toMatchObject({ borderColor: "blue" });
+          done();
+        });
       });
 
       it("calls merge function when <Link>'s props match the current response's", done => {
@@ -347,28 +317,25 @@ describe("<Link>", () => {
           addons: [createActiveAddon()]
         });
 
-        router.respond(
-          () => {
-            const tree = renderer.create(
-              <CuriProvider router={router}>
-                {() => (
-                  <Link
-                    to="Test"
-                    style={{ borderColor: "blue" }}
-                    active={{ merge }}
-                  >
-                    <Text>Test</Text>
-                  </Link>
-                )}
-              </CuriProvider>
-            );
+        router.respond(() => {
+          const tree = renderer.create(
+            <CuriProvider router={router}>
+              {() => (
+                <Link
+                  to="Test"
+                  style={{ borderColor: "blue" }}
+                  active={{ merge }}
+                >
+                  <Text>Test</Text>
+                </Link>
+              )}
+            </CuriProvider>
+          );
 
-            const anchor = tree.root.findByType(TouchableHighlight);
-            expect(anchor.props.style).toMatchObject({ borderColor: "red" });
-            done();
-          },
-          { once: true }
-        );
+          const anchor = tree.root.findByType(TouchableHighlight);
+          expect(anchor.props.style).toMatchObject({ borderColor: "red" });
+          done();
+        });
       });
     });
 
@@ -389,31 +356,28 @@ describe("<Link>", () => {
           }
         );
 
-        router.respond(
-          () => {
-            const tree = renderer.create(
-              <CuriProvider router={router}>
-                {() => (
-                  <Link
-                    to="Test"
-                    style={{ backgroundColor: "green" }}
-                    active={{ partial: true, merge }}
-                  >
-                    <Text>Test</Text>
-                  </Link>
-                )}
-              </CuriProvider>
-            );
+        router.respond(() => {
+          const tree = renderer.create(
+            <CuriProvider router={router}>
+              {() => (
+                <Link
+                  to="Test"
+                  style={{ backgroundColor: "green" }}
+                  active={{ partial: true, merge }}
+                >
+                  <Text>Test</Text>
+                </Link>
+              )}
+            </CuriProvider>
+          );
 
-            const anchor = tree.root.findByType(TouchableHighlight);
-            expect(anchor.props.style).toMatchObject({
-              backgroundColor: "green",
-              borderColor: "red"
-            });
-            done();
-          },
-          { once: true }
-        );
+          const anchor = tree.root.findByType(TouchableHighlight);
+          expect(anchor.props.style).toMatchObject({
+            backgroundColor: "green",
+            borderColor: "red"
+          });
+          done();
+        });
       });
     });
 
@@ -428,28 +392,25 @@ describe("<Link>", () => {
           addons: [createActiveAddon()]
         });
 
-        router.respond(
-          () => {
-            const tree = renderer.create(
-              <CuriProvider router={router}>
-                {() => (
-                  <Link
-                    to="Test"
-                    details={{ query: "test=ing" }}
-                    active={{ merge, extra }}
-                  >
-                    <Text>Test</Text>
-                  </Link>
-                )}
-              </CuriProvider>
-            );
+        router.respond(() => {
+          const tree = renderer.create(
+            <CuriProvider router={router}>
+              {() => (
+                <Link
+                  to="Test"
+                  details={{ query: "test=ing" }}
+                  active={{ merge, extra }}
+                >
+                  <Text>Test</Text>
+                </Link>
+              )}
+            </CuriProvider>
+          );
 
-            const anchor = tree.root.findByType(TouchableHighlight);
-            expect(anchor.props.style).toMatchObject({ borderColor: "red" });
-            done();
-          },
-          { once: true }
-        );
+          const anchor = tree.root.findByType(TouchableHighlight);
+          expect(anchor.props.style).toMatchObject({ borderColor: "red" });
+          done();
+        });
       });
 
       it("active is false when pathname matches, but extra returns false", done => {
@@ -458,24 +419,21 @@ describe("<Link>", () => {
           addons: [createActiveAddon()]
         });
 
-        router.respond(
-          () => {
-            const tree = renderer.create(
-              <CuriProvider router={router}>
-                {() => (
-                  <Link to="Test" active={{ merge, extra }}>
-                    <Text>Test</Text>
-                  </Link>
-                )}
-              </CuriProvider>
-            );
+        router.respond(() => {
+          const tree = renderer.create(
+            <CuriProvider router={router}>
+              {() => (
+                <Link to="Test" active={{ merge, extra }}>
+                  <Text>Test</Text>
+                </Link>
+              )}
+            </CuriProvider>
+          );
 
-            const anchor = tree.root.findByType(TouchableHighlight);
-            expect(anchor.props.style).toBeUndefined();
-            done();
-          },
-          { once: true }
-        );
+          const anchor = tree.root.findByType(TouchableHighlight);
+          expect(anchor.props.style).toBeUndefined();
+          done();
+        });
       });
     });
   });
@@ -488,24 +446,21 @@ describe("<Link>", () => {
 
       const router = curi(history, [{ name: "Test", path: "" }]);
 
-      router.respond(
-        () => {
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Test">
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.findByType(TouchableHighlight);
-          anchor.props.onPress(fakeEvent());
-          expect(mockNavigate.mock.calls.length).toBe(1);
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Test">
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        anchor.props.onPress(fakeEvent());
+        expect(mockNavigate.mock.calls.length).toBe(1);
+        done();
+      });
     });
 
     it("includes details in location passed to history.navigate", done => {
@@ -515,28 +470,25 @@ describe("<Link>", () => {
 
       const router = curi(history, [{ name: "Test", path: "" }]);
 
-      router.respond(
-        () => {
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Test" details={{ hash: "thing" }}>
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.findByType(TouchableHighlight);
-          anchor.props.onPress(fakeEvent());
-          const mockLocation = mockNavigate.mock.calls[0][0];
-          expect(mockLocation).toMatchObject({
-            pathname: "/",
-            hash: "thing"
-          });
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Test" details={{ hash: "thing" }}>
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        anchor.props.onPress(fakeEvent());
+        const mockLocation = mockNavigate.mock.calls[0][0];
+        expect(mockLocation).toMatchObject({
+          pathname: "/",
+          hash: "thing"
+        });
+        done();
+      });
     });
 
     describe("onPress", () => {
@@ -547,26 +499,23 @@ describe("<Link>", () => {
         const onPress = jest.fn();
         const router = curi(history, [{ name: "Test", path: "" }]);
 
-        router.respond(
-          () => {
-            const tree = renderer.create(
-              <CuriProvider router={router}>
-                {() => (
-                  <Link to="Test" onPress={onPress}>
-                    <Text>Test</Text>
-                  </Link>
-                )}
-              </CuriProvider>
-            );
-            const anchor = tree.root.findByType(TouchableHighlight);
-            anchor.props.onPress(fakeEvent());
-            expect(mockNavigate.mock.calls.length).toBe(1);
-            expect(onPress.mock.calls.length).toBe(1);
-            expect(mockNavigate.mock.calls.length).toBe(1);
-            done();
-          },
-          { once: true }
-        );
+        router.respond(() => {
+          const tree = renderer.create(
+            <CuriProvider router={router}>
+              {() => (
+                <Link to="Test" onPress={onPress}>
+                  <Text>Test</Text>
+                </Link>
+              )}
+            </CuriProvider>
+          );
+          const anchor = tree.root.findByType(TouchableHighlight);
+          anchor.props.onPress(fakeEvent());
+          expect(mockNavigate.mock.calls.length).toBe(1);
+          expect(onPress.mock.calls.length).toBe(1);
+          expect(mockNavigate.mock.calls.length).toBe(1);
+          done();
+        });
       });
 
       it("does not call history.navigate if onPress prevents default", done => {
@@ -577,25 +526,22 @@ describe("<Link>", () => {
           event.preventDefault();
         });
         const router = curi(history, [{ name: "Test", path: "" }]);
-        router.respond(
-          () => {
-            const tree = renderer.create(
-              <CuriProvider router={router}>
-                {() => (
-                  <Link to="Test" onPress={onPress}>
-                    <Text>Test</Text>
-                  </Link>
-                )}
-              </CuriProvider>
-            );
-            const anchor = tree.root.findByType(TouchableHighlight);
-            anchor.props.onPress(fakeEvent());
-            expect(onPress.mock.calls.length).toBe(1);
-            expect(mockNavigate.mock.calls.length).toBe(0);
-            done();
-          },
-          { once: true }
-        );
+        router.respond(() => {
+          const tree = renderer.create(
+            <CuriProvider router={router}>
+              {() => (
+                <Link to="Test" onPress={onPress}>
+                  <Text>Test</Text>
+                </Link>
+              )}
+            </CuriProvider>
+          );
+          const anchor = tree.root.findByType(TouchableHighlight);
+          anchor.props.onPress(fakeEvent());
+          expect(onPress.mock.calls.length).toBe(1);
+          expect(mockNavigate.mock.calls.length).toBe(0);
+          done();
+        });
       });
     });
 
@@ -606,24 +552,21 @@ describe("<Link>", () => {
 
       const router = curi(history, [{ name: "Test", path: "" }]);
 
-      router.respond(
-        () => {
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Test">
-                  <Text>Test</Text>
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          const anchor = tree.root.findByType(TouchableHighlight);
-          anchor.props.onPress(fakeEvent({ defaultPrevented: true }));
-          expect(mockNavigate.mock.calls.length).toBe(0);
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Test">
+                <Text>Test</Text>
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        anchor.props.onPress(fakeEvent({ defaultPrevented: true }));
+        expect(mockNavigate.mock.calls.length).toBe(0);
+        done();
+      });
     });
   });
 });

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* (Internal) `<CuriProvider>` uses `router.respond(fn, { observe: true })`.
 * Use `react-broadcast` to simulate new context API. This removes the `<ResponsiveBase>` and `<CuriBase>` components in favor of a single `<CuriProvider>`. The `<Curious>` prop also now just expects a `children` render function prop.
 * (Internal) Router's response handler receives `Emitted` object.
 

--- a/packages/react/src/CuriProvider.tsx
+++ b/packages/react/src/CuriProvider.tsx
@@ -33,7 +33,7 @@ class CuriProvider extends React.Component<
       ({ response, navigation }: Emitted) => {
         this.setState({ response, navigation });
       },
-      { initial: false }
+      { observe: true, initial: false }
     );
   }
 

--- a/packages/react/tests/Active.spec.tsx
+++ b/packages/react/tests/Active.spec.tsx
@@ -125,19 +125,16 @@ describe("<Active>", () => {
       const router = curi(history, routes, {
         addons: [createActiveAddon()]
       });
-      router.respond(
-        () => {
-          const wrapper = render(router, () => (
-            <Active name="Contact" partial={true} merge={merge}>
-              <div className="test" />
-            </Active>
-          ));
-          const div = wrapper.find("div");
-          expect(div.prop("className")).toBe("not-a-test");
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const wrapper = render(router, () => (
+          <Active name="Contact" partial={true} merge={merge}>
+            <div className="test" />
+          </Active>
+        ));
+        const div = wrapper.find("div");
+        expect(div.prop("className")).toBe("not-a-test");
+        done();
+      });
     });
   });
 

--- a/packages/react/tests/Block.spec.tsx
+++ b/packages/react/tests/Block.spec.tsx
@@ -35,154 +35,130 @@ describe("Block", () => {
 
   it("if active=true when mounting, adds block", done => {
     const confirm = jest.fn();
-    router.respond(
-      () => {
-        const wrapper = render(router, () => (
-          <Block active={true} confirm={confirm} />
-        ));
-        expect(confirmWith.mock.calls.length).toBe(1);
-        expect(confirmWith.mock.calls[0][0]).toBe(confirm);
-        done();
-      },
-      { once: true }
-    );
+    router.respond(() => {
+      const wrapper = render(router, () => (
+        <Block active={true} confirm={confirm} />
+      ));
+      expect(confirmWith.mock.calls.length).toBe(1);
+      expect(confirmWith.mock.calls[0][0]).toBe(confirm);
+      done();
+    });
   });
 
   it("defaults to active=true", done => {
     const confirm = jest.fn();
-    router.respond(
-      () => {
-        const wrapper = render(router, () => <Block confirm={confirm} />);
-        expect(confirmWith.mock.calls.length).toBe(1);
-        expect(confirmWith.mock.calls[0][0]).toBe(confirm);
-        done();
-      },
-      { once: true }
-    );
+    router.respond(() => {
+      const wrapper = render(router, () => <Block confirm={confirm} />);
+      expect(confirmWith.mock.calls.length).toBe(1);
+      expect(confirmWith.mock.calls[0][0]).toBe(confirm);
+      done();
+    });
   });
 
   it("if active=false when mounting, does not add block", done => {
     const confirm = jest.fn();
-    router.respond(
-      () => {
-        const wrapper = render(router, () => (
-          <Block active={false} confirm={confirm} />
-        ));
-        expect(confirmWith.mock.calls.length).toBe(0);
-        done();
-      },
-      { once: true }
-    );
+    router.respond(() => {
+      const wrapper = render(router, () => (
+        <Block active={false} confirm={confirm} />
+      ));
+      expect(confirmWith.mock.calls.length).toBe(0);
+      done();
+    });
   });
 
   it("removes block if active goes true->false while updating", done => {
     const confirm = jest.fn();
-    router.respond(
-      () => {
-        const tree = renderer.create(
-          <CuriProvider router={router}>
-            {() => <Block active={true} confirm={confirm} />}
-          </CuriProvider>
-        );
-        expect(removeConfirmation.mock.calls.length).toBe(0);
-        tree.update(
-          <CuriProvider router={router}>
-            {() => <Block active={false} confirm={confirm} />}
-          </CuriProvider>
-        );
-        expect(removeConfirmation.mock.calls.length).toBe(1);
-        done();
-      },
-      { once: true }
-    );
+    router.respond(() => {
+      const tree = renderer.create(
+        <CuriProvider router={router}>
+          {() => <Block active={true} confirm={confirm} />}
+        </CuriProvider>
+      );
+      expect(removeConfirmation.mock.calls.length).toBe(0);
+      tree.update(
+        <CuriProvider router={router}>
+          {() => <Block active={false} confirm={confirm} />}
+        </CuriProvider>
+      );
+      expect(removeConfirmation.mock.calls.length).toBe(1);
+      done();
+    });
   });
 
   it("adds block if active goes false->true while updating", done => {
     const confirm = jest.fn();
-    router.respond(
-      () => {
-        const tree = renderer.create(
-          <CuriProvider router={router}>
-            {() => <Block active={false} confirm={confirm} />}
-          </CuriProvider>
-        );
-        expect(confirmWith.mock.calls.length).toBe(0);
-        tree.update(
-          <CuriProvider router={router}>
-            {() => <Block active={true} confirm={confirm} />}
-          </CuriProvider>
-        );
-        expect(confirmWith.mock.calls.length).toBe(1);
-        done();
-      },
-      { once: true }
-    );
+    router.respond(() => {
+      const tree = renderer.create(
+        <CuriProvider router={router}>
+          {() => <Block active={false} confirm={confirm} />}
+        </CuriProvider>
+      );
+      expect(confirmWith.mock.calls.length).toBe(0);
+      tree.update(
+        <CuriProvider router={router}>
+          {() => <Block active={true} confirm={confirm} />}
+        </CuriProvider>
+      );
+      expect(confirmWith.mock.calls.length).toBe(1);
+      done();
+    });
   });
 
   it("resets block on updates if confirm function changes", done => {
     const confirm = jest.fn();
     const confirm2 = jest.fn();
-    router.respond(
-      () => {
-        const tree = renderer.create(
-          <CuriProvider router={router}>
-            {() => <Block active={true} confirm={confirm} />}
-          </CuriProvider>
-        );
-        expect(confirmWith.mock.calls.length).toBe(1);
-        expect(removeConfirmation.mock.calls.length).toBe(0);
-        tree.update(
-          <CuriProvider router={router}>
-            {() => <Block active={true} confirm={confirm2} />}
-          </CuriProvider>
-        );
-        expect(confirmWith.mock.calls.length).toBe(2);
-        expect(removeConfirmation.mock.calls.length).toBe(1);
+    router.respond(() => {
+      const tree = renderer.create(
+        <CuriProvider router={router}>
+          {() => <Block active={true} confirm={confirm} />}
+        </CuriProvider>
+      );
+      expect(confirmWith.mock.calls.length).toBe(1);
+      expect(removeConfirmation.mock.calls.length).toBe(0);
+      tree.update(
+        <CuriProvider router={router}>
+          {() => <Block active={true} confirm={confirm2} />}
+        </CuriProvider>
+      );
+      expect(confirmWith.mock.calls.length).toBe(2);
+      expect(removeConfirmation.mock.calls.length).toBe(1);
 
-        done();
-      },
-      { once: true }
-    );
+      done();
+    });
   });
 
   it("does not reset block if both active and confirm stay the same", done => {
     const confirm = jest.fn();
-    router.respond(
-      () => {
-        const tree = renderer.create(
-          <CuriProvider router={router}>
-            {() => <Block active={true} confirm={confirm} />}
-          </CuriProvider>
-        );
+    router.respond(() => {
+      const tree = renderer.create(
+        <CuriProvider router={router}>
+          {() => <Block active={true} confirm={confirm} />}
+        </CuriProvider>
+      );
 
-        expect(confirmWith.mock.calls.length).toBe(1);
-        expect(removeConfirmation.mock.calls.length).toBe(0);
-        tree.update(
-          <CuriProvider router={router}>
-            {() => <Block active={true} confirm={confirm} />}
-          </CuriProvider>
-        );
-        expect(confirmWith.mock.calls.length).toBe(1);
-        expect(removeConfirmation.mock.calls.length).toBe(0);
-        done();
-      },
-      { once: true }
-    );
+      expect(confirmWith.mock.calls.length).toBe(1);
+      expect(removeConfirmation.mock.calls.length).toBe(0);
+      tree.update(
+        <CuriProvider router={router}>
+          {() => <Block active={true} confirm={confirm} />}
+        </CuriProvider>
+      );
+      expect(confirmWith.mock.calls.length).toBe(1);
+      expect(removeConfirmation.mock.calls.length).toBe(0);
+      done();
+    });
   });
 
   it("unblocks when unmounting", done => {
     const confirm = jest.fn();
-    router.respond(
-      () => {
-        const wrapper = render(router, () => (
-          <Block active={true} confirm={confirm} />
-        ));
-        expect(removeConfirmation.mock.calls.length).toBe(0);
-        wrapper.unmount();
-        expect(removeConfirmation.mock.calls.length).toBe(1);
-        done();
-      },
-      { once: true }
-    );
+    router.respond(() => {
+      const wrapper = render(router, () => (
+        <Block active={true} confirm={confirm} />
+      ));
+      expect(removeConfirmation.mock.calls.length).toBe(0);
+      wrapper.unmount();
+      expect(removeConfirmation.mock.calls.length).toBe(1);
+      done();
+    });
   });
 });

--- a/packages/react/tests/CuriProvider.spec.tsx
+++ b/packages/react/tests/CuriProvider.spec.tsx
@@ -41,16 +41,13 @@ describe("<CuriProvider>", () => {
         return null;
       });
 
-      router.respond(
-        () => {
-          const wrapper = mount(
-            <CuriProvider router={router}>{fn}</CuriProvider>
-          );
-          history.push("/about");
-          pushedHistory = true;
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const wrapper = mount(
+          <CuriProvider router={router}>{fn}</CuriProvider>
+        );
+        history.push("/about");
+        pushedHistory = true;
+      });
     });
 
     it("passes { response, navigation, router } to render prop", done => {
@@ -68,14 +65,11 @@ describe("<CuriProvider>", () => {
       });
 
       const router = curi(history, routes);
-      router.respond(
-        () => {
-          const wrapper = mount(
-            <CuriProvider router={router}>{fn}</CuriProvider>
-          );
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const wrapper = mount(
+          <CuriProvider router={router}>{fn}</CuriProvider>
+        );
+      });
     });
   });
 
@@ -98,18 +92,13 @@ describe("<CuriProvider>", () => {
         </Curious>
       );
 
-      router.respond(
-        ({ response, navigation }) => {
-          emittedResponse = response;
-          emittedNavigation = navigation;
-          const wrapper = mount(
-            <CuriProvider router={router}>
-              {() => <ContextLogger />}
-            </CuriProvider>
-          );
-        },
-        { once: true }
-      );
+      router.respond(({ response, navigation }) => {
+        emittedResponse = response;
+        emittedNavigation = navigation;
+        const wrapper = mount(
+          <CuriProvider router={router}>{() => <ContextLogger />}</CuriProvider>
+        );
+      });
     });
   });
 });

--- a/packages/react/tests/Curious.spec.tsx
+++ b/packages/react/tests/Curious.spec.tsx
@@ -23,21 +23,18 @@ describe("<Curious>", () => {
   });
 
   it("passes router, response, and navigation to children function", done => {
-    router.respond(
-      ({ response, navigation }) => {
-        const wrapper = render(router, () => (
-          <Curious>
-            {value => {
-              expect(value.router).toBe(router);
-              expect(value.response).toBe(response);
-              expect(value.navigation).toBe(navigation);
-              done();
-              return null;
-            }}
-          </Curious>
-        ));
-      },
-      { once: true }
-    );
+    router.respond(({ response, navigation }) => {
+      const wrapper = render(router, () => (
+        <Curious>
+          {value => {
+            expect(value.router).toBe(router);
+            expect(value.response).toBe(response);
+            expect(value.navigation).toBe(navigation);
+            done();
+            return null;
+          }}
+        </Curious>
+      ));
+    });
   });
 });

--- a/packages/react/tests/Link.spec.tsx
+++ b/packages/react/tests/Link.spec.tsx
@@ -55,15 +55,12 @@ describe("<Link>", () => {
         locations: ["/the-initial-location"]
       });
       const router = curi(history, []);
-      router.respond(
-        () => {
-          const wrapper = render(router, () => <Link to={null}>Test</Link>);
-          const a = wrapper.find("a");
-          expect(a.prop("href")).toBe("/the-initial-location");
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const wrapper = render(router, () => <Link to={null}>Test</Link>);
+        const a = wrapper.find("a");
+        expect(a.prop("href")).toBe("/the-initial-location");
+        done();
+      });
     });
   });
 
@@ -88,35 +85,32 @@ describe("<Link>", () => {
     });
 
     it("updates href when props change", done => {
-      router.respond(
-        () => {
-          const params = { name: "Glacier" };
-          const tree = renderer.create(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Park" params={params}>
-                  Test
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          let a = tree.root.findByType("a");
-          expect(a.props.href).toBe("/park/Glacier");
-          const newParams = { name: "Yellowstone" };
-          tree.update(
-            <CuriProvider router={router}>
-              {() => (
-                <Link to="Park" params={newParams}>
-                  Test
-                </Link>
-              )}
-            </CuriProvider>
-          );
-          expect(a.props.href).toBe("/park/Yellowstone");
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const params = { name: "Glacier" };
+        const tree = renderer.create(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Park" params={params}>
+                Test
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        let a = tree.root.findByType("a");
+        expect(a.props.href).toBe("/park/Glacier");
+        const newParams = { name: "Yellowstone" };
+        tree.update(
+          <CuriProvider router={router}>
+            {() => (
+              <Link to="Park" params={newParams}>
+                Test
+              </Link>
+            )}
+          </CuriProvider>
+        );
+        expect(a.props.href).toBe("/park/Yellowstone");
+        done();
+      });
     });
   });
 
@@ -124,37 +118,31 @@ describe("<Link>", () => {
     it("merges the details prop with the generated pathname when navigating", done => {
       const history = InMemory();
       const router = curi(history, [{ name: "Test", path: "test" }]);
-      router.respond(
-        () => {
-          const wrapper = render(router, () => (
-            <Link to="Test" details={{ query: "one=two", hash: "#hashtag" }}>
-              Test
-            </Link>
-          ));
-          const a = wrapper.find("a");
-          expect(a.prop("href")).toBe("/test?one=two#hashtag");
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const wrapper = render(router, () => (
+          <Link to="Test" details={{ query: "one=two", hash: "#hashtag" }}>
+            Test
+          </Link>
+        ));
+        const a = wrapper.find("a");
+        expect(a.prop("href")).toBe("/test?one=two#hashtag");
+        done();
+      });
     });
 
     it("providing a pathname in details does not overwrite the generated pathname", done => {
       const history = InMemory();
       const router = curi(history, [{ name: "Test", path: "test" }]);
-      router.respond(
-        () => {
-          const wrapper = render(router, () => (
-            <Link to="Test" details={{ pathname: "/not-a-test" }}>
-              Test
-            </Link>
-          ));
-          const a = wrapper.find("a");
-          expect(a.prop("href")).toBe("/test");
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const wrapper = render(router, () => (
+          <Link to="Test" details={{ pathname: "/not-a-test" }}>
+            Test
+          </Link>
+        ));
+        const a = wrapper.find("a");
+        expect(a.prop("href")).toBe("/test");
+        done();
+      });
     });
   });
 
@@ -179,53 +167,47 @@ describe("<Link>", () => {
       it("throws on mount", done => {
         const history = InMemory();
         const router = curi(history, [{ name: "Test", path: "test" }]);
-        router.respond(
-          () => {
-            expect(() => {
-              const wrapper = render(router, () => (
-                <Link to="Test" active={{ merge }}>
-                  Test
-                </Link>
-              ));
-            }).toThrow(
-              'You are attempting to use the "active" prop, but have not included the "active" ' +
-                "addon (@curi/addon-active) in your Curi router."
-            );
-            done();
-          },
-          { once: true }
-        );
+        router.respond(() => {
+          expect(() => {
+            const wrapper = render(router, () => (
+              <Link to="Test" active={{ merge }}>
+                Test
+              </Link>
+            ));
+          }).toThrow(
+            'You are attempting to use the "active" prop, but have not included the "active" ' +
+              "addon (@curi/addon-active) in your Curi router."
+          );
+          done();
+        });
       });
 
       it("throws if adding active prop on re-render", done => {
         const history = InMemory();
         const router = curi(history, [{ name: "Test", path: "test" }]);
 
-        router.respond(
-          () => {
-            const tree = renderer.create(
+        router.respond(() => {
+          const tree = renderer.create(
+            <CuriProvider router={router}>
+              {() => <Link to="Test">Test</Link>}
+            </CuriProvider>
+          );
+          expect(() => {
+            tree.update(
               <CuriProvider router={router}>
-                {() => <Link to="Test">Test</Link>}
+                {() => (
+                  <Link to="Test" active={{ merge }}>
+                    Test
+                  </Link>
+                )}
               </CuriProvider>
             );
-            expect(() => {
-              tree.update(
-                <CuriProvider router={router}>
-                  {() => (
-                    <Link to="Test" active={{ merge }}>
-                      Test
-                    </Link>
-                  )}
-                </CuriProvider>
-              );
-            }).toThrow(
-              'You are attempting to use the "active" prop, but have not included the "active" ' +
-                "addon (@curi/addon-active) in your Curi router."
-            );
-            done();
-          },
-          { once: true }
-        );
+          }).toThrow(
+            'You are attempting to use the "active" prop, but have not included the "active" ' +
+              "addon (@curi/addon-active) in your Curi router."
+          );
+          done();
+        });
       });
     });
 
@@ -236,19 +218,16 @@ describe("<Link>", () => {
           addons: [createActiveAddon()]
         });
 
-        router.respond(
-          () => {
-            const wrapper = render(router, () => (
-              <Link to="Test" className="test" active={{ merge }}>
-                Test
-              </Link>
-            ));
-            const link = wrapper.find("a");
-            expect(link.prop("className")).toBe("test");
-            done();
-          },
-          { once: true }
-        );
+        router.respond(() => {
+          const wrapper = render(router, () => (
+            <Link to="Test" className="test" active={{ merge }}>
+              Test
+            </Link>
+          ));
+          const link = wrapper.find("a");
+          expect(link.prop("className")).toBe("test");
+          done();
+        });
       });
 
       it("calls merge function when <Link>'s props match the current response's", done => {
@@ -257,19 +236,16 @@ describe("<Link>", () => {
           addons: [createActiveAddon()]
         });
 
-        router.respond(
-          () => {
-            const wrapper = render(router, () => (
-              <Link to="Test" className="test" active={{ merge }}>
-                Test
-              </Link>
-            ));
-            const link = wrapper.find("a");
-            expect(link.prop("className")).toBe("test active");
-            done();
-          },
-          { once: true }
-        );
+        router.respond(() => {
+          const wrapper = render(router, () => (
+            <Link to="Test" className="test" active={{ merge }}>
+              Test
+            </Link>
+          ));
+          const link = wrapper.find("a");
+          expect(link.prop("className")).toBe("test active");
+          done();
+        });
       });
     });
 
@@ -289,23 +265,16 @@ describe("<Link>", () => {
             addons: [createActiveAddon()]
           }
         );
-        router.respond(
-          () => {
-            const wrapper = render(router, () => (
-              <Link
-                to="Test"
-                className="test"
-                active={{ partial: true, merge }}
-              >
-                Test
-              </Link>
-            ));
-            const link = wrapper.find("a");
-            expect(link.prop("className")).toBe("test active");
-            done();
-          },
-          { once: true }
-        );
+        router.respond(() => {
+          const wrapper = render(router, () => (
+            <Link to="Test" className="test" active={{ partial: true, merge }}>
+              Test
+            </Link>
+          ));
+          const link = wrapper.find("a");
+          expect(link.prop("className")).toBe("test active");
+          done();
+        });
       });
     });
 
@@ -320,23 +289,20 @@ describe("<Link>", () => {
           return location.query === details["query"];
         }
 
-        router.respond(
-          () => {
-            const wrapper = render(router, () => (
-              <Link
-                to="Test"
-                details={{ query: "test=ing" }}
-                active={{ merge, extra }}
-              >
-                Test
-              </Link>
-            ));
-            const link = wrapper.find("a");
-            expect(link.prop("className")).toBe("active");
-            done();
-          },
-          { once: true }
-        );
+        router.respond(() => {
+          const wrapper = render(router, () => (
+            <Link
+              to="Test"
+              details={{ query: "test=ing" }}
+              active={{ merge, extra }}
+            >
+              Test
+            </Link>
+          ));
+          const link = wrapper.find("a");
+          expect(link.prop("className")).toBe("active");
+          done();
+        });
       });
 
       it("active is false when pathname matches, but extra returns false", done => {
@@ -349,19 +315,16 @@ describe("<Link>", () => {
           return location.query === details["query"];
         }
 
-        router.respond(
-          () => {
-            const wrapper = render(router, () => (
-              <Link to="Test" active={{ merge, extra }}>
-                Test
-              </Link>
-            ));
-            const link = wrapper.find("a");
-            expect(link.prop("className")).toBeUndefined();
-            done();
-          },
-          { once: true }
-        );
+        router.respond(() => {
+          const wrapper = render(router, () => (
+            <Link to="Test" active={{ merge, extra }}>
+              Test
+            </Link>
+          ));
+          const link = wrapper.find("a");
+          expect(link.prop("className")).toBeUndefined();
+          done();
+        });
       });
     });
   });
@@ -373,26 +336,23 @@ describe("<Link>", () => {
       history.navigate = mockNavigate;
 
       const router = curi(history, [{ name: "Test", path: "" }]);
-      router.respond(
-        () => {
-          const wrapper = render(router, () => <Link to="Test">Test</Link>);
-          const leftClickEvent = {
-            defaultPrevented: false,
-            preventDefault() {
-              this.defaultPrevented = true;
-            },
-            metaKey: null,
-            altKey: null,
-            ctrlKey: null,
-            shiftKey: null,
-            button: 0
-          };
-          wrapper.find("a").simulate("click", leftClickEvent);
-          expect(mockNavigate.mock.calls.length).toBe(1);
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const wrapper = render(router, () => <Link to="Test">Test</Link>);
+        const leftClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        wrapper.find("a").simulate("click", leftClickEvent);
+        expect(mockNavigate.mock.calls.length).toBe(1);
+        done();
+      });
     });
 
     it("includes details in location passed to history.navigate", done => {
@@ -401,10 +361,44 @@ describe("<Link>", () => {
       history.navigate = mockNavigate;
 
       const router = curi(history, [{ name: "Test", path: "" }]);
-      router.respond(
-        () => {
+      router.respond(() => {
+        const wrapper = render(router, () => (
+          <Link to="Test" details={{ hash: "thing" }}>
+            Test
+          </Link>
+        ));
+        const leftClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        wrapper.find("a").simulate("click", leftClickEvent);
+        const mockLocation = mockNavigate.mock.calls[0][0];
+        expect(mockLocation).toMatchObject({
+          pathname: "/",
+          hash: "thing"
+        });
+        done();
+      });
+    });
+
+    describe("onClick", () => {
+      it("calls onClick prop func if provided", done => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
+        history.navigate = mockNavigate;
+        const onClick = jest.fn();
+        const router = curi(history, [{ name: "Test", path: "" }]);
+
+        router.respond(() => {
           const wrapper = render(router, () => (
-            <Link to="Test" details={{ hash: "thing" }}>
+            <Link to="Test" onClick={onClick}>
               Test
             </Link>
           ));
@@ -420,50 +414,10 @@ describe("<Link>", () => {
             button: 0
           };
           wrapper.find("a").simulate("click", leftClickEvent);
-          const mockLocation = mockNavigate.mock.calls[0][0];
-          expect(mockLocation).toMatchObject({
-            pathname: "/",
-            hash: "thing"
-          });
+          expect(onClick.mock.calls.length).toBe(1);
+          expect(mockNavigate.mock.calls.length).toBe(1);
           done();
-        },
-        { once: true }
-      );
-    });
-
-    describe("onClick", () => {
-      it("calls onClick prop func if provided", done => {
-        const history = InMemory();
-        const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
-        const onClick = jest.fn();
-        const router = curi(history, [{ name: "Test", path: "" }]);
-
-        router.respond(
-          () => {
-            const wrapper = render(router, () => (
-              <Link to="Test" onClick={onClick}>
-                Test
-              </Link>
-            ));
-            const leftClickEvent = {
-              defaultPrevented: false,
-              preventDefault() {
-                this.defaultPrevented = true;
-              },
-              metaKey: null,
-              altKey: null,
-              ctrlKey: null,
-              shiftKey: null,
-              button: 0
-            };
-            wrapper.find("a").simulate("click", leftClickEvent);
-            expect(onClick.mock.calls.length).toBe(1);
-            expect(mockNavigate.mock.calls.length).toBe(1);
-            done();
-          },
-          { once: true }
-        );
+        });
       });
 
       it("does not call history.navigate if onClick prevents default", done => {
@@ -474,44 +428,13 @@ describe("<Link>", () => {
           event.preventDefault();
         });
         const router = curi(history, [{ name: "Test", path: "" }]);
-        router.respond(
-          () => {
-            const wrapper = render(router, () => (
-              <Link to="Test" onClick={onClick}>
-                Test
-              </Link>
-            ));
-            const leftClickEvent = {
-              defaultPrevented: false,
-              preventDefault() {
-                this.defaultPrevented = true;
-              },
-              metaKey: null,
-              altKey: null,
-              ctrlKey: null,
-              shiftKey: null,
-              button: 0
-            };
-            wrapper.find("a").simulate("click", leftClickEvent);
-            expect(onClick.mock.calls.length).toBe(1);
-            expect(mockNavigate.mock.calls.length).toBe(0);
-            done();
-          },
-          { once: true }
-        );
-      });
-    });
-
-    it("doesn't call history.navigate for modified clicks", done => {
-      const history = InMemory();
-      const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
-
-      const router = curi(history, [{ name: "Test", path: "" }]);
-      router.respond(
-        () => {
-          const wrapper = render(router, () => <Link to="Test">Test</Link>);
-          const modifiedClickEvent = {
+        router.respond(() => {
+          const wrapper = render(router, () => (
+            <Link to="Test" onClick={onClick}>
+              Test
+            </Link>
+          ));
+          const leftClickEvent = {
             defaultPrevented: false,
             preventDefault() {
               this.defaultPrevented = true;
@@ -522,17 +445,42 @@ describe("<Link>", () => {
             shiftKey: null,
             button: 0
           };
-          const modifiers = ["metaKey", "altKey", "ctrlKey", "shiftKey"];
-          modifiers.forEach(m => {
-            const eventCopy = Object.assign({}, modifiedClickEvent);
-            eventCopy[m] = true;
-            wrapper.find("a").simulate("click", eventCopy);
-            expect(mockNavigate.mock.calls.length).toBe(0);
-          });
+          wrapper.find("a").simulate("click", leftClickEvent);
+          expect(onClick.mock.calls.length).toBe(1);
+          expect(mockNavigate.mock.calls.length).toBe(0);
           done();
-        },
-        { once: true }
-      );
+        });
+      });
+    });
+
+    it("doesn't call history.navigate for modified clicks", done => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+
+      const router = curi(history, [{ name: "Test", path: "" }]);
+      router.respond(() => {
+        const wrapper = render(router, () => <Link to="Test">Test</Link>);
+        const modifiedClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        const modifiers = ["metaKey", "altKey", "ctrlKey", "shiftKey"];
+        modifiers.forEach(m => {
+          const eventCopy = Object.assign({}, modifiedClickEvent);
+          eventCopy[m] = true;
+          wrapper.find("a").simulate("click", eventCopy);
+          expect(mockNavigate.mock.calls.length).toBe(0);
+        });
+        done();
+      });
     });
 
     it("doesn't call history.navigate if event.preventDefault has been called", done => {
@@ -542,26 +490,23 @@ describe("<Link>", () => {
 
       const router = curi(history, [{ name: "Test", path: "" }]);
 
-      router.respond(
-        () => {
-          const wrapper = render(router, () => <Link to="Test">Test</Link>);
-          const preventedEvent = {
-            defaultPrevented: true,
-            preventDefault() {
-              this.defaultPrevented = true;
-            },
-            metaKey: null,
-            altKey: null,
-            ctrlKey: null,
-            shiftKey: null,
-            button: 0
-          };
-          wrapper.find("a").simulate("click", preventedEvent);
-          expect(mockNavigate.mock.calls.length).toBe(0);
-          done();
-        },
-        { once: true }
-      );
+      router.respond(() => {
+        const wrapper = render(router, () => <Link to="Test">Test</Link>);
+        const preventedEvent = {
+          defaultPrevented: true,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        wrapper.find("a").simulate("click", preventedEvent);
+        expect(mockNavigate.mock.calls.length).toBe(0);
+        done();
+      });
     });
   });
 });

--- a/packages/react/types/Curious.d.ts
+++ b/packages/react/types/Curious.d.ts
@@ -2,6 +2,6 @@
 /// <reference types="../typings/react-broadcast" />
 import React from "react";
 import { Emitted } from "@curi/core";
-import { ConsumerProps } from 'react-broadcast';
+import { ConsumerProps } from "react-broadcast";
 declare const Curious: React.ComponentClass<ConsumerProps<Emitted>>;
 export default Curious;

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -50,11 +50,14 @@ export const syncResponses = (store: Store<any>, router: CuriRouter): void => {
     router
   });
 
-  router.respond(({ response, navigation }: Emitted) => {
-    store.dispatch({
-      type: LOCATION_CHANGE,
-      response,
-      navigation
-    });
-  });
+  router.respond(
+    ({ response, navigation }: Emitted) => {
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        response,
+        navigation
+      });
+    },
+    { observe: true }
+  );
 };

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -21,10 +21,13 @@ const CuriPlugin: PluginObject<CuriPluginOptions> = {
       data: { response: null, navigation: null }
     });
 
-    options.router.respond(({ response, navigation }) => {
-      reactive.response = response;
-      reactive.navigation = navigation;
-    });
+    options.router.respond(
+      ({ response, navigation }) => {
+        reactive.response = response;
+        reactive.navigation = navigation;
+      },
+      { observe: true }
+    );
 
     _Vue.mixin({
       beforeCreate: function() {

--- a/packages/vue/tests/plugin.spec.ts
+++ b/packages/vue/tests/plugin.spec.ts
@@ -35,21 +35,18 @@ describe("CuriPlugin", () => {
           return h("div");
         }
       };
-      router.respond(
-        ({ response, navigation }) => {
-          Vue.use(CuriPlugin, { router });
+      router.respond(({ response, navigation }) => {
+        Vue.use(CuriPlugin, { router });
 
-          const wrapper = shallow(FakeComponent, {
-            localVue: Vue
-          });
+        const wrapper = shallow(FakeComponent, {
+          localVue: Vue
+        });
 
-          expect(wrapper.vm.$curi.response).toBe(response);
-          expect(wrapper.vm.$curi.navigation).toBe(navigation);
+        expect(wrapper.vm.$curi.response).toBe(response);
+        expect(wrapper.vm.$curi.navigation).toBe(navigation);
 
-          done();
-        },
-        { once: true }
-      );
+        done();
+      });
     });
 
     describe("reactive properties", () => {
@@ -101,25 +98,28 @@ describe("CuriPlugin", () => {
         let wrapper;
         Vue.use(CuriPlugin, { router });
 
-        router.respond(() => {
-          if (!wrapper) {
-            wrapper = mount(
-              {
-                template: "<div><FakeComponent /></div>",
-                components: { FakeComponent }
-              },
-              {
-                localVue: Vue
-              }
-            );
-            router.history.push("/another-one");
-          }
-        });
+        router.respond(
+          () => {
+            if (!wrapper) {
+              wrapper = mount(
+                {
+                  template: "<div><FakeComponent /></div>",
+                  components: { FakeComponent }
+                },
+                {
+                  localVue: Vue
+                }
+              );
+              router.history.push("/another-one");
+            }
+          },
+          { observe: true }
+        );
       });
     });
   });
 
-  describe("<curi-link>", () => {
+  describe("registering components components", () => {
     it("Registers the Link component as <curi-link>", () => {
       const Vue = createLocalVue();
       Vue.use(CuriPlugin, {
@@ -128,9 +128,7 @@ describe("CuriPlugin", () => {
       });
       expect(Vue.options.components["curi-link"]).toBeDefined();
     });
-  });
 
-  describe("<curi-block>", () => {
     it("Registers the Block component as <curi-block>", () => {
       const Vue = createLocalVue();
       Vue.use(CuriPlugin, {


### PR DESCRIPTION
Instead of specifying that a response handler should once, that is now the default behavior and the `observe` property can be provided to specify that the handler should be called for every response.
```js
// old
router.respond(everyResponse);
router.respond(oneResponse, { once: true });

// new
router.respond(everyResponse, { observe: true });
router.respond(oneResponse);
```
The reason for this change is that the user should only have to use `router.respond` to wait for the initial response to be emitted. For other responses, a Curi package should be handling this. For example, in `@curi/react`, the `<CuriProvider>` will observe the router. In `@curi/vue`, the `CuriPlugin` sets up a response handler. It makes more sense to have this behind-the-scenes code have to specify that it wants to observe than to ask the user to do so.