### PR TITLE
Better set.redirect signature

### DIFF
--- a/documentation-website/src/client/Examples/react/Authentication.js
+++ b/documentation-website/src/client/Examples/react/Authentication.js
@@ -32,10 +32,15 @@ export default ({ name }) => (
     match: {
       response: ({ set }) => {
         if (!store.userIsAuthenticated) {
-          set.redirect('/login', 302);
+          set.redirect({ name: 'Login', status: 302 });
         }
       }
     }
+  },
+  {
+    name: 'Login',
+    path: 'login',
+    ...
   }
 ];`}
       </PrismBlock>

--- a/documentation-website/src/client/Examples/vue/Authentication.js
+++ b/documentation-website/src/client/Examples/vue/Authentication.js
@@ -32,10 +32,15 @@ export default ({ name }) => (
     match: {
       response: ({ set }) => {
         if (!store.userIsAuthenticated) {
-          set.redirect('/login', 302);
+          set.redirect({ name: 'Login', status: 302 });
         }
       }
     }
+  },
+  {
+    name: 'Login',
+    path: 'login',
+    ...
   }
 ];`}
       </PrismBlock>

--- a/documentation-website/src/client/Guides/AllAboutRoutes.js
+++ b/documentation-website/src/client/Guides/AllAboutRoutes.js
@@ -278,15 +278,15 @@ const user = {
                 set as the response's <IJS>data</IJS> property.
               </li>
               <li>
-                <IJS>redirect(to, code)</IJS> - This allows you to turn the
-                response into a redirect response. When you application receives
-                a redirect response, it should redirect to the new location
-                (using your history object) instead of re-rendering. If you do
-                not provide a code, then 301 will be used. Setting the status
-                code is mostly important for rendering on the server. The{" "}
-                <IJS>to</IJS> argument should be a string or a location object.
-                Once the response has been created, Curi will automatically
-                redirect to the <IJS>to</IJS> location.
+                <IJS>{`redirect({ name, status, ... })`}</IJS> - This allows you
+                to turn the response into a redirect response. When you
+                application receives a redirect response, it should redirect to
+                the new location (using your history object) instead of
+                re-rendering. If you do not provide a code, then 301 will be
+                used. Setting the status code is mostly important for rendering
+                on the server. The <IJS>to</IJS> argument should be a string or
+                a location object. Once the response has been created, Curi will
+                automatically redirect to the <IJS>to</IJS> location.
               </li>
               <li>
                 <IJS>error(error)</IJS> - A method to call when something goes
@@ -320,30 +320,8 @@ const routes = [
           <Subsection tag="h6" title="addons" id="response-addons">
             <p>
               The add-ons that have been registered with Curi are available to
-              the <IJS>response</IJS> function. This includes the built-in{" "}
-              <IJS>pathname</IJS> add-on, which you might find useful if you
-              need to redirect in a <IJS>response</IJS> function.
+              the <IJS>response</IJS> function.
             </p>
-            <PrismBlock lang="javascript">
-              {`// set a permanent redirect
-// navigating to /photo/123 will automatically redirect to /p/123
-const routes = [
-  {
-    name: 'Photo',
-    path: 'p/:id'
-  },
-  {
-    name: 'Old Photo',
-    path: 'photo/:id',
-    match: {
-      response: ({ route, set, addons }) => {
-        const pathname = addons.pathname('Photo', route.params);
-        set.redirect({ ...route.location, pathname }, 301);
-      }
-    }
-  }
-];`}
-            </PrismBlock>
           </Subsection>
         </Subsection>
       </Subsection>

--- a/documentation-website/src/client/Guides/Loading.js
+++ b/documentation-website/src/client/Guides/Loading.js
@@ -128,10 +128,8 @@ export default ({ name }) => (
       </p>
 
       <p>
-        By calling the <IJS>set.redirect</IJS> method, you can specify the URI
-        that we should redirect to. As always, with Curi you aren't expected to
-        have to manually generate pathnames. Instead, you can use{" "}
-        <IJS>addons.pathname</IJS>.
+        By calling the <IJS>set.redirect</IJS> method, you can specify the route
+        that we should redirect to.
       </p>
 
       <PrismBlock lang="javascript">
@@ -139,11 +137,14 @@ export default ({ name }) => (
   name: 'Old Recipe',
   path: 'r/:id',
   match: {
-    response: ({ route, set, addons }) => {
-      const pathname = addons.pathname('Recipe', route.params);
+    response: ({ route, set }) => {
       // destructure the current location to preserve
       // query/hash values
-      set.redirect({ ...route.location, pathname });
+      set.redirect({
+        name: 'Recipe',
+        params: route.params,
+        ...route.location
+      });
     }
   }
 }`}

--- a/packages/core/src/finishResponse.ts
+++ b/packages/core/src/finishResponse.ts
@@ -1,15 +1,21 @@
-import routeProperties from './utils/routeProperties';
+import routeProperties from "./utils/routeProperties";
 
-import { ToArgument } from '@hickory/root';
-import { InternalRoute } from './types/route';
-import { Addons } from './types/addon';
-import { Response, PendingResponse, ResponseProps } from './types/response';
+import { InternalRoute, RedirectProps } from "./types/route";
+import { Addons } from "./types/addon";
+import { Response, PendingResponse, ResponseProps } from "./types/response";
 
-function responseSetters(props: ResponseProps) {
+function responseSetters(props: ResponseProps, addons: Addons) {
   return {
-    redirect(to: ToArgument, code: number = 301): void {
-      props.status = code;
-      props.redirectTo = to;
+    redirect(redProps: RedirectProps): void {
+      const { name, params, query, hash, state, status = 301 } = redProps;
+      props.status = status;
+      const pathname = addons.pathname(name, params);
+      props.redirectTo = {
+        pathname,
+        query,
+        hash,
+        state
+      };
     },
 
     error(err: any): void {
@@ -56,7 +62,7 @@ export default function finishResponse(
       error,
       resolved,
       route: routeProperties(route, props),
-      set: responseSetters(props),
+      set: responseSetters(props, addons),
       addons
     });
   }

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -1,7 +1,8 @@
-import { RegExpOptions, Key } from 'path-to-regexp';
+import { RegExpOptions, Key } from "path-to-regexp";
 
-import { Params } from './response';
-import { Addons } from './addon';
+import { Params } from "./response";
+import { Addons } from "./addon";
+import { LocationDetails } from "@hickory/root";
 
 export type ParamParser = (input: string) => any;
 export interface ParamParsers {
@@ -14,9 +15,15 @@ export interface RouteProps {
   name: string;
 }
 
+export interface RedirectProps extends LocationDetails {
+  name: string;
+  params?: Params;
+  status?: number;
+}
+
 export interface ResponseSetters {
   error: (err: any) => void;
-  redirect: (to: any, status?: number) => void;
+  redirect: (props: RedirectProps) => void;
   data: (data: any) => void;
   status: (status: number) => void;
   body: (body: any) => void;

--- a/packages/core/tests/curi.spec.ts
+++ b/packages/core/tests/curi.spec.ts
@@ -341,7 +341,7 @@ describe("curi", () => {
               path: "",
               match: {
                 response: ({ set }) => {
-                  set.redirect("/other");
+                  set.redirect({ name: "Other" });
                 }
               }
             },
@@ -369,7 +369,7 @@ describe("curi", () => {
               path: "",
               match: {
                 response: ({ set }) => {
-                  set.redirect("/other");
+                  set.redirect({ name: "Other" });
                 }
               }
             },
@@ -838,9 +838,13 @@ describe("curi", () => {
           path: "",
           match: {
             response: ({ set }) => {
-              set.redirect("/somewhere-else", 301);
+              set.redirect({ name: "B Route", status: 301 });
             }
           }
+        },
+        {
+          name: "B Route",
+          path: "somewhere-else"
         }
       ];
 

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -280,16 +280,20 @@ describe("route matching/response generation", () => {
         it("is set by calling set.redirect in the matching match.response", done => {
           const routes = [
             {
+              name: "New",
+              path: "new"
+            },
+            {
               name: "302 Route",
-              path: "",
+              path: "old",
               match: {
                 response: ({ set }) => {
-                  set.redirect("/somewhere", 302);
+                  set.redirect({ name: "New", status: 302 });
                 }
               }
             }
           ];
-          const history = InMemory({ locations: ["/"] });
+          const history = InMemory({ locations: ["/old"] });
           const router = curi(history, routes);
           let firstCall = true;
           router.respond(({ response }) => {
@@ -304,16 +308,20 @@ describe("route matching/response generation", () => {
         it("is set to 301 by default when calling set.redirect in match.response", done => {
           const routes = [
             {
+              name: "New",
+              path: "new"
+            },
+            {
               name: "301 Route",
-              path: "",
+              path: "old",
               match: {
                 response: ({ set }) => {
-                  set.redirect("/somewhere");
+                  set.redirect({ name: "New" });
                 }
               }
             }
           ];
-          const history = InMemory({ locations: ["/"] });
+          const history = InMemory({ locations: ["/old"] });
           const router = curi(history, routes);
           let firstCall = true;
           router.respond(({ response }) => {
@@ -655,9 +663,16 @@ describe("route matching/response generation", () => {
               path: "",
               match: {
                 response: ({ set }) => {
-                  set.redirect("/somewhere", 301);
+                  set.redirect({
+                    name: "B Route",
+                    status: 301
+                  });
                 }
               }
+            },
+            {
+              name: "B Route",
+              path: "b"
             }
           ];
           const history = InMemory({ locations: ["/"] });
@@ -665,7 +680,7 @@ describe("route matching/response generation", () => {
           let firstCall = true;
           router.respond(({ response }) => {
             if (firstCall) {
-              expect(response.redirectTo).toBe("/somewhere");
+              expect(response.redirectTo).toMatchObject({ pathname: "/b" });
               firstCall = false;
               done();
             }
@@ -1009,8 +1024,7 @@ describe("route matching/response generation", () => {
               path: "old/:id",
               match: {
                 response: ({ route, set, addons }) => {
-                  const pathname = addons.pathname("New", route.params);
-                  set.redirect(pathname);
+                  set.redirect({ name: "New", params: route.params });
                 }
               }
             },
@@ -1024,7 +1038,7 @@ describe("route matching/response generation", () => {
           let firstCall = true;
           router.respond(({ response }) => {
             if (firstCall) {
-              expect(response.redirectTo).toBe("/new/1");
+              expect(response.redirectTo).toMatchObject({ pathname: "/new/1" });
               firstCall = false;
               done();
             }

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,6 +1,7 @@
 import { RegExpOptions, Key } from 'path-to-regexp';
 import { Params } from './response';
 import { Addons } from './addon';
+import { LocationDetails } from '@hickory/root';
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
     [key: string]: ParamParser;
@@ -10,9 +11,14 @@ export interface RouteProps {
     location: object;
     name: string;
 }
+export interface RedirectProps extends LocationDetails {
+    name: string;
+    params?: Params;
+    status?: number;
+}
 export interface ResponseSetters {
     error: (err: any) => void;
-    redirect: (to: any, status?: number) => void;
+    redirect: (props: RedirectProps) => void;
     data: (data: any) => void;
     status: (status: number) => void;
     body: (body: any) => void;


### PR DESCRIPTION
The previous setup expected the user to provide the `pathname` themselves (or use the `pathname` add-on to genreate it). While add-ons are there for users to use, the new method should be easier and less error prone (you can only redirect to valid routes).

```js
// old
response({ set, route, addons }) {
  const pathname = addons.pathname('Album', route.params);
  set.redirect(pathname);
}

// new
response({ set, route }) {
  set.redirect({ name: 'Album', params: route.params });
}
```