### PR TITLE
Break up the Match API

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Move `match.response` to top level and group `match.every` and `match.initial` under `async` object.
 * Group `initial` and `every` resolved values with `error` under `async` object.
 * Rename `router.refresh` to `router.replaceRoutes`.
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Group `initial` and `every` resolved values with `error` under `async` object.
 * Rename `router.refresh` to `router.replaceRoutes`.
 
 ## 1.0.0-beta.27

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
-* Move `match.response` to top level and group `match.every` and `match.initial` under `async` object.
-* Group `initial` and `every` resolved values with `error` under `async` object.
+* Move `match.response` to top level and group `match.every` and `match.initial` under `on` object (`on.initial` and `on.every`).
+* Group `initial` and `every` resolved values with `error` under `load` object.
 * Rename `router.refresh` to `router.replaceRoutes`.
 
 ## 1.0.0-beta.27

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 * Move `match.response` to top level and group `match.every` and `match.initial` under `on` object (`on.initial` and `on.every`).
-* Group `initial` and `every` resolved values with `error` under `load` object.
+* Group `initial` and `every` resolved values with `error` under `resolved` object.
 * Rename `router.refresh` to `router.replaceRoutes`.
 
 ## 1.0.0-beta.27

--- a/packages/core/src/createResponse.ts
+++ b/packages/core/src/createResponse.ts
@@ -11,7 +11,7 @@ export function createResponse(
 ): PendingResponse {
   return {
     ...matchLocation(location, routes),
-    async: null
+    load: null
   };
 }
 
@@ -36,16 +36,16 @@ function resolveRoute(
       response
     });
   }
