### PR TITLE
Revert router.createLocation (#37)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Next
 
-* Add a `location` method to the `router` object, which will create a location object that can be used in navigation.
-
 ## 1.0.0-beta.26
 
 * Replace `once` option with `observe`, which is `false` by default (reverses previous default behavior).

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -4,13 +4,7 @@ import createResponse from "./createResponse";
 import finishResponse from "./finishResponse";
 import createRoute from "./route";
 
-import {
-  History,
-  HickoryLocation,
-  PendingNavigation,
-  Action,
-  PartialLocation
-} from "@hickory/root";
+import { History, PendingNavigation } from "@hickory/root";
 
 import { RouteDescriptor, InternalRoute } from "./types/route";
 import { Response, PendingResponse, Params } from "./types/response";
@@ -25,8 +19,7 @@ import {
   RemoveResponseHandler,
   Cache,
   CurrentResponse,
-  Navigation,
-  LocationProps
+  Navigation
 } from "./types/curi";
 
 function createRouter(
@@ -180,18 +173,6 @@ function createRouter(
     }
   }
 
-  /*
-   * A shortcut to creating location objects without having
-   * to use the pathname addon
-   */
-  function createLocation(props: LocationProps): PartialLocation {
-    const { name, params, state, query, hash } = props;
-    const pathname = name
-      ? registeredAddons.pathname(name, params)
-      : mostRecent.response.location.pathname;
-    return { pathname, state, query, hash };
-  }
-
   // now that everything is defined, actually do the setup
   setupRoutesAndAddons(routeArray);
   history.respondWith(navigationHandler);
@@ -206,8 +187,7 @@ function createRouter(
         response: mostRecent.response,
         navigation: mostRecent.navigation
       };
-    },
-    createLocation
+    }
   };
 
   return router;

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -1,10 +1,4 @@
-import {
-  History,
-  LocationDetails,
-  HickoryLocation,
-  PartialLocation,
-  Action
-} from "@hickory/root";
+import { History, HickoryLocation, Action } from "@hickory/root";
 import { PathFunctionOptions } from "path-to-regexp";
 
 import { Addon, Addons } from "./addon";
@@ -53,11 +47,6 @@ export interface CurrentResponse {
   navigation: Navigation;
 }
 
-export interface LocationProps extends LocationDetails {
-  name: string;
-  params?: Params;
-}
-
 export interface CuriRouter {
   refresh: (routeArray: Array<RouteDescriptor>) => void;
   respond: (
@@ -67,5 +56,4 @@ export interface CuriRouter {
   addons: Addons;
   history: History;
   current(): CurrentResponse;
-  createLocation(options: LocationProps): PartialLocation;
 }

--- a/packages/core/tests/curi.spec.ts
+++ b/packages/core/tests/curi.spec.ts
@@ -780,55 +780,6 @@ describe("curi", () => {
     });
   });
 
