### PR TITLE
Pass router to match.response

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Pass `router` to `match.response` instead of `addons`. Addons are still available through the `router`.
 * Add a `location` method to the `router` object, which will create a location object that can be used in navigation.
 
 ## 1.0.0-beta.26

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -158,7 +158,7 @@ function createRouter(
         return;
       }
       pendingNav.finish();
-      const response = finishResponse(pendingResponse, registeredAddons);
+      const response = finishResponse(pendingResponse, router);
       cacheAndEmit(response, navigation);
     });
   }

--- a/packages/core/src/finishResponse.ts
+++ b/packages/core/src/finishResponse.ts
@@ -1,9 +1,9 @@
-import routeProperties from './utils/routeProperties';
+import routeProperties from "./utils/routeProperties";
 
-import { ToArgument } from '@hickory/root';
-import { InternalRoute } from './types/route';
-import { Addons } from './types/addon';
-import { Response, PendingResponse, ResponseProps } from './types/response';
+import { ToArgument } from "@hickory/root";
+import { InternalRoute } from "./types/route";
+import { CuriRouter } from "./types/curi";
+import { Response, PendingResponse, ResponseProps } from "./types/response";
 
 function responseSetters(props: ResponseProps) {
   return {
@@ -48,7 +48,7 @@ function freezeResponse(route: InternalRoute, props: ResponseProps): Response {
 
 export default function finishResponse(
   pending: PendingResponse,
-  addons: Addons
+  router: CuriRouter
 ): Response {
   const { error, resolved, route, props } = pending;
   if (route && route.public.match.response) {
@@ -57,7 +57,7 @@ export default function finishResponse(
       resolved,
       route: routeProperties(route, props),
       set: responseSetters(props),
-      addons
+      router
     });
   }
   return freezeResponse(route, props);

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -1,7 +1,7 @@
-import { RegExpOptions, Key } from 'path-to-regexp';
+import { RegExpOptions, Key } from "path-to-regexp";
 
-import { Params } from './response';
-import { Addons } from './addon';
+import { CuriRouter } from "./curi";
+import { Params } from "./response";
 
 export type ParamParser = (input: string) => any;
 export interface ParamParsers {
@@ -28,7 +28,7 @@ export interface ResponseBuilder {
   resolved: any;
   route: RouteProps;
   set: ResponseSetters;
-  addons: Addons;
+  router: CuriRouter;
 }
 
 export type EveryMatchFn = (route?: RouteProps) => Promise<any>;

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -985,10 +985,10 @@ describe("route matching/response generation", () => {
         });
       });
 
-      describe("addons", () => {
-        it("receives the registered addons object", done => {
-          const spy = jest.fn(({ addons }) => {
-            expect(typeof addons.pathname).toBe("function");
+      describe("router", () => {
+        it("receives the router object", done => {
+          const spy = jest.fn(({ router: routerProp }) => {
+            expect(routerProp).toBe(router);
             done();
           });
 
@@ -1000,35 +1000,6 @@ describe("route matching/response generation", () => {
 
           const history = InMemory({ locations: ["/hello?one=two"] });
           const router = curi(history, [CatchAll]);
-        });
-
-        it("can use registered addons", done => {
-          const routes = [
-            {
-              name: "Old",
-              path: "old/:id",
-              match: {
-                response: ({ route, set, addons }) => {
-                  const pathname = addons.pathname("New", route.params);
-                  set.redirect(pathname);
-                }
-              }
-            },
-            {
-              name: "New",
-              path: "new/:id"
-            }
-          ];
-          const history = InMemory({ locations: ["/old/1"] });
-          const router = curi(history, routes);
-          let firstCall = true;
-          router.respond(({ response }) => {
-            if (firstCall) {
-              expect(response.redirectTo).toBe("/new/1");
-              firstCall = false;
-              done();
-            }
-          });
         });
       });
     });

--- a/packages/core/types/finishResponse.d.ts
+++ b/packages/core/types/finishResponse.d.ts
@@ -1,3 +1,3 @@
-import { Addons } from './types/addon';
+import { CuriRouter } from './types/curi';
 import { Response, PendingResponse } from './types/response';
-export default function finishResponse(pending: PendingResponse, addons: Addons): Response;
+export default function finishResponse(pending: PendingResponse, router: CuriRouter): Response;

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,6 +1,6 @@
 import { RegExpOptions, Key } from 'path-to-regexp';
+import { CuriRouter } from './curi';
 import { Params } from './response';
-import { Addons } from './addon';
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
     [key: string]: ParamParser;
@@ -23,7 +23,7 @@ export interface ResponseBuilder {
     resolved: any;
     route: RouteProps;
     set: ResponseSetters;
-    addons: Addons;
+    router: CuriRouter;
 }
 export declare type EveryMatchFn = (route?: RouteProps) => Promise<any>;
 export declare type InitialMatchFn = () => Promise<any>;


### PR DESCRIPTION
This replaces `addons` with `router`. The addons are still accessible through the `router` object.
```js
const routes = [
  {
    name: 'Old Album',
    path: 'album/:albumID',
    match: {
      response({ set, router, route }) {
        set.redirect(
          router.createLocation({
            name: 'Album'
            params: route.params
          })
        );
      }
    }
  },
  {
    name: 'Album',
    path: 'a/:albumID'
  }
]
```