-  const { async } = route.public;
+  const { on } = route.public;
   return Promise.all([
-    async.initial ? async.initial() : undefined,
-    async.every ? async.every(routeProperties(response)) : undefined
+    on.initial ? on.initial() : undefined,
+    on.every ? on.every(routeProperties(response)) : undefined
   ]).then(
     ([initial, every]) => {
       return {
         route,
         response,
-        async: {
+        load: {
           error: null,
           initial,
           every
@@ -57,7 +57,7 @@ function resolveRoute(
       return {
         route,
         response,
-        async: {
+        load: {
           error,
           initial: null,
           every: null

--- a/packages/core/src/createResponse.ts
+++ b/packages/core/src/createResponse.ts
@@ -36,10 +36,10 @@ function resolveRoute(
       response
     });
   }
-  const { match } = route.public;
+  const { async } = route.public;
   return Promise.all([
-    match.initial ? match.initial() : undefined,
-    match.every ? match.every(routeProperties(response)) : undefined
+    async.initial ? async.initial() : undefined,
+    async.every ? async.every(routeProperties(response)) : undefined
   ]).then(
     ([initial, every]) => {
       return {

--- a/packages/core/src/createResponse.ts
+++ b/packages/core/src/createResponse.ts
@@ -11,8 +11,7 @@ export function createResponse(
 ): PendingResponse {
   return {
     ...matchLocation(location, routes),
-    resolved: null,
-    error: null
+    async: null
   };
 }
 
@@ -43,22 +42,26 @@ function resolveRoute(
     match.every ? match.every(routeProperties(response)) : undefined
   ]).then(
     ([initial, every]) => {
-      const resolved =
-        !match.initial && !match.every ? null : { initial, every };
       return {
         route,
         response,
-        error: null,
-        resolved
+        async: {
+          error: null,
+          initial,
+          every
+        }
       };
     },
-    err => {
+    error => {
       // when there is an uncaught error, set it on the response
       return {
         route,
         response,
-        error: err,
-        resolved: null
+        async: {
+          error,
+          initial: null,
+          every: null
+        }
       };
     }
   );

--- a/packages/core/src/createResponse.ts
+++ b/packages/core/src/createResponse.ts
@@ -11,7 +11,7 @@ export function createResponse(
 ): PendingResponse {
   return {
     ...matchLocation(location, routes),
-    load: null
+    resolved: null
   };
 }
 
@@ -33,7 +33,8 @@ function resolveRoute(
   if (!route) {
     return Promise.resolve({
       route,
-      response
+      response,
+      resolved: null
     });
   }
   const { on } = route.public;
@@ -45,7 +46,7 @@ function resolveRoute(
       return {
         route,
         response,
-        load: {
+        resolved: {
           error: null,
           initial,
           every
@@ -57,7 +58,7 @@ function resolveRoute(
       return {
         route,
         response,
-        load: {
+        resolved: {
           error,
           initial: null,
           every: null

--- a/packages/core/src/finishResponse.ts
+++ b/packages/core/src/finishResponse.ts
@@ -45,8 +45,8 @@ export default function finishResponse(
   addons: Addons
 ): Response {
   const { async, route, response } = pending;
-  if (route && route.public.match.response) {
-    route.public.match.response({
+  if (route && route.response) {
+    route.response({
       async,
       route: routeProperties(response),
       set: responseSetters(response, addons),

--- a/packages/core/src/finishResponse.ts
+++ b/packages/core/src/finishResponse.ts
@@ -44,10 +44,10 @@ export default function finishResponse(
   pending: PendingResponse,
   addons: Addons
 ): Response {
-  const { async, route, response } = pending;
+  const { load, route, response } = pending;
   if (route && route.response) {
     route.response({
-      async,
+      load,
       route: routeProperties(response),
       set: responseSetters(response, addons),
       addons

--- a/packages/core/src/finishResponse.ts
+++ b/packages/core/src/finishResponse.ts
@@ -44,10 +44,10 @@ export default function finishResponse(
   pending: PendingResponse,
   addons: Addons
 ): Response {
-  const { load, route, response } = pending;
+  const { resolved, route, response } = pending;
   if (route && route.response) {
     route.response({
-      load,
+      resolved,
       route: routeProperties(response),
       set: responseSetters(response, addons),
       addons

--- a/packages/core/src/finishResponse.ts
+++ b/packages/core/src/finishResponse.ts
@@ -44,11 +44,10 @@ export default function finishResponse(
   pending: PendingResponse,
   addons: Addons
 ): Response {
-  const { error, resolved, route, response } = pending;
+  const { async, route, response } = pending;
   if (route && route.public.match.response) {
     route.public.match.response({
-      error,
-      resolved,
+      async,
       route: routeProperties(response),
       set: responseSetters(response, addons),
       addons

--- a/packages/core/src/route.ts
+++ b/packages/core/src/route.ts
@@ -11,7 +11,8 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
     path,
     pathOptions = {},
     children: descriptorChildren = [],
-    match = {},
+    response,
+    async = {},
     extra,
     params: paramParsers
   } = options;
@@ -37,10 +38,9 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
       name,
       path: path,
       keys: keys.map(key => key.name),
-      match: {
-        initial: match.initial && once(match.initial),
-        every: match.every,
-        response: match.response
+      async: {
+        initial: async.initial && once(async.initial),
+        every: async.every
       },
       extra
     },
@@ -49,6 +49,7 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
       keys,
       mustBeExact
     },
+    response,
     children,
     paramParsers
   };

--- a/packages/core/src/route.ts
+++ b/packages/core/src/route.ts
@@ -12,7 +12,7 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
     pathOptions = {},
     children: descriptorChildren = [],
     response,
-    async = {},
+    on = {},
     extra,
     params: paramParsers
   } = options;
@@ -38,9 +38,9 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
       name,
       path: path,
       keys: keys.map(key => key.name),
-      async: {
-        initial: async.initial && once(async.initial),
-        every: async.every
+      on: {
+        initial: on.initial && once(on.initial),
+        every: on.every
       },
       extra
     },

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -19,14 +19,14 @@ export interface Response {
   redirectTo?: ToArgument;
 }
 
-export interface AsyncResults {
+export interface LoadResults {
   error: any;
   initial: any;
   every: any;
 }
 
 export interface PendingResponse {
-  async?: AsyncResults;
+  load?: LoadResults;
   route: InternalRoute;
   response: Response;
 }

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -19,14 +19,14 @@ export interface Response {
   redirectTo?: ToArgument;
 }
 
-export interface LoadResults {
+export interface Resolved {
   error: any;
   initial: any;
   every: any;
 }
 
 export interface PendingResponse {
-  load?: LoadResults;
+  resolved: Resolved;
   route: InternalRoute;
   response: Response;
 }

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -19,14 +19,14 @@ export interface Response {
   redirectTo?: ToArgument;
 }
 
-export interface ResolvedObject {
+export interface AsyncResults {
+  error: any;
   initial: any;
   every: any;
 }
 
 export interface PendingResponse {
-  error?: any;
-  resolved?: ResolvedObject;
+  async?: AsyncResults;
   route: InternalRoute;
   response: Response;
 }

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -1,7 +1,7 @@
 import { RegExpOptions, Key } from "path-to-regexp";
 
 import { LocationDetails } from "@hickory/root";
-import { Params, Response } from "./response";
+import { Params, Response, AsyncResults } from "./response";
 import { Addons } from "./addon";
 
 export type ParamParser = (input: string) => any;
@@ -31,8 +31,7 @@ export interface ResponseSetters {
 }
 
 export interface ResponseBuilder {
-  error: any;
-  resolved: any;
+  async: AsyncResults;
   route: RouteProps;
   set: ResponseSetters;
   addons: Addons;

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -1,7 +1,7 @@
 import { RegExpOptions, Key } from "path-to-regexp";
 
 import { LocationDetails } from "@hickory/root";
-import { Params, Response, LoadResults } from "./response";
+import { Params, Response, Resolved } from "./response";
 import { Addons } from "./addon";
 
 export type ParamParser = (input: string) => any;
@@ -31,7 +31,7 @@ export interface ResponseSetters {
 }
 
 export interface ResponseBuilder {
-  load: LoadResults;
+  resolved: Resolved;
   route: RouteProps;
   set: ResponseSetters;
   addons: Addons;

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -39,12 +39,11 @@ export interface ResponseBuilder {
 
 export type EveryMatchFn = (route?: RouteProps) => Promise<any>;
 export type InitialMatchFn = () => Promise<any>;
-export type ResponseMatchFn = (props: ResponseBuilder) => void;
+export type ResponseFn = (props: ResponseBuilder) => void;
 
-export interface MatchFns {
+export interface AsyncFns {
   initial?: InitialMatchFn;
   every?: EveryMatchFn;
-  response?: ResponseMatchFn;
 }
 
 export interface RouteDescriptor {
@@ -53,7 +52,8 @@ export interface RouteDescriptor {
   pathOptions?: RegExpOptions;
   params?: ParamParsers;
   children?: Array<RouteDescriptor>;
-  match?: MatchFns;
+  response?: ResponseFn;
+  async?: AsyncFns;
   extra?: { [key: string]: any };
 }
 
@@ -65,7 +65,7 @@ export interface Route {
   name: string;
   path: string;
   keys: Array<string | number>;
-  match: MatchFns;
+  async: AsyncFns;
   extra: { [key: string]: any };
 }
 
@@ -78,6 +78,7 @@ export interface InternalMatch {
 export interface InternalRoute {
   public: Route;
   children: Array<InternalRoute>;
+  response: ResponseFn;
   pathMatching: InternalMatch;
   paramParsers: ParamParsers;
 }

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -1,7 +1,7 @@
 import { RegExpOptions, Key } from "path-to-regexp";
 
 import { LocationDetails } from "@hickory/root";
-import { Params, Response, AsyncResults } from "./response";
+import { Params, Response, LoadResults } from "./response";
 import { Addons } from "./addon";
 
 export type ParamParser = (input: string) => any;
@@ -31,7 +31,7 @@ export interface ResponseSetters {
 }
 
 export interface ResponseBuilder {
-  async: AsyncResults;
+  load: LoadResults;
   route: RouteProps;
   set: ResponseSetters;
   addons: Addons;
@@ -41,7 +41,7 @@ export type EveryMatchFn = (route?: RouteProps) => Promise<any>;
 export type InitialMatchFn = () => Promise<any>;
 export type ResponseFn = (props: ResponseBuilder) => void;
 
-export interface AsyncFns {
+export interface OnFns {
   initial?: InitialMatchFn;
   every?: EveryMatchFn;
 }
@@ -53,7 +53,7 @@ export interface RouteDescriptor {
   params?: ParamParsers;
   children?: Array<RouteDescriptor>;
   response?: ResponseFn;
-  async?: AsyncFns;
+  on?: OnFns;
   extra?: { [key: string]: any };
 }
 
@@ -65,7 +65,7 @@ export interface Route {
   name: string;
   path: string;
   keys: Array<string | number>;
-  async: AsyncFns;
+  on: OnFns;
   extra: { [key: string]: any };
 }
 

--- a/packages/core/src/utils/async.ts
+++ b/packages/core/src/utils/async.ts
@@ -1,13 +1,13 @@
 import { RouteDescriptor, InternalRoute } from "../types/route";
 
-function hasMatchFunction(route: InternalRoute): boolean {
-  const { async } = route.public;
-  return !!(async && (async.every || async.initial));
+function hasAsyncOnFunction(route: InternalRoute): boolean {
+  const { on } = route.public;
+  return !!(on && (on.every || on.initial));
 }
 
 export default function hasAsyncRoute(routes: Array<InternalRoute>): boolean {
   return routes.some(route => {
-    if (hasMatchFunction(route)) {
+    if (hasAsyncOnFunction(route)) {
       return true;
     }
     if (route.children.length) {

--- a/packages/core/src/utils/async.ts
+++ b/packages/core/src/utils/async.ts
@@ -1,8 +1,8 @@
 import { RouteDescriptor, InternalRoute } from "../types/route";
 
 function hasMatchFunction(route: InternalRoute): boolean {
-  const { match } = route.public;
-  return !!(match && (match.every || match.initial));
+  const { async } = route.public;
+  return !!(async && (async.every || async.initial));
 }
 
 export default function hasAsyncRoute(routes: Array<InternalRoute>): boolean {

--- a/packages/core/tests/curi.spec.ts
+++ b/packages/core/tests/curi.spec.ts
@@ -208,7 +208,7 @@ describe("curi", () => {
             {
               name: "All",
               path: ":all+",
-              async: {
+              on: {
                 initial: () => Promise.resolve() // force async
               }
             }
@@ -401,12 +401,12 @@ describe("curi", () => {
         after();
       });
 
-      it("does asynchronous matching when a route has async.initial", () => {
+      it("does asynchronous matching when a route has on.initial", () => {
         const routes = [
           {
             name: "Home",
             path: "",
-            async: {
+            on: {
               initial: () => Promise.resolve()
             }
           }
@@ -419,12 +419,12 @@ describe("curi", () => {
         after();
       });
 
-      it("does asynchronous matching when a route has async.every", () => {
+      it("does asynchronous matching when a route has on.every", () => {
         const routes = [
           {
             name: "Home",
             path: "",
-            async: {
+            on: {
               every: () => Promise.resolve()
             }
           }
@@ -437,7 +437,7 @@ describe("curi", () => {
         after();
       });
 
-      it("does asynchronous matching when a nested route has async.initial/every", () => {
+      it("does asynchronous matching when a nested route has on.initial/every", () => {
         const routes = [
           {
             name: "Parent",
@@ -446,7 +446,7 @@ describe("curi", () => {
               {
                 name: "Child",
                 path: "child",
-                async: {
+                on: {
                   initial: () => Promise.resolve()
                 }
               }
@@ -474,13 +474,13 @@ describe("curi", () => {
       });
     });
 
-    describe("async", () => {
+    describe("on", () => {
       it("initial value is an object with null response and navigation properties", () => {
         const router = curi(history, [
           {
             name: "Catch All",
             path: "(.*)",
-            async: {
+            on: {
               initial: () => Promise.resolve()
             }
           }
@@ -647,7 +647,7 @@ describe("curi", () => {
             {
               name: "How",
               path: ":method",
-              async: {
+              on: {
                 every: () => {
                   promiseResolved = true;
                   return Promise.resolve(promiseResolved);
@@ -679,7 +679,7 @@ describe("curi", () => {
             {
               name: "How",
               path: ":method",
-              async: {
+              on: {
                 initial: () => Promise.resolve()
               }
             }
@@ -719,7 +719,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              async: { initial: () => Promise.resolve() }
+              on: { initial: () => Promise.resolve() }
             }
           ];
           const sub = jest.fn();
@@ -736,7 +736,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              async: { initial: () => Promise.resolve() }
+              on: { initial: () => Promise.resolve() }
             }
           ];
           const sub = jest.fn();
@@ -785,7 +785,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              async: { initial: () => Promise.resolve() }
+              on: { initial: () => Promise.resolve() }
             },
             { name: "Catch All", path: "(.*)" }
           ];
@@ -839,7 +839,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              async: { initial: () => Promise.resolve() }
+              on: { initial: () => Promise.resolve() }
             },
             { name: "Catch All", path: "(.*)" }
           ];

--- a/packages/core/tests/curi.spec.ts
+++ b/packages/core/tests/curi.spec.ts
@@ -208,7 +208,7 @@ describe("curi", () => {
             {
               name: "All",
               path: ":all+",
-              match: {
+              async: {
                 initial: () => Promise.resolve() // force async
               }
             }
@@ -253,10 +253,8 @@ describe("curi", () => {
             {
               name: "All",
               path: "(.*)",
-              match: {
-                response: ({ set }) => {
-                  set.data(Math.random());
-                }
+              response: ({ set }) => {
+                set.data(Math.random());
               }
             }
           ];
@@ -307,10 +305,8 @@ describe("curi", () => {
             {
               name: "All",
               path: "(.*)",
-              match: {
-                response: ({ set }) => {
-                  set.data(Math.random());
-                }
+              response: ({ set }) => {
+                set.data(Math.random());
               }
             }
           ];
@@ -347,10 +343,8 @@ describe("curi", () => {
             {
               name: "Start",
               path: "",
-              match: {
-                response: ({ set }) => {
-                  set.redirect({ name: "Other" });
-                }
+              response: ({ set }) => {
+                set.redirect({ name: "Other" });
               }
             },
             {
@@ -375,10 +369,8 @@ describe("curi", () => {
             {
               name: "Start",
               path: "",
-              match: {
-                response: ({ set }) => {
-                  set.redirect({ name: "Other" });
-                }
+              response: ({ set }) => {
+                set.redirect({ name: "Other" });
               }
             },
             {
@@ -409,12 +401,12 @@ describe("curi", () => {
         after();
       });
 
-      it("does asynchronous matching when a route has match.initial", () => {
+      it("does asynchronous matching when a route has async.initial", () => {
         const routes = [
           {
             name: "Home",
             path: "",
-            match: {
+            async: {
               initial: () => Promise.resolve()
             }
           }
@@ -427,12 +419,12 @@ describe("curi", () => {
         after();
       });
 
-      it("does asynchronous matching when a route has match.every", () => {
+      it("does asynchronous matching when a route has async.every", () => {
         const routes = [
           {
             name: "Home",
             path: "",
-            match: {
+            async: {
               every: () => Promise.resolve()
             }
           }
@@ -445,7 +437,7 @@ describe("curi", () => {
         after();
       });
 
-      it("does asynchronous matching when a nested route has match.initial/every", () => {
+      it("does asynchronous matching when a nested route has async.initial/every", () => {
         const routes = [
           {
             name: "Parent",
@@ -454,7 +446,7 @@ describe("curi", () => {
               {
                 name: "Child",
                 path: "child",
-                match: {
+                async: {
                   initial: () => Promise.resolve()
                 }
               }
@@ -488,7 +480,7 @@ describe("curi", () => {
           {
             name: "Catch All",
             path: "(.*)",
-            match: {
+            async: {
               initial: () => Promise.resolve()
             }
           }
@@ -655,7 +647,7 @@ describe("curi", () => {
             {
               name: "How",
               path: ":method",
-              match: {
+              async: {
                 every: () => {
                   promiseResolved = true;
                   return Promise.resolve(promiseResolved);
@@ -687,7 +679,7 @@ describe("curi", () => {
             {
               name: "How",
               path: ":method",
-              match: {
+              async: {
                 initial: () => Promise.resolve()
               }
             }
@@ -727,7 +719,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              match: { initial: () => Promise.resolve() }
+              async: { initial: () => Promise.resolve() }
             }
           ];
           const sub = jest.fn();
@@ -744,7 +736,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              match: { initial: () => Promise.resolve() }
+              async: { initial: () => Promise.resolve() }
             }
           ];
           const sub = jest.fn();
@@ -793,7 +785,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              match: { initial: () => Promise.resolve() }
+              async: { initial: () => Promise.resolve() }
             },
             { name: "Catch All", path: "(.*)" }
           ];
@@ -847,7 +839,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              match: { initial: () => Promise.resolve() }
+              async: { initial: () => Promise.resolve() }
             },
             { name: "Catch All", path: "(.*)" }
           ];
@@ -915,10 +907,8 @@ describe("curi", () => {
         {
           name: "A Route",
           path: "",
-          match: {
-            response: ({ set }) => {
-              set.redirect({ name: "B Route", status: 301 });
-            }
+          response: ({ set }) => {
+            set.redirect({ name: "B Route", status: 301 });
           }
         },
         {

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -138,13 +138,13 @@ describe("route matching/response generation", () => {
         {
           name: "Contact",
           path: "contact",
-          match: {
+          response: ({ async }) => {
+            expect(async.error).toBe("This is an error");
+            done();
+          },
+          async: {
             every: () => {
               return Promise.reject("This is an error");
-            },
-            response: ({ async }) => {
-              expect(async.error).toBe("This is an error");
-              done();
             }
           }
         }
@@ -181,7 +181,7 @@ describe("route matching/response generation", () => {
       });
 
       describe("body", () => {
-        it("is undefined if it isn't set in match.response", done => {
+        it("is undefined if it isn't set in response()", done => {
           const history = InMemory({ locations: ["/test"] });
           const routes = [
             {
@@ -203,10 +203,8 @@ describe("route matching/response generation", () => {
             {
               name: "Test",
               path: "test",
-              match: {
-                response: ({ set }) => {
-                  set.body(body);
-                }
+              response: ({ set }) => {
+                set.body(body);
               }
             }
           ];
@@ -257,15 +255,13 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is the value set by calling status in the matching route's match.response function", done => {
+        it("is the value set by calling status in the matching route's response() function", done => {
           const routes = [
             {
               name: "A Route",
               path: "",
-              match: {
-                response: ({ set }) => {
-                  set.status(451);
-                }
+              response: ({ set }) => {
+                set.status(451);
               }
             }
           ];
@@ -277,7 +273,7 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is set by calling set.redirect in the matching match.response", () => {
+        it("is set by calling set.redirect() in the matching response()", () => {
           const routes = [
             {
               name: "New",
@@ -286,10 +282,8 @@ describe("route matching/response generation", () => {
             {
               name: "302 Route",
               path: "old",
-              match: {
-                response: ({ set }) => {
-                  set.redirect({ name: "New", status: 302 });
-                }
+              response: ({ set }) => {
+                set.redirect({ name: "New", status: 302 });
               }
             }
           ];
@@ -306,7 +300,7 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is set to 301 by default when calling set.redirect in match.response", () => {
+        it("is set to 301 by default when calling set.redirect() in response()", () => {
           const routes = [
             {
               name: "New",
@@ -315,10 +309,8 @@ describe("route matching/response generation", () => {
             {
               name: "301 Route",
               path: "old",
-              match: {
-                response: ({ set }) => {
-                  set.redirect({ name: "New" });
-                }
+              response: ({ set }) => {
+                set.redirect({ name: "New" });
               }
             }
           ];
@@ -354,15 +346,13 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is the value set by calling set.data in match.response", done => {
+        it("is the value set by calling set.data() in response()", done => {
           const routes = [
             {
               name: "A Route",
               path: "",
-              match: {
-                response: ({ set }) => {
-                  set.data({ test: "value" });
-                }
+              response: ({ set }) => {
+                set.data({ test: "value" });
               }
             }
           ];
@@ -408,15 +398,13 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is the value set by calling set.title in match.response", done => {
+        it("is the value set by calling set.title() in response()", done => {
           const routes = [
             {
               name: "State",
               path: ":state",
-              match: {
-                response: ({ set }) => {
-                  set.title("A State");
-                }
+              response: ({ set }) => {
+                set.title("A State");
               }
             }
           ];
@@ -638,15 +626,13 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is set by calling the error method from a matched route's match.response function", done => {
+        it("is set by calling the set.error() method from a matched route's response() function", done => {
           const routes = [
             {
               name: "A Route",
               path: "",
-              match: {
-                response: ({ set }) => {
-                  set.error("woops");
-                }
+              response: ({ set }) => {
+                set.error("woops");
               }
             }
           ];
@@ -660,18 +646,16 @@ describe("route matching/response generation", () => {
       });
 
       describe("redirectTo", () => {
-        it("is set by calling the redirect function in a matching route's match.response function", () => {
+        it("is set by calling set.redirect() in a matching route's response()", () => {
           const routes = [
             {
               name: "A Route",
               path: "",
-              match: {
-                response: ({ set }) => {
-                  set.redirect({
-                    name: "B Route",
-                    status: 301
-                  });
-                }
+              response: ({ set }) => {
+                set.redirect({
+                  name: "B Route",
+                  status: 301
+                });
               }
             },
             {
@@ -697,13 +681,13 @@ describe("route matching/response generation", () => {
     });
   });
 
-  describe("the match functions", () => {
+  describe("the async functions", () => {
     describe("initial", () => {
       it("will only be called once", done => {
         /*
          * This test is a bit odd to read, but it verifies that the
-         * match.initial function is only called once (while the
-         * match.every function is called on every match).
+         * async.initial function is only called once (while the
+         * async.every function is called on every match).
          */
         let initialCount = 0;
         let everyCount = 0;
@@ -714,7 +698,7 @@ describe("route matching/response generation", () => {
           {
             name: "Test",
             path: ":test",
-            match: { initial, every }
+            async: { initial, every }
           }
         ];
         const router = curi(history, routes);
@@ -754,7 +738,7 @@ describe("route matching/response generation", () => {
         const CatchAll = {
           name: "Catch All",
           path: ":anything",
-          match: { every: spy }
+          async: { every: spy }
         };
 
         const history = InMemory({ locations: ["/hello?one=two"] });
@@ -779,25 +763,25 @@ describe("route matching/response generation", () => {
           {
             name: "First",
             path: "first",
-            match: {
-              every: everySpy,
-              response: responseSpy
+            response: responseSpy,
+            async: {
+              every: everySpy
             }
           },
           {
             name: "Second",
             path: "second",
-            match: {
+            response: () => {
+              expect(firstHasResolved).toBe(true);
+              expect(everySpy.mock.calls.length).toBe(2);
+              expect(responseSpy.mock.calls.length).toBe(0);
+              done();
+            },
+            async: {
               // re-use the every spy so that this route's response
               // fn isn't call until after the first route's every
               // fn has resolved
-              every: everySpy,
-              response: () => {
-                expect(firstHasResolved).toBe(true);
-                expect(everySpy.mock.calls.length).toBe(2);
-                expect(responseSpy.mock.calls.length).toBe(0);
-                done();
-              }
+              every: everySpy
             }
           }
         ];
@@ -808,14 +792,12 @@ describe("route matching/response generation", () => {
       });
 
       describe("async", () => {
-        it("is null when route has no match.initial/every functions", () => {
+        it("is null when route has no async.initial/every functions", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            match: {
-              response: ({ async }) => {
-                expect(async).toBe(null);
-              }
+            response: ({ async }) => {
+              expect(async).toBe(null);
             }
           };
 
@@ -827,13 +809,13 @@ describe("route matching/response generation", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            match: {
-              initial: () => Promise.resolve(1),
-              response: ({ async }) => {
-                expect(async).toHaveProperty("error");
-                expect(async).toHaveProperty("initial");
-                expect(async).toHaveProperty("every");
-              }
+            response: ({ async }) => {
+              expect(async).toHaveProperty("error");
+              expect(async).toHaveProperty("initial");
+              expect(async).toHaveProperty("every");
+            },
+            async: {
+              initial: () => Promise.resolve(1)
             }
           };
 
@@ -842,7 +824,7 @@ describe("route matching/response generation", () => {
         });
 
         describe("error", () => {
-          it("receives the error rejected by match.initial", done => {
+          it("receives the error rejected by async.initial", done => {
             const spy = jest.fn(({ async }) => {
               expect(async.error).toBe("rejected by initial");
               done();
@@ -851,9 +833,9 @@ describe("route matching/response generation", () => {
             const CatchAll = {
               name: "Catch All",
               path: ":anything",
-              match: {
-                initial: () => Promise.reject("rejected by initial"),
-                response: spy
+              response: spy,
+              async: {
+                initial: () => Promise.reject("rejected by initial")
               }
             };
 
@@ -861,7 +843,7 @@ describe("route matching/response generation", () => {
             const router = curi(history, [CatchAll]);
           });
 
-          it("receives the error rejected by match.every", done => {
+          it("receives the error rejected by async.every", done => {
             const spy = jest.fn(({ async }) => {
               expect(async.error).toBe("rejected by every");
               done();
@@ -870,9 +852,9 @@ describe("route matching/response generation", () => {
             const CatchAll = {
               name: "Catch All",
               path: ":anything",
-              match: {
-                every: () => Promise.reject("rejected by every"),
-                response: spy
+              response: spy,
+              async: {
+                every: () => Promise.reject("rejected by every")
               }
             };
 
@@ -882,7 +864,7 @@ describe("route matching/response generation", () => {
         });
 
         describe("initial", () => {
-          it("is the data resolved by match.initial", done => {
+          it("is the data resolved by async.initial", done => {
             const spy = jest.fn(({ async }) => {
               expect(async.initial).toMatchObject({ test: "ing" });
               done();
@@ -891,9 +873,9 @@ describe("route matching/response generation", () => {
             const CatchAll = {
               name: "Catch All",
               path: ":anything",
-              match: {
-                initial: () => Promise.resolve({ test: "ing" }),
-                response: spy
+              response: spy,
+              async: {
+                initial: () => Promise.resolve({ test: "ing" })
               }
             };
 
@@ -909,18 +891,18 @@ describe("route matching/response generation", () => {
               {
                 name: "Test",
                 path: ":test",
-                match: {
+                response: ({ async }) => {
+                  if (!hasFinished) {
+                    hasFinished = true;
+                    random = async.initial;
+                  } else {
+                    expect(async.initial).toBe(random);
+                    done();
+                  }
+                },
+                async: {
                   initial: () => {
                     return Promise.resolve(Math.random());
-                  },
-                  response: ({ async }) => {
-                    if (!hasFinished) {
-                      hasFinished = true;
-                      random = async.initial;
-                    } else {
-                      expect(async.initial).toBe(random);
-                      done();
-                    }
                   }
                 }
               }
@@ -940,9 +922,9 @@ describe("route matching/response generation", () => {
             const CatchAll = {
               name: "Catch All",
               path: ":anything",
-              match: {
-                every: () => Promise.resolve(),
-                response: spy
+              response: spy,
+              async: {
+                every: () => Promise.resolve()
               }
             };
 
@@ -952,7 +934,7 @@ describe("route matching/response generation", () => {
         });
 
         describe("every", () => {
-          it("is the data resolved by match.every", done => {
+          it("is the data resolved by async.every", done => {
             const spy = jest.fn(({ async }) => {
               expect(async.every).toMatchObject({ test: "ing" });
               done();
@@ -961,9 +943,9 @@ describe("route matching/response generation", () => {
             const CatchAll = {
               name: "Catch All",
               path: ":anything",
-              match: {
-                every: () => Promise.resolve({ test: "ing" }),
-                response: spy
+              response: spy,
+              async: {
+                every: () => Promise.resolve({ test: "ing" })
               }
             };
 
@@ -980,9 +962,9 @@ describe("route matching/response generation", () => {
             const CatchAll = {
               name: "Catch All",
               path: ":anything",
-              match: {
-                initial: () => Promise.resolve(),
-                response: spy
+              response: spy,
+              async: {
+                initial: () => Promise.resolve()
               }
             };
 
@@ -1008,7 +990,7 @@ describe("route matching/response generation", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            match: { response: spy }
+            response: spy
           };
 
           const history = InMemory({ locations: ["/hello?one=two"] });
@@ -1034,7 +1016,7 @@ describe("route matching/response generation", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            match: { response: spy }
+            response: spy
           };
 
           const history = InMemory({ locations: ["/hello?one=two"] });
@@ -1052,7 +1034,7 @@ describe("route matching/response generation", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            match: { response: spy }
+            response: spy
           };
 
           const history = InMemory({ locations: ["/hello?one=two"] });
@@ -1064,10 +1046,8 @@ describe("route matching/response generation", () => {
             {
               name: "Old",
               path: "old/:id",
-              match: {
-                response: ({ route, set, addons }) => {
-                  set.redirect({ name: "New", params: route.params });
-                }
+              response: ({ route, set, addons }) => {
+                set.redirect({ name: "New", params: route.params });
               }
             },
             {

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -138,8 +138,8 @@ describe("route matching/response generation", () => {
         {
           name: "Contact",
           path: "contact",
-          response: ({ load }) => {
-            expect(load.error).toBe("This is an error");
+          response: ({ resolved }) => {
+            expect(resolved.error).toBe("This is an error");
             done();
           },
           on: {
@@ -791,13 +791,13 @@ describe("route matching/response generation", () => {
         history.push("/second");
       });
 
-      describe("load", () => {
+      describe("resolved", () => {
         it("is null when route has no on.initial/every functions", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            response: ({ load }) => {
-              expect(load).toBe(null);
+            response: ({ resolved }) => {
+              expect(resolved).toBe(null);
             }
           };
 
@@ -809,10 +809,10 @@ describe("route matching/response generation", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            response: ({ load }) => {
-              expect(load).toHaveProperty("error");
-              expect(load).toHaveProperty("initial");
-              expect(load).toHaveProperty("every");
+            response: ({ resolved }) => {
+              expect(resolved).toHaveProperty("error");
+              expect(resolved).toHaveProperty("initial");
+              expect(resolved).toHaveProperty("every");
             },
             on: {
               initial: () => Promise.resolve(1)
@@ -825,8 +825,8 @@ describe("route matching/response generation", () => {
 
         describe("error", () => {
           it("receives the error rejected by on.initial()", done => {
-            const spy = jest.fn(({ load }) => {
-              expect(load.error).toBe("rejected by initial");
+            const spy = jest.fn(({ resolved }) => {
+              expect(resolved.error).toBe("rejected by initial");
               done();
             });
 
@@ -844,8 +844,8 @@ describe("route matching/response generation", () => {
           });
 
           it("receives the error rejected by on.every()", done => {
-            const spy = jest.fn(({ load }) => {
-              expect(load.error).toBe("rejected by every");
+            const spy = jest.fn(({ resolved }) => {
+              expect(resolved.error).toBe("rejected by every");
               done();
             });
 
@@ -865,8 +865,8 @@ describe("route matching/response generation", () => {
 
         describe("initial", () => {
           it("is the data resolved by on.initial()", done => {
-            const spy = jest.fn(({ load }) => {
-              expect(load.initial).toMatchObject({ test: "ing" });
+            const spy = jest.fn(({ resolved }) => {
+              expect(resolved.initial).toMatchObject({ test: "ing" });
               done();
             });
 
@@ -891,12 +891,12 @@ describe("route matching/response generation", () => {
               {
                 name: "Test",
                 path: ":test",
-                response: ({ load }) => {
+                response: ({ resolved }) => {
                   if (!hasFinished) {
                     hasFinished = true;
-                    random = load.initial;
+                    random = resolved.initial;
                   } else {
-                    expect(load.initial).toBe(random);
+                    expect(resolved.initial).toBe(random);
                     done();
                   }
                 },
@@ -913,9 +913,9 @@ describe("route matching/response generation", () => {
             });
           });
 
-          it("load.initial is undefined if there is an every fn but no initial fn", done => {
-            const spy = jest.fn(({ load }) => {
-              expect(load.initial).toBeUndefined();
+          it("resolved.initial is undefined if there is an on.every() fn but no on.initial() fn", done => {
+            const spy = jest.fn(({ resolved }) => {
+              expect(resolved.initial).toBeUndefined();
               done();
             });
 
@@ -935,8 +935,8 @@ describe("route matching/response generation", () => {
 
         describe("every", () => {
           it("is the data resolved by on.every()", done => {
-            const spy = jest.fn(({ load }) => {
-              expect(load.every).toMatchObject({ test: "ing" });
+            const spy = jest.fn(({ resolved }) => {
+              expect(resolved.every).toMatchObject({ test: "ing" });
               done();
             });
 
@@ -953,9 +953,9 @@ describe("route matching/response generation", () => {
             const router = curi(history, [CatchAll]);
           });
 
-          it("load.every is undefined if there is an initial fn but no every fn", done => {
+          it("resolved.every is undefined if there is an on.initial() fn but no on.every() fn", done => {
             const spy = jest.fn(opts => {
-              expect(opts.load.every).toBeUndefined();
+              expect(opts.resolved.every).toBeUndefined();
               done();
             });
 

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -138,11 +138,11 @@ describe("route matching/response generation", () => {
         {
           name: "Contact",
           path: "contact",
-          response: ({ async }) => {
-            expect(async.error).toBe("This is an error");
+          response: ({ load }) => {
+            expect(load.error).toBe("This is an error");
             done();
           },
-          async: {
+          on: {
             every: () => {
               return Promise.reject("This is an error");
             }
@@ -681,13 +681,13 @@ describe("route matching/response generation", () => {
     });
   });
 
-  describe("the async functions", () => {
+  describe("the on functions", () => {
     describe("initial", () => {
       it("will only be called once", done => {
         /*
          * This test is a bit odd to read, but it verifies that the
-         * async.initial function is only called once (while the
-         * async.every function is called on every match).
+         * on.initial function is only called once (while the
+         * on.every function is called on every match).
          */
         let initialCount = 0;
         let everyCount = 0;
@@ -698,7 +698,7 @@ describe("route matching/response generation", () => {
           {
             name: "Test",
             path: ":test",
-            async: { initial, every }
+            on: { initial, every }
           }
         ];
         const router = curi(history, routes);
@@ -738,7 +738,7 @@ describe("route matching/response generation", () => {
         const CatchAll = {
           name: "Catch All",
           path: ":anything",
-          async: { every: spy }
+          on: { every: spy }
         };
 
         const history = InMemory({ locations: ["/hello?one=two"] });
@@ -764,7 +764,7 @@ describe("route matching/response generation", () => {
             name: "First",
             path: "first",
             response: responseSpy,
-            async: {
+            on: {
               every: everySpy
             }
           },
@@ -777,7 +777,7 @@ describe("route matching/response generation", () => {
               expect(responseSpy.mock.calls.length).toBe(0);
               done();
             },
-            async: {
+            on: {
               // re-use the every spy so that this route's response
               // fn isn't call until after the first route's every
               // fn has resolved
@@ -791,13 +791,13 @@ describe("route matching/response generation", () => {
         history.push("/second");
       });
 
-      describe("async", () => {
-        it("is null when route has no async.initial/every functions", () => {
+      describe("load", () => {
+        it("is null when route has no on.initial/every functions", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            response: ({ async }) => {
-              expect(async).toBe(null);
+            response: ({ load }) => {
+              expect(load).toBe(null);
             }
           };
 
@@ -809,12 +809,12 @@ describe("route matching/response generation", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            response: ({ async }) => {
-              expect(async).toHaveProperty("error");
-              expect(async).toHaveProperty("initial");
-              expect(async).toHaveProperty("every");
+            response: ({ load }) => {
+              expect(load).toHaveProperty("error");
+              expect(load).toHaveProperty("initial");
+              expect(load).toHaveProperty("every");
             },
-            async: {
+            on: {
               initial: () => Promise.resolve(1)
             }
           };
@@ -824,9 +824,9 @@ describe("route matching/response generation", () => {
         });
 
         describe("error", () => {
-          it("receives the error rejected by async.initial", done => {
-            const spy = jest.fn(({ async }) => {
-              expect(async.error).toBe("rejected by initial");
+          it("receives the error rejected by on.initial()", done => {
+            const spy = jest.fn(({ load }) => {
+              expect(load.error).toBe("rejected by initial");
               done();
             });
 
@@ -834,7 +834,7 @@ describe("route matching/response generation", () => {
               name: "Catch All",
               path: ":anything",
               response: spy,
-              async: {
+              on: {
                 initial: () => Promise.reject("rejected by initial")
               }
             };
@@ -843,9 +843,9 @@ describe("route matching/response generation", () => {
             const router = curi(history, [CatchAll]);
           });
 
-          it("receives the error rejected by async.every", done => {
-            const spy = jest.fn(({ async }) => {
-              expect(async.error).toBe("rejected by every");
+          it("receives the error rejected by on.every()", done => {
+            const spy = jest.fn(({ load }) => {
+              expect(load.error).toBe("rejected by every");
               done();
             });
 
@@ -853,7 +853,7 @@ describe("route matching/response generation", () => {
               name: "Catch All",
               path: ":anything",
               response: spy,
-              async: {
+              on: {
                 every: () => Promise.reject("rejected by every")
               }
             };
@@ -864,9 +864,9 @@ describe("route matching/response generation", () => {
         });
 
         describe("initial", () => {
-          it("is the data resolved by async.initial", done => {
-            const spy = jest.fn(({ async }) => {
-              expect(async.initial).toMatchObject({ test: "ing" });
+          it("is the data resolved by on.initial()", done => {
+            const spy = jest.fn(({ load }) => {
+              expect(load.initial).toMatchObject({ test: "ing" });
               done();
             });
 
@@ -874,7 +874,7 @@ describe("route matching/response generation", () => {
               name: "Catch All",
               path: ":anything",
               response: spy,
-              async: {
+              on: {
                 initial: () => Promise.resolve({ test: "ing" })
               }
             };
@@ -891,16 +891,16 @@ describe("route matching/response generation", () => {
               {
                 name: "Test",
                 path: ":test",
-                response: ({ async }) => {
+                response: ({ load }) => {
                   if (!hasFinished) {
                     hasFinished = true;
-                    random = async.initial;
+                    random = load.initial;
                   } else {
-                    expect(async.initial).toBe(random);
+                    expect(load.initial).toBe(random);
                     done();
                   }
                 },
-                async: {
+                on: {
                   initial: () => {
                     return Promise.resolve(Math.random());
                   }
@@ -913,9 +913,9 @@ describe("route matching/response generation", () => {
             });
           });
 
-          it("async.initial is undefined if there is an every fn but no initial fn", done => {
-            const spy = jest.fn(({ async }) => {
-              expect(async.initial).toBeUndefined();
+          it("load.initial is undefined if there is an every fn but no initial fn", done => {
+            const spy = jest.fn(({ load }) => {
+              expect(load.initial).toBeUndefined();
               done();
             });
 
@@ -923,7 +923,7 @@ describe("route matching/response generation", () => {
               name: "Catch All",
               path: ":anything",
               response: spy,
-              async: {
+              on: {
                 every: () => Promise.resolve()
               }
             };
@@ -934,9 +934,9 @@ describe("route matching/response generation", () => {
         });
 
         describe("every", () => {
-          it("is the data resolved by async.every", done => {
-            const spy = jest.fn(({ async }) => {
-              expect(async.every).toMatchObject({ test: "ing" });
+          it("is the data resolved by on.every()", done => {
+            const spy = jest.fn(({ load }) => {
+              expect(load.every).toMatchObject({ test: "ing" });
               done();
             });
 
@@ -944,7 +944,7 @@ describe("route matching/response generation", () => {
               name: "Catch All",
               path: ":anything",
               response: spy,
-              async: {
+              on: {
                 every: () => Promise.resolve({ test: "ing" })
               }
             };
@@ -953,9 +953,9 @@ describe("route matching/response generation", () => {
             const router = curi(history, [CatchAll]);
           });
 
-          it("async.every is undefined if there is an initial fn but no every fn", done => {
+          it("load.every is undefined if there is an initial fn but no every fn", done => {
             const spy = jest.fn(opts => {
-              expect(opts.async.every).toBeUndefined();
+              expect(opts.load.every).toBeUndefined();
               done();
             });
 
@@ -963,7 +963,7 @@ describe("route matching/response generation", () => {
               name: "Catch All",
               path: ":anything",
               response: spy,
-              async: {
+              on: {
                 initial: () => Promise.resolve()
               }
             };

--- a/packages/core/tests/route.spec.ts
+++ b/packages/core/tests/route.spec.ts
@@ -94,9 +94,9 @@ describe("public route properties", () => {
     });
   });
 
-  describe("async", () => {
+  describe("load", () => {
     describe("initial", () => {
-      it("will be defined when a async.initial function is provided", () => {
+      it("will be defined when a on.initial function is provided", () => {
         const initialTest = () => Promise.resolve();
 
         const history = InMemory({ locations: ["/test"] });
@@ -104,7 +104,7 @@ describe("public route properties", () => {
           {
             name: "Test",
             path: "test",
-            async: {
+            on: {
               initial: initialTest
             }
           }
@@ -113,10 +113,10 @@ describe("public route properties", () => {
           addons: [PropertyReporter()]
         });
         const routeProperties = router.addons.properties("Test");
-        expect(routeProperties.async.initial).toBeDefined();
+        expect(routeProperties.on.initial).toBeDefined();
       });
 
-      it("will be undefined when async.initial fn isn't defined", () => {
+      it("will be undefined when on.initial fn isn't defined", () => {
         const history = InMemory({ locations: ["/test"] });
         const routes = [
           {
@@ -128,12 +128,12 @@ describe("public route properties", () => {
           addons: [PropertyReporter()]
         });
         const routeProperties = router.addons.properties("Test");
-        expect(routeProperties.async.initial).toBeUndefined();
+        expect(routeProperties.on.initial).toBeUndefined();
       });
     });
 
     describe("every", () => {
-      it("will be the provided async.every function", () => {
+      it("will be the provided on.every() function", () => {
         const everyTest = () => Promise.resolve();
 
         const history = InMemory({ locations: ["/test"] });
@@ -141,17 +141,17 @@ describe("public route properties", () => {
           {
             name: "Test",
             path: "test",
-            async: { every: everyTest }
+            on: { every: everyTest }
           }
         ];
         const router = curi(history, routes, {
           addons: [PropertyReporter()]
         });
         const routeProperties = router.addons.properties("Test");
-        expect(routeProperties.async.every).toBe(everyTest);
+        expect(routeProperties.on.every).toBe(everyTest);
       });
 
-      it("will be undefined when async.every isn't defined", () => {
+      it("will be undefined when on.every() isn't defined", () => {
         const history = InMemory({ locations: ["/test"] });
         const routes = [
           {
@@ -163,7 +163,7 @@ describe("public route properties", () => {
           addons: [PropertyReporter()]
         });
         const routeProperties = router.addons.properties("Test");
-        expect(routeProperties.async.every).toBeUndefined();
+        expect(routeProperties.on.every).toBeUndefined();
       });
     });
   });

--- a/packages/core/tests/route.spec.ts
+++ b/packages/core/tests/route.spec.ts
@@ -94,7 +94,7 @@ describe("public route properties", () => {
     });
   });
 
-  describe("load", () => {
+  describe("on", () => {
     describe("initial", () => {
       it("will be defined when a on.initial function is provided", () => {
         const initialTest = () => Promise.resolve();

--- a/packages/core/tests/route.spec.ts
+++ b/packages/core/tests/route.spec.ts
@@ -1,13 +1,13 @@
-import 'jest';
-import createRoute from '../src/route';
-import { Route, Addon } from '../src/types';
-import curi from '../src/curi';
-import InMemory from '@hickory/in-memory';
+import "jest";
+import createRoute from "../src/route";
+import { Route, Addon } from "../src/types";
+import curi from "../src/curi";
+import InMemory from "@hickory/in-memory";
 
 function PropertyReporter(): Addon {
   let knownRoutes = {};
   return {
-    name: 'properties',
+    name: "properties",
     register: (route: Route): void => {
       const { name, path } = route;
       knownRoutes[name] = route;
@@ -27,200 +27,165 @@ function PropertyReporter(): Addon {
   };
 }
 
-describe('public route properties', () => {
-  describe('name', () => {
-    it('is the provided value', () => {
-      const history = InMemory({ locations: ['/test'] });
+describe("public route properties", () => {
+  describe("name", () => {
+    it("is the provided value", () => {
+      const history = InMemory({ locations: ["/test"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'test'
+          name: "Test",
+          path: "test"
         }
       ];
       const router = curi(history, routes, {
         addons: [PropertyReporter()]
       });
-      const routeProperties = router.addons.properties('Test');
-      expect(routeProperties.name).toBe('Test');
+      const routeProperties = router.addons.properties("Test");
+      expect(routeProperties.name).toBe("Test");
     });
   });
 
-  describe('path', () => {
-    it('is the provided value', () => {
-      const history = InMemory({ locations: ['/test'] });
+  describe("path", () => {
+    it("is the provided value", () => {
+      const history = InMemory({ locations: ["/test"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'test'
+          name: "Test",
+          path: "test"
         }
       ];
       const router = curi(history, routes, {
         addons: [PropertyReporter()]
       });
-      const routeProperties = router.addons.properties('Test');
-      expect(routeProperties.path).toBe('test');
+      const routeProperties = router.addons.properties("Test");
+      expect(routeProperties.path).toBe("test");
     });
   });
 
-  describe('keys', () => {
-    it('is the array of param names parsed from the path', () => {
-      const history = InMemory({ locations: ['/test'] });
+  describe("keys", () => {
+    it("is the array of param names parsed from the path", () => {
+      const history = InMemory({ locations: ["/test"] });
       const routes = [
         {
-          name: 'Test',
-          path: ':one/:two/:three'
+          name: "Test",
+          path: ":one/:two/:three"
         }
       ];
       const router = curi(history, routes, {
         addons: [PropertyReporter()]
       });
-      const routeProperties = router.addons.properties('Test');
-      expect(routeProperties.keys).toEqual(['one', 'two', 'three']);
+      const routeProperties = router.addons.properties("Test");
+      expect(routeProperties.keys).toEqual(["one", "two", "three"]);
     });
 
-    it('is an empty array when the path has no params', () => {
-      const history = InMemory({ locations: ['/test'] });
+    it("is an empty array when the path has no params", () => {
+      const history = InMemory({ locations: ["/test"] });
       const routes = [
         {
-          name: 'Test',
-          path: 'one/two/three'
+          name: "Test",
+          path: "one/two/three"
         }
       ];
       const router = curi(history, routes, {
         addons: [PropertyReporter()]
       });
-      const routeProperties = router.addons.properties('Test');
+      const routeProperties = router.addons.properties("Test");
       expect(routeProperties.keys).toEqual([]);
     });
   });
 
-  describe('match', () => {
-    describe('initial', () => {
-      it('will be defined when a match.initial function is provided', () => {
-        const matchTest = () => Promise.resolve();
+  describe("async", () => {
+    describe("initial", () => {
+      it("will be defined when a async.initial function is provided", () => {
+        const initialTest = () => Promise.resolve();
 
-        const history = InMemory({ locations: ['/test'] });
+        const history = InMemory({ locations: ["/test"] });
         const routes = [
           {
-            name: 'Test',
-            path: 'test',
-            match: {
-              initial: matchTest
+            name: "Test",
+            path: "test",
+            async: {
+              initial: initialTest
             }
           }
         ];
         const router = curi(history, routes, {
           addons: [PropertyReporter()]
         });
-        const routeProperties = router.addons.properties('Test');
-        expect(routeProperties.match.initial).toBeDefined();
+        const routeProperties = router.addons.properties("Test");
+        expect(routeProperties.async.initial).toBeDefined();
       });
 
-      it("will be undefined when match.initial fn isn't defined", () => {
-        const history = InMemory({ locations: ['/test'] });
+      it("will be undefined when async.initial fn isn't defined", () => {
+        const history = InMemory({ locations: ["/test"] });
         const routes = [
           {
-            name: 'Test',
-            path: 'test'
+            name: "Test",
+            path: "test"
           }
         ];
         const router = curi(history, routes, {
           addons: [PropertyReporter()]
         });
-        const routeProperties = router.addons.properties('Test');
-        expect(routeProperties.match.initial).toBeUndefined();
-      });
-    });
-
-    describe('every', () => {
-      it('will be the provided match.every function', () => {
-        const matchTest = () => Promise.resolve();
-
-        const history = InMemory({ locations: ['/test'] });
-        const routes = [
-          {
-            name: 'Test',
-            path: 'test',
-            match: { every: matchTest }
-          }
-        ];
-        const router = curi(history, routes, {
-          addons: [PropertyReporter()]
-        });
-        const routeProperties = router.addons.properties('Test');
-        expect(routeProperties.match.every).toBe(matchTest);
-      });
-
-      it("will be undefined when match.every isn't defined", () => {
-        const history = InMemory({ locations: ['/test'] });
-        const routes = [
-          {
-            name: 'Test',
-            path: 'test'
-          }
-        ];
-        const router = curi(history, routes, {
-          addons: [PropertyReporter()]
-        });
-        const routeProperties = router.addons.properties('Test');
-        expect(routeProperties.match.every).toBeUndefined();
+        const routeProperties = router.addons.properties("Test");
+        expect(routeProperties.async.initial).toBeUndefined();
       });
     });
 
-    describe('response', () => {
-      it('will be the provided match.response function', () => {
-        const matchTest = () => Promise.resolve();
+    describe("every", () => {
+      it("will be the provided async.every function", () => {
+        const everyTest = () => Promise.resolve();
 
-        const history = InMemory({ locations: ['/test'] });
+        const history = InMemory({ locations: ["/test"] });
         const routes = [
           {
-            name: 'Test',
-            path: 'test',
-            match: { response: matchTest }
+            name: "Test",
+            path: "test",
+            async: { every: everyTest }
           }
         ];
         const router = curi(history, routes, {
           addons: [PropertyReporter()]
         });
-        const routeProperties = router.addons.properties('Test');
-        expect(routeProperties.match.response).toBe(matchTest);
+        const routeProperties = router.addons.properties("Test");
+        expect(routeProperties.async.every).toBe(everyTest);
       });
 
-      it("will be undefined when match.response isn't defined", () => {
-        const history = InMemory({ locations: ['/test'] });
+      it("will be undefined when async.every isn't defined", () => {
+        const history = InMemory({ locations: ["/test"] });
         const routes = [
           {
-            name: 'Test',
-            path: 'test'
+            name: "Test",
+            path: "test"
           }
         ];
         const router = curi(history, routes, {
           addons: [PropertyReporter()]
         });
-        const routeProperties = router.addons.properties('Test');
-        expect(routeProperties.match.response).toBeUndefined();
+        const routeProperties = router.addons.properties("Test");
+        expect(routeProperties.async.every).toBeUndefined();
       });
     });
   });
 
-  describe('extra', () => {
-    it('is the provided value', () => {
-      const history = InMemory({ locations: ['/test'] });
+  describe("extra", () => {
+    it("is the provided value", () => {
+      const history = InMemory({ locations: ["/test"] });
       const extra = {
         unofficial: true,
         another: 1
       };
       const routes = [
         {
-          name: 'Test',
-          path: 'test',
+          name: "Test",
+          path: "test",
           extra
         }
       ];
       const router = curi(history, routes, {
         addons: [PropertyReporter()]
       });
-      const routeProperties = router.addons.properties('Test');
+      const routeProperties = router.addons.properties("Test");
       expect(routeProperties.extra).toBe(extra);
     });
   });

--- a/packages/core/types/types/response.d.ts
+++ b/packages/core/types/types/response.d.ts
@@ -19,13 +19,13 @@ export interface Response {
     error?: any;
     redirectTo?: ToArgument;
 }
-export interface ResolvedObject {
+export interface AsyncResults {
+    error: any;
     initial: any;
     every: any;
 }
 export interface PendingResponse {
-    error?: any;
-    resolved?: ResolvedObject;
+    async?: AsyncResults;
     route: InternalRoute;
     response: Response;
 }

--- a/packages/core/types/types/response.d.ts
+++ b/packages/core/types/types/response.d.ts
@@ -19,13 +19,13 @@ export interface Response {
     error?: any;
     redirectTo?: ToArgument;
 }
-export interface LoadResults {
+export interface Resolved {
     error: any;
     initial: any;
     every: any;
 }
 export interface PendingResponse {
-    load?: LoadResults;
+    resolved: Resolved;
     route: InternalRoute;
     response: Response;
 }

--- a/packages/core/types/types/response.d.ts
+++ b/packages/core/types/types/response.d.ts
@@ -19,13 +19,13 @@ export interface Response {
     error?: any;
     redirectTo?: ToArgument;
 }
-export interface AsyncResults {
+export interface LoadResults {
     error: any;
     initial: any;
     every: any;
 }
 export interface PendingResponse {
-    async?: AsyncResults;
+    load?: LoadResults;
     route: InternalRoute;
     response: Response;
 }

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,6 +1,6 @@
 import { RegExpOptions, Key } from "path-to-regexp";
 import { LocationDetails } from "@hickory/root";
-import { Params, Response } from "./response";
+import { Params, Response, AsyncResults } from "./response";
 import { Addons } from "./addon";
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
@@ -25,8 +25,7 @@ export interface ResponseSetters {
     title: (title: string) => void;
 }
 export interface ResponseBuilder {
-    error: any;
-    resolved: any;
+    async: AsyncResults;
     route: RouteProps;
     set: ResponseSetters;
     addons: Addons;

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -32,11 +32,10 @@ export interface ResponseBuilder {
 }
 export declare type EveryMatchFn = (route?: RouteProps) => Promise<any>;
 export declare type InitialMatchFn = () => Promise<any>;
-export declare type ResponseMatchFn = (props: ResponseBuilder) => void;
-export interface MatchFns {
+export declare type ResponseFn = (props: ResponseBuilder) => void;
+export interface AsyncFns {
     initial?: InitialMatchFn;
     every?: EveryMatchFn;
-    response?: ResponseMatchFn;
 }
 export interface RouteDescriptor {
     name: string;
@@ -44,7 +43,8 @@ export interface RouteDescriptor {
     pathOptions?: RegExpOptions;
     params?: ParamParsers;
     children?: Array<RouteDescriptor>;
-    match?: MatchFns;
+    response?: ResponseFn;
+    async?: AsyncFns;
     extra?: {
         [key: string]: any;
     };
@@ -53,7 +53,7 @@ export interface Route {
     name: string;
     path: string;
     keys: Array<string | number>;
-    match: MatchFns;
+    async: AsyncFns;
     extra: {
         [key: string]: any;
     };
@@ -66,6 +66,7 @@ export interface InternalMatch {
 export interface InternalRoute {
     public: Route;
     children: Array<InternalRoute>;
+    response: ResponseFn;
     pathMatching: InternalMatch;
     paramParsers: ParamParsers;
 }

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,6 +1,6 @@
 import { RegExpOptions, Key } from "path-to-regexp";
 import { LocationDetails } from "@hickory/root";
-import { Params, Response, LoadResults } from "./response";
+import { Params, Response, Resolved } from "./response";
 import { Addons } from "./addon";
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
@@ -25,7 +25,7 @@ export interface ResponseSetters {
     title: (title: string) => void;
 }
 export interface ResponseBuilder {
-    load: LoadResults;
+    resolved: Resolved;
     route: RouteProps;
     set: ResponseSetters;
     addons: Addons;

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,6 +1,6 @@
 import { RegExpOptions, Key } from "path-to-regexp";
 import { LocationDetails } from "@hickory/root";
-import { Params, Response, AsyncResults } from "./response";
+import { Params, Response, LoadResults } from "./response";
 import { Addons } from "./addon";
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
@@ -25,7 +25,7 @@ export interface ResponseSetters {
     title: (title: string) => void;
 }
 export interface ResponseBuilder {
-    async: AsyncResults;
+    load: LoadResults;
     route: RouteProps;
     set: ResponseSetters;
     addons: Addons;
@@ -33,7 +33,7 @@ export interface ResponseBuilder {
 export declare type EveryMatchFn = (route?: RouteProps) => Promise<any>;
 export declare type InitialMatchFn = () => Promise<any>;
 export declare type ResponseFn = (props: ResponseBuilder) => void;
-export interface AsyncFns {
+export interface OnFns {
     initial?: InitialMatchFn;
     every?: EveryMatchFn;
 }
@@ -44,7 +44,7 @@ export interface RouteDescriptor {
     params?: ParamParsers;
     children?: Array<RouteDescriptor>;
     response?: ResponseFn;
-    async?: AsyncFns;
+    on?: OnFns;
     extra?: {
         [key: string]: any;
     };
@@ -53,7 +53,7 @@ export interface Route {
     name: string;
     path: string;
     keys: Array<string | number>;
-    async: AsyncFns;
+    on: OnFns;
     extra: {
         [key: string]: any;
     };


### PR DESCRIPTION
I was never completely satisfied with the Match API setup. This does a few things:

1. Moves `response()` to the top level of a route.
2. Groups `initial()` and `every()` in an `on` object.
3. `response()` receives a `resolved` object with `error`, `initial`, and `every` properties instead of an `error` and `resolved` properties.

```js
// old
{
  name: "Async Route",
  path: "async/:id",
  match: {
    response({ error, resolved }) {
      if (error) {
        // ...
      } else {
        // do something with resolved data
      }
    },
    initial() {...},
    every() {...}
  }
}

// new
{
  name: "Async Route",
  path: "async/:id",
  response({ resolved }) {
      if (resolved.error) {
        // ...
      } else {
        // do something with resolved data
      }
  },
  on: {
    initial() {...},
    every() {...}
  }
}
```