-  describe("createLocation", () => {
-    const routes = [
-      { name: "Home", path: "" },
-      { name: "User", path: "u/:id" }
-    ];
-
-    it("returns a partial location", () => {
-      const router = curi(history, routes);
-      const location = router.createLocation({ name: "Home" });
-      expect(location).toHaveProperty("pathname");
-      expect(location).toHaveProperty("hash");
-      expect(location).toHaveProperty("query");
-      expect(location).toHaveProperty("state");
-    });
-
-    it('uses the "name" prop to generate the location\'s pathname', () => {
-      const router = curi(history, routes);
-      const location = router.createLocation({ name: "Home" });
-      expect(location).toMatchObject({ pathname: "/" });
-    });
-
-    it('uses the "params" prop to generate the location\'s pathname', () => {
-      const router = curi(history, routes);
-      const location = router.createLocation({
-        name: "User",
-        params: { id: 7 }
-      });
-      expect(location).toMatchObject({ pathname: "/u/7" });
-    });
-
-    it('passes the "query", "hash", and "state" props to location', () => {
-      const router = curi(history, routes);
-      const state = { state: true };
-      const query = "test=ing";
-      const hash = "test";
-      const location = router.createLocation({
-        name: "Home",
-        query,
-        hash,
-        state
-      });
-      expect(location).toMatchObject({
-        query,
-        hash,
-        state
-      });
-    });
-  });
-
   describe("response.redirectTo", () => {
     it("triggers a history.replace call AFTER emitting response", done => {
       let callPosition = 0;

--- a/packages/core/types/finishResponse.d.ts
+++ b/packages/core/types/finishResponse.d.ts
@@ -1,3 +1,3 @@
-import { Addons } from './types/addon';
-import { Response, PendingResponse } from './types/response';
+import { Addons } from "./types/addon";
+import { Response, PendingResponse } from "./types/response";
 export default function finishResponse(pending: PendingResponse, addons: Addons): Response;

--- a/packages/core/types/types/curi.d.ts
+++ b/packages/core/types/types/curi.d.ts
@@ -1,8 +1,8 @@
-import { History, LocationDetails, HickoryLocation, PartialLocation, Action } from "@hickory/root";
+import { History, HickoryLocation, Action } from "@hickory/root";
 import { PathFunctionOptions } from "path-to-regexp";
 import { Addon, Addons } from "./addon";
 import { RouteDescriptor } from "./route";
-import { Response, Params } from "./response";
+import { Response } from "./response";
 export interface Navigation {
     action: Action;
     previous: Response;
@@ -37,15 +37,10 @@ export interface CurrentResponse {
     response: Response;
     navigation: Navigation;
 }
-export interface LocationProps extends LocationDetails {
-    name: string;
-    params?: Params;
-}
 export interface CuriRouter {
     refresh: (routeArray: Array<RouteDescriptor>) => void;
     respond: (fn: ResponseHandler, options?: RespondOptions) => RemoveResponseHandler;
     addons: Addons;
     history: History;
     current(): CurrentResponse;
-    createLocation(options: LocationProps): PartialLocation;
 }

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,7 +1,7 @@
-import { RegExpOptions, Key } from 'path-to-regexp';
-import { Params } from './response';
-import { Addons } from './addon';
-import { LocationDetails } from '@hickory/root';
+import { RegExpOptions, Key } from "path-to-regexp";
+import { Params } from "./response";
+import { Addons } from "./addon";
+import { LocationDetails } from "@hickory/root";
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
     [key: string]: ParamParser;

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -61,12 +61,14 @@ class BaseLink extends React.Component<BaseLinkProps, LinkState> {
   };
 
   setLocation(props: BaseLinkProps) {
-    const { router, to, params, details } = props;
-    const location = router.createLocation({
-      name: to,
-      params,
-      ...details
-    });
+    const { router, response, to, params, details } = props;
+    const pathname = to
+      ? router.addons.pathname(to, params)
+      : response.location.pathname;
+    const location = {
+      ...details,
+      pathname
+    };
     this.setState({ location });
   }
 

--- a/packages/react/src/Link.tsx
+++ b/packages/react/src/Link.tsx
@@ -58,12 +58,14 @@ class BaseLink extends React.Component<BaseLinkProps, LinkState> {
   };
 
   setLocation(props: BaseLinkProps) {
-    const { router, to, params, details } = props;
-    const location = router.createLocation({
-      name: to,
-      params,
-      ...details
-    });
+    const { router, to, params, details, response } = props;
+    const pathname = to
+      ? router.addons.pathname(to, params)
+      : response.location.pathname;
+    const location = {
+      ...details,
+      pathname
+    };
     this.setState({ location });
   }
 

--- a/packages/svelte/src/Link.html
+++ b/packages/svelte/src/Link.html
@@ -20,13 +20,11 @@
 			};
 		},
 		computed: {
-			location: (to, params, details, $router) => {
-				return $router.createLocation(
-					Object.assign({
-						name: to,
-						params
-					}, details)
-				);
+			location: (to, params, details, $router, $curi) => {
+				const pathname = to
+					? $router.addons.pathname(to, params)
+					: $curi.response.location.pathname;
+				return Object.assign({}, details, { pathname });
 			},
 			href: (location, $router) => {
 				return $router.history.toHref(location);

--- a/packages/svelte/tests/link.spec.js
+++ b/packages/svelte/tests/link.spec.js
@@ -1,164 +1,196 @@
-import InMemory from '@hickory/in-memory';
-import curi from '@curi/core';
-import { Store } from 'svelte/store';
-import simulant from 'simulant';
-import { Link } from '../dist/curi-svelte.es.js';
+import InMemory from "@hickory/in-memory";
+import curi from "@curi/core";
+import { Store } from "svelte/store";
+import simulant from "simulant";
+import { Link } from "../dist/curi-svelte.es.js";
 
-describe('<Link>', () => {
-  it('renders an anchor with expected pathname', () => {
+describe("<Link>", () => {
+  it("renders an anchor with expected pathname", () => {
     const history = InMemory();
-    const routes = [{ name: 'Home', path: '' }];
+    const routes = [{ name: "Home", path: "" }];
     const router = curi(history, routes);
 
     const store = new Store({ router });
 
-    const node = document.createElement('div');
+    const node = document.createElement("div");
     const link = new Link({
       target: node,
       store,
       data: {
-        to: 'Home'
+        to: "Home"
       }
     });
 
-    const a = node.querySelector('a');
+    const a = node.querySelector("a");
     expect(a).not.toBeUndefined();
-    expect(a.href).toEqual('/');
+    expect(a.href).toEqual("/");
   });
 
-  it('uses params attribute to generate pathname', () => {
+  it("uses params attribute to generate pathname", () => {
     const history = InMemory();
-    const routes = [{ name: 'User', path: 'u/:id' }];
+    const routes = [{ name: "User", path: "u/:id" }];
     const router = curi(history, routes);
     const store = new Store({ router });
 
-    const node = document.createElement('div');
+    const node = document.createElement("div");
     const link = new Link({
       target: node,
       store,
       data: {
-        to: 'User',
-        params: { id: '1' }
+        to: "User",
+        params: { id: "1" }
       }
     });
 
-    const a = node.querySelector('a');
-    expect(a.href).toEqual('/u/1');
+    const a = node.querySelector("a");
+    expect(a.href).toEqual("/u/1");
   });
 
-  it('appends details to end of URI', () => {
-    const history = InMemory();
-    const routes = [{ name: 'Home', path: '' }];
+  it("falls back to current response's pathname if to isn't provided", done => {
+    const history = InMemory({ locations: ["/u/2"] });
+    const routes = [{ name: "User", path: "u/:id" }];
     const router = curi(history, routes);
-    const store = new Store({ router });
-
-    const node = document.createElement('div');
-    const link = new Link({
-      target: node,
-      store,
-      data: {
-        to: 'Home',
-        details: { hash: 'test', query: 'one=two' }
-      }
+    const store = new Store({
+      router,
+      curi: { response: undefined, navigation: undefined }
     });
 
-    const a = node.querySelector('a');
-    expect(a.href).toEqual('/?one=two#test');
-  });
+    router.respond(
+      ({ response, navigation }) => {
+        store.set({ curi: { response, navigation } });
+      },
+      { observe: true }
+    );
 
-  describe('clicking a <Link>', () => {
-    it('will navigate to the new location', () => {
-      const history = InMemory();
-      history.navigate = jest.fn();
-      const routes = [{ name: 'User', path: 'u/:id' }];
-      const router = curi(history, routes);
-      const store = new Store({ router });
-
-      const node = document.createElement('div');
+    router.respond(() => {
+      const node = document.createElement("div");
       const link = new Link({
         target: node,
         store,
         data: {
-          to: 'User',
+          details: { hash: "is-a-band" }
+        }
+      });
+
+      const a = node.querySelector("a");
+      expect(a.href).toEqual("/u/2#is-a-band");
+      done();
+    });
+  });
+
+  it("appends details to end of URI", () => {
+    const history = InMemory();
+    const routes = [{ name: "Home", path: "" }];
+    const router = curi(history, routes);
+    const store = new Store({ router });
+
+    const node = document.createElement("div");
+    const link = new Link({
+      target: node,
+      store,
+      data: {
+        to: "Home",
+        details: { hash: "test", query: "one=two" }
+      }
+    });
+
+    const a = node.querySelector("a");
+    expect(a.href).toEqual("/?one=two#test");
+  });
+
+  describe("clicking a <Link>", () => {
+    it("will navigate to the new location", () => {
+      const history = InMemory();
+      history.navigate = jest.fn();
+      const routes = [{ name: "User", path: "u/:id" }];
+      const router = curi(history, routes);
+      const store = new Store({ router });
+
+      const node = document.createElement("div");
+      const link = new Link({
+        target: node,
+        store,
+        data: {
+          to: "User",
           params: { id: 1 }
         }
       });
 
-      const a = node.querySelector('a');
-      const event = simulant('click');
+      const a = node.querySelector("a");
+      const event = simulant("click");
       simulant.fire(a, event);
       expect(history.navigate.mock.calls.length).toBe(1);
     });
 
-    it('will ignore modified clicks', () => {
+    it("will ignore modified clicks", () => {
       const history = InMemory();
       history.navigate = jest.fn();
-      const routes = [{ name: 'User', path: 'u/:id' }];
+      const routes = [{ name: "User", path: "u/:id" }];
       const router = curi(history, routes);
       const store = new Store({ router });
 
-      const node = document.createElement('div');
+      const node = document.createElement("div");
       const link = new Link({
         target: node,
         store,
         data: {
-          to: 'User',
+          to: "User",
           params: { id: 2 }
         }
       });
 
-      const a = node.querySelector('a');
+      const a = node.querySelector("a");
 
-      const modifiers = ['metaKey', 'altKey', 'ctrlKey', 'shiftKey'];
+      const modifiers = ["metaKey", "altKey", "ctrlKey", "shiftKey"];
       modifiers.forEach(m => {
-        simulant.fire(a, 'click', { [m]: true });
+        simulant.fire(a, "click", { [m]: true });
         expect(history.navigate.mock.calls.length).toBe(0);
       });
     });
 
-    it('will ignore click if event.defaultPrevented is true', () => {
+    it("will ignore click if event.defaultPrevented is true", () => {
       const history = InMemory();
       history.navigate = jest.fn();
-      const routes = [{ name: 'User', path: 'u/:id' }];
+      const routes = [{ name: "User", path: "u/:id" }];
       const router = curi(history, routes);
       const store = new Store({ router });
 
-      const node = document.createElement('div');
+      const node = document.createElement("div");
       const link = new Link({
         target: node,
         store,
         data: {
-          to: 'User',
+          to: "User",
           params: { id: 3 }
         }
       });
 
-      const a = node.querySelector('a');
-      const event = simulant('click');
+      const a = node.querySelector("a");
+      const event = simulant("click");
       event.preventDefault();
       simulant.fire(a, event);
       expect(history.navigate.mock.calls.length).toBe(0);
     });
 
-    it('will ignore click if not done with left mouse button', () => {
+    it("will ignore click if not done with left mouse button", () => {
       const history = InMemory();
       history.navigate = jest.fn();
-      const routes = [{ name: 'User', path: 'u/:id' }];
+      const routes = [{ name: "User", path: "u/:id" }];
       const router = curi(history, routes);
       const store = new Store({ router });
 
-      const node = document.createElement('div');
+      const node = document.createElement("div");
       const link = new Link({
         target: node,
         store,
         data: {
-          to: 'User',
+          to: "User",
           params: { id: 3 }
         }
       });
 
-      const a = node.querySelector('a');
-      const event = simulant('click', { button: 1 });
+      const a = node.querySelector("a");
+      const event = simulant("click", { button: 1 });
       simulant.fire(a, event);
       expect(history.navigate.mock.calls.length).toBe(0);
     });

--- a/packages/vue/src/Link.ts
+++ b/packages/vue/src/Link.ts
@@ -33,11 +33,13 @@ const Link: ComponentOptions<LinkComponent> = {
 
   computed: {
     location: function() {
-      return this.$router.createLocation({
-        name: this.to,
-        params: this.params,
-        ...this.details
-      });
+      const pathname = this.to
+        ? this.$router.addons.pathname(this.to, this.params)
+        : this.$curi.response.location.pathname;
+      return {
+        ...this.details,
+        pathname
+      };
     },
     href: function() {
       return this.$router.history.toHref(this.location);


### PR DESCRIPTION
I've decided against adding a global router method. The only benefit this really had over using `router.addons.pathname` was that it would automatically fall back to the response's `location.pathname` if a `to` valid is not provided. However, the `<Link>`s can just grab this internally from the `response` (each has access to it, although how varies).