### PR TITLE
route.response() returns an object to modify the response

### DIFF
--- a/documentation-website/src/client/pages/Examples/react/Authentication.js
+++ b/documentation-website/src/client/pages/Examples/react/Authentication.js
@@ -29,9 +29,12 @@ export default ({ name }) => (
   {
     name: 'Protected',
     path: 'super-secret',
-    response: ({ set }) => {
+    response: () => {
       if (!store.userIsAuthenticated) {
-        set.redirect({ name: 'Login', status: 302 });
+        return {
+          redirectTo: { name: "Login" },
+          status: 302
+        };
       }
     }
   },

--- a/documentation-website/src/client/pages/Examples/react/MultiBody.js
+++ b/documentation-website/src/client/pages/Examples/react/MultiBody.js
@@ -21,11 +21,13 @@ export default ({ name }) => (
         {`const routes = [
   {
     ...,
-    response({ set }) {
-      set.body({
-        main: MainComponent,
-        menu: MenuComponent
-      });
+    response() {
+      return {
+        body: {
+          main: MainComponent,
+          menu: MenuComponent
+        }
+      };
     }
   }
 ];`}
@@ -41,14 +43,18 @@ export default ({ name }) => (
 const routes = [
   {
     ...,
-    response({ set }) {
-      set.body(OneLayout);
+    response() {
+      return {
+        body: OneLayout
+      };
     }
   },
   {
     ...,
-    response({ set }) {
-      set.body({ another: Layout });
+    response() {
+      return {
+        body: { another: Layout }
+      };
     }
   }
 ];`}

--- a/documentation-website/src/client/pages/Examples/vue/Authentication.js
+++ b/documentation-website/src/client/pages/Examples/vue/Authentication.js
@@ -29,9 +29,12 @@ export default ({ name }) => (
   {
     name: 'Protected',
     path: 'super-secret',
-    response: ({ set }) => {
+    response: () => {
       if (!store.userIsAuthenticated) {
-        set.redirect({ name: 'Login', status: 302 });
+        return {
+          name: "Login",
+          status: 302
+        };
       }
     }
   },

--- a/documentation-website/src/client/pages/Guides/CodeSplitting.js
+++ b/documentation-website/src/client/pages/Guides/CodeSplitting.js
@@ -38,22 +38,28 @@ const routes = [
   {
     name: 'Home',
     path: '',
-    response: ({ set }) => {
-      set.body(Home);
+    response: () => {
+      return {
+        body: Home
+      };
     }
   },
   {
     name: 'Contact',
     path: 'contact',
-    response: ({ set }) => {
-      set.body(Contact);
+    response: () => {
+      return {
+        body: Contact
+      };
     },
     children: [
       {
         name: 'Contact Method',
         path: ':method',
-        response: ({ set }) => {
-          set.body(ContactMethod);
+        response: () => {
+          return {
+            body: ContactMethod
+          };
         }
       }
     ]
@@ -90,8 +96,10 @@ const routes = [
   {
     name: 'Home',
     path: '',
-    response: ({ resolved, set }) => {
-      set.body(resolved.initial.default);
+    response: ({ resolved }) => {
+      return {
+        body: resolved.initial.default
+      };
     },
     on: {
       initial: () => import('./components/Home'),
@@ -100,8 +108,10 @@ const routes = [
   {
     name: 'Contact',
     path: 'contact',
-    response: ({ resolved, set }) => {
-      set.body(resolved.initial.default);
+    response: ({ resolved }) => {
+      return {
+        body: resolved.initial.default
+      };
     },
     on: {
       initial: () => import('./components/Contact'),
@@ -110,8 +120,10 @@ const routes = [
       {
         name: 'Contact Method',
         path: ':method',
-        response: ({ resolved, set }) => {
-          set.body(resolved.initial);
+        response: ({ resolved }) => {
+          return {
+            body: resolved.initial.default
+          };
         },
         on: {
           // we can resolve module.default in initial

--- a/documentation-website/src/client/pages/Guides/GettingStarted.js
+++ b/documentation-website/src/client/pages/Guides/GettingStarted.js
@@ -162,10 +162,12 @@ const routes = [
   {
     name: 'Home',
     path: '',
-    response({ set }) {
+    response() {
       // set response.body to be the imported
       // Home component
-      set.body(Home);
+      return {
+        body: Home
+      };
     }
   }
 ];

--- a/documentation-website/src/client/pages/Guides/Loading.js
+++ b/documentation-website/src/client/pages/Guides/Loading.js
@@ -96,23 +96,24 @@ export default ({ name }) => (
         >
           All About Routes
         </Link>{" "}
-        guide.
+        guide. The function returns an object with values that will modify the
+        response.
       </p>
 
       <p>
-        Here, we will be using the <IJS>resolved</IJS> and <IJS>set</IJS>{" "}
-        properties. We will use <IJS>set.data</IJS> to attach the data loaded
-        from our API to our response. Calling <IJS>set.data</IJS> will set the{" "}
-        <IJS>data</IJS> property of the response object.
+        Here, we will be using the <IJS>resolved</IJS> object to modify the
+        response's <IJS>data</IJS>
       </p>
 
       <PrismBlock lang="javascript">
         {`{
   name: 'Recipe',
   path: 'recipe/:id',
-  response({ set, resolved }) {                                                                                                                                   : ({ resolved, set }) => {
-    set.data(resolved);
-    set.body(Recipe);
+  response({ resolved }) {
+    return {
+      body: Recipe,
+      data: resolved.every
+    }
   },
   on: {
     every: ({ params }) => fakeAPI.getRecipe(params.id),
@@ -127,22 +128,27 @@ export default ({ name }) => (
       </p>
 
       <p>
-        By calling the <IJS>set.redirect</IJS> method, you can specify the route
-        that we should redirect to.
+        You can specify the route to redirect to with <IJS>redirectTo</IJS>.
+        This takes the <IJS>name</IJS> of the route to redirect to,{" "}
+        <IJS>params</IJS> if the route (or ancestor routes) have route params.{" "}
+        <IJS>hash</IJS>, <IJS>query</IJS>, and <IJS>state</IJS> can also be
+        provided.
       </p>
 
       <PrismBlock lang="javascript">
         {`{
   name: 'Old Recipe',
   path: 'r/:id',
-  response: ({ route, set }) => {
+  response: ({ params }) => {
     // destructure the current location to preserve
     // query/hash values
-    set.redirect({
-      name: 'Recipe',
-      params: route.params,
-      ...route.location
-    });
+    return {
+      redirectTo: {
+        name: 'Recipe',
+        params: params,
+        hash: location.hash
+      }
+    };
   }
 }`}
       </PrismBlock>

--- a/documentation-website/src/client/pages/Guides/MigrateReactRouterv3.js
+++ b/documentation-website/src/client/pages/Guides/MigrateReactRouterv3.js
@@ -134,33 +134,37 @@ export default ({ name }) => (
           (assuming we actually need it).
         </p>
         <p>
-          With Curi routes, we have a <IJS>response()</IJS> function.{" "}
-          <IJS>response()</IJS> is passed an object with properties to help
-          modify the response object that our application will receive. One of
-          these is a <IJS>set</IJS> object that is used to set properties of the
-          response. <IJS>set.body()</IJS> sets the <IJS>body</IJS> property of
-          the response. For this React application, we want our <IJS>body</IJS>{" "}
-          property to be the React component associated with each route.
+          With Curi routes, we have a <IJS>response()</IJS> function. The object
+          returned by <IJS>response()</IJS> is used to modify the response that
+          the application will use to render. For this React application, we
+          want our <IJS>body</IJS> property to be the React component associated
+          with each route.
         </p>
 
         <PrismBlock lang="javascript">
           {`const routes = [
   {
     path: '',
-    response: ({ set }) => {
-      set.body(Home);
+    response: () => {
+      return {
+        body: Home
+      };
     }
   },
   {
     path: 'inbox',
-    response: ({ set }) => {
-      set.body(Inbox);
+    response: () => {
+      return {
+        body: Inbox
+      };
     },
     children: [
       {
         path: ':message',
-        response: ({ set }) => {
-          set.body(Message);
+        response: () => {
+          return {
+            body: Message
+          };
         }
       }
     ]
@@ -202,20 +206,26 @@ export default ({ name }) => (
           {`const routes = [
   {
     path: '',
-    response: ({ set }) => {
-      set.body(Home);
+    response: () => {
+      return {
+        body: Home
+      };
     }
   },
   {
     path: 'inbox',
-    response: ({ set }) => {
-      set.body(Inbox);
+    response: () => {
+      return {
+        body: Inbox
+      };
     },
     children: [
       {
         path: ':message',
-        response: ({ set }) => {
-          set.body(Message);
+        response: () => {
+          return {
+            body: Message
+          };
         },
         on: {
           every: (route) => { return ... },
@@ -245,22 +255,28 @@ export default ({ name }) => (
   {
     name: 'Home',
     path: '',
-    response: ({ set }) => {
-      set.body(Home);
+    response: () => {
+      return {
+        body: Home
+      };
     }
   },
   {
     name: 'Inbox',
     path: 'inbox',
-    response: ({ set }) => {
-      set.body(Inbox);
+    response: () => {
+      return {
+        body: Inbox
+      };
     },
     children: [
       {
         name: 'Message',
         path: ':message',
-        response: ({ set }) => {
-          set.body(Message);
+        response: () => {
+          return {
+            body: Message
+          };
         },
         on: {
           every: (route) => { return ... },

--- a/documentation-website/src/client/pages/Guides/ReactBasics.js
+++ b/documentation-website/src/client/pages/Guides/ReactBasics.js
@@ -87,8 +87,10 @@ const routes = [
   {
     name: 'Home',
     path: '',
-    response: ({ set }) => {
-      set.body(Home);
+    response: () => {
+      return {
+        body: Home
+      };
     }
   },
   ...
@@ -121,8 +123,10 @@ const routes = [
   {
     name: 'Not Found',
     path: '(.*)' // this path matches EVERY pathname
-    response({ set }) {
-      set.body(NotFound);
+    response: () => {
+      return {
+        body: NotFound
+      };
     }
   }
 ];`}

--- a/documentation-website/src/client/pages/Guides/Responses.js
+++ b/documentation-website/src/client/pages/Guides/Responses.js
@@ -12,15 +12,15 @@ export default ({ name }) => (
     <p>
       Response objects are created by the router to descibe the route that
       matches a location. Some of these properties are set automatically, while
-      others can be configured using the <IJS>set</IJS> functions in a route's{" "}
-      <IJS>response()</IJS> method.
+      others can be modified using the object returned a route's{" "}
+      <IJS>response()</IJS> function.
     </p>
     <Note>
-      You can review the <IJS>set</IJS> functions in the{" "}
+      You can review the response properties that can be modified in the{" "}
       <Link
         to="Guide"
         params={{ slug: "routes" }}
-        details={{ hash: "response-set" }}
+        details={{ hash: "response" }}
       >
         routes guide
       </Link>.
@@ -50,23 +50,22 @@ export default ({ name }) => (
   params: { photoID: 12345, albumID: 6789 },
 
   // The status code for the response.
-  // This defaults to 200, but is 404 if no routes match.
-  // It can also be set with set.status() and set.redirect()
-  // in a route's response() method.
+  // This defaults to 200.
+  // It can also be set with a route's response() return object
   status: 200,
 
   // This can be anything you want. It is set using
-  // the set.data() in a route's response() method.
+  // a route's response() return object.
   // The default value is undefined.
   data: {...},
 
-  // The title string is set by calling set.title() in
-  // response(). The default value is an empty string.
+  // The title string is set using a route's response() return object
+  // The default value is an empty string.
   title: 'Photo 12345',
 
-  // The value set using set.body. This is where you can attach
-  // component(s) to a route. The structure here is up to
-  // you, but each of your routes should have the same structure.
+  // The body value is set using a route's response() return object.
+  // This is where you can attach component(s) to a route. The structure here
+  // is up to you, but each of your routes should have the same structure.
   body: Photo,
   // or maybe
   body: {
@@ -75,24 +74,24 @@ export default ({ name }) => (
   },
   // Please see below for more information about this property
 
-  // A value set by the response()'s set.error() function
+  // A value set by the route's response() return object.
+  // defaults to undefined
   error: undefined
 }`}
       </PrismBlock>
 
       <Subsection title="Redirect Response" id="redirect-properties">
         <p>
-          When you call{" "}
+          When <IJS>route.response()</IJS> returns an object with a{" "}
           <Link
             to="Guide"
             params={{ slug: "routes" }}
-            details={{ hash: "response-set" }}
+            details={{ hash: "response" }}
           >
-            <IJS>set.redirect()</IJS>
+            <IJS>redirectTo</IJS> property
           </Link>{" "}
-          in <IJS>response()</IJS>, the response will have a{" "}
-          <IJS>redirectTo</IJS> property. Curi will automatically trigger a
-          redirect when it sees this.
+          the response's <IJS>redirectTo</IJS> will be a location object. Curi
+          will automatically redirect the location when it sees this.
         </p>
         <PrismBlock lang="javascript">
           {`{
@@ -120,14 +119,13 @@ export default ({ name }) => (
       <p>
         The body property of a response is likely the most important property of
         a <IJS>response</IJS> because it is what you will actually render. It is
-        the value set by the matched route's <IJS>response()</IJS> function,
-        using{" "}
+        set using the object returned from the matched route's
         <Link
           to="Guide"
           params={{ slug: "routes" }}
-          details={{ hash: "response-set" }}
+          details={{ hash: "response" }}
         >
-          <IJS>set.body()</IJS>
+          <IJS>response()</IJS> function
         </Link>. This value can be anything you want it to be, but it should
         usually be a function/component or an object containing
         functions/components.
@@ -136,15 +134,19 @@ export default ({ name }) => (
         {`{
   name: "Home",
   path: "",
-  response: ({ set }) => {
+  response: () => {
     // a function/component
-    set.body(Home);
+    return {
+      body: Home
+    };
     // an object containing
     // functions/componnets
-    set.body({
-      menu: HomeMenu,
-      body: Home
-    });
+    return {
+      body: {
+        menu: HomeMenu,
+        main: Home
+      }
+    };
   }
 }`}
       </PrismBlock>

--- a/documentation-website/src/client/pages/Packages/Core.js
+++ b/documentation-website/src/client/pages/Packages/Core.js
@@ -160,12 +160,14 @@ const router = curi(history, routes, {
   {
     name: "Old",
     path: "old/:id",
-    response({ set, params }) {
+    response({ params }) {
       // setup a redirect to the "New" route
-      set.redirect({
-        name: "New",
-        params
-      });
+      return {
+        redirectTo: {
+          name: "New",
+          params
+        }
+      };
     }
   },
   {

--- a/documentation-website/src/client/pages/Packages/SideEffectTitle.js
+++ b/documentation-website/src/client/pages/Packages/SideEffectTitle.js
@@ -40,13 +40,13 @@ const router = curi(history, routes, {
         </PrismBlock>
 
         <p>
-          In order for this to work, you will need to use <IJS>set.title()</IJS>{" "}
-          in your routes' <IJS>response()</IJS> functions. You can learn more
-          about <IJS>route.title</IJS> in the{" "}
+          In order for this to work, your routes' <IJS>route.response()</IJS>{" "}
+          functions need to return an object with a <IJS>title</IJS> string.
+          about setting a title in the{" "}
           <Link
             to="Guide"
             params={{ slug: "routes" }}
-            details={{ hash: "response-set" }}
+            details={{ hash: "response" }}
           >
             all about routes
           </Link>{" "}

--- a/documentation-website/src/client/pages/Tutorials/ReactBasics.js
+++ b/documentation-website/src/client/pages/Tutorials/ReactBasics.js
@@ -378,19 +378,21 @@ registerServiceWorker();`}
       </p>
       <p>
         Earlier it was mentioned that response objects can be modified. This is
-        done in a route's <IJS>response()</IJS> function. <IJS>response()</IJS>{" "}
-        receives an object with a whole bunch of properties that we can use to
-        modify the response. For the time being, we only care about one:{" "}
-        <IJS>set</IJS>. This is an object with functions that actually modify
-        the response. <IJS>set.body()</IJS> will set the <IJS>body</IJS>{" "}
-        property of the response object.
+        done by returning an object from a route's <IJS>response()</IJS>{" "}
+        function. <IJS>response()</IJS> receives an object with a whole bunch of
+        properties that we can use to help determine how to modify the response,
+        but for the time being, we don't care about any of those. All we need to
+        know is that if we return an object with a <IJS>body</IJS> property,
+        that value will be set on our response object.
       </p>
       <PrismBlock lang="javascript">
         {`{
   name: "Home",
   path: "",
-  response({ set }) {
-    set.body('Home, sweet home.');
+  response() {
+    return {
+      body: "Home, sweet home."
+    };
     /*
       * response = {
       *   body: "Home, sweet home.",
@@ -401,8 +403,8 @@ registerServiceWorker();`}
 }`}
       </PrismBlock>
       <p>
-        If we pass React components to <IJS>set.body()</IJS>, we can render
-        those in the <Cmp>CuriProvider</Cmp>'s children function. We haven't
+        If the return object's <IJS>body</IJS> is a React component, we can
+        render it in the <Cmp>CuriProvider</Cmp>'s children function. We haven't
         actually defined components for our routes yet, so we should throw
         together some placeholders.
       </p>
@@ -458,29 +460,37 @@ export default [
   {
     name: "Home",
     path: "",
-    response({ set }) {
-      set.body(Home);
+    response() {
+      return {
+        body: Home
+      };
     }
   },
   {
     name: "Book",
     path: "book/:id",
-    response({ set }) {
-      set.body(Book);
+    response() {
+      return {
+        body: Book
+      };
     }
   },
   {
     name: "Checkout",
     path: "checkout",
-    response({ set }) {
-      set.body(Checkout);
+    response() {
+      return {
+        body: Checkout
+      };
     }
   },
   {
     name: "Catch All",
     path: "(.*)",
-    response({ set }) {
-      set.body(NotFound);
+    response() {
+      return {
+        body: NotFound
+      };
     }
   }
 ];`}

--- a/documentation-website/src/client/pages/Tutorials/VueBasics.js
+++ b/documentation-website/src/client/pages/Tutorials/VueBasics.js
@@ -400,19 +400,21 @@ new Vue({
       </p>
       <p>
         Earlier it was mentioned that response objects can be modified. This is
-        done in a route's <IJS>response()</IJS> function. <IJS>response()</IJS>{" "}
-        receives an object with a whole bunch of properties that we can use to
-        modify the response. For the time being, we only care about one:{" "}
-        <IJS>set</IJS>. This is an object with functions that actually modify
-        the response. <IJS>set.body()</IJS> will set the <IJS>body</IJS>{" "}
-        property of the response object.
+        done by returning an object from a route's <IJS>response()</IJS>{" "}
+        function. <IJS>response()</IJS> receives an object with a whole bunch of
+        properties that we can use to help determine how to modify the response,
+        but for the time being, we don't care about any of those. All we need to
+        know is that if we return an object with a <IJS>body</IJS> property,
+        that value will be set on our response object.
       </p>
       <PrismBlock lang="javascript">
         {`{
   name: "Home",
   path: "",
-  response({ set }) {
-    set.body('Home, sweet home.');
+  response() {
+    return {
+      body: "Home, sweet home."
+    };
     /*
       * response = {
       *   body: "Home, sweet home.",
@@ -423,8 +425,8 @@ new Vue({
 }`}
       </PrismBlock>
       <p>
-        If we pass Vue components to <IJS>set.body()</IJS>, we can render those
-        using <Cmp>Component :is</Cmp>.
+        If the return object's <IJS>body</IJS> property is a Vue component, we
+        can render it using <Cmp>Component :is</Cmp>.
       </p>
       <p>
         We haven't actually defined components for our routes yet, so we should
@@ -473,29 +475,37 @@ export default [
   {
     name: "Home",
     path: "",
-    response({ set }) {
-      set.body(Home);
+    response() {
+      return {
+        body: Home
+      };
     }
   },
   {
     name: "Book",
     path: "book/:id",
-    response({ set }) {
-      set.body(Book);
+    response() {
+      return {
+        body: Book
+      };
     }
   },
   {
     name: "Checkout",
     path: "checkout",
-    response({ set }) {
-      set.body(Checkout);
+    response() {
+      return {
+        body: Checkout
+      };
     }
   },
   {
     name: "Catch All",
     path: "(.*)",
-    response({ set }) {
-      set.body(NotFound);
+    response() {
+      return {
+        body: NotFound
+      };
     }
   }
 ];`}

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* `route.response()` returns object with properties to update and removes `set` from the properties passed to the function. `redirectTo` will auto-generate the location from the provided `name` and `params` while all of the other properties will be copied directly.
 * Do no emit a response if no routes match. The user should add a catch-all route (`{ path: "(.*)" }`) to handle these themselves.
 * Move `match.response` to top level and group `match.every` and `match.initial` under `on` object (`on.initial` and `on.every`).
 * Group `initial` and `every` resolved values with `error` under `resolved` object.

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -10,13 +10,17 @@ export {
   ParamParser,
   ParamParsers,
   MatchedRouteProps,
-  ResponseSetters,
   ResponseBuilder,
   EveryMatchFn,
   InitialMatchFn,
   OnFns
 } from "./route";
-export { Response, RawParams, Params } from "./response";
+export {
+  Response,
+  RawParams,
+  Params,
+  ModifiableResponseProperties
+} from "./response";
 export {
   CuriRouter,
   RouterOptions,

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -5,6 +5,15 @@ import { InternalRoute } from "./route";
 export type RawParams = { [key: string]: string };
 export type Params = { [key: string]: any };
 
+export interface ModifiableResponseProperties {
+  status?: number;
+  error?: any;
+  body?: any;
+  data?: any;
+  title?: string;
+  redirectTo?: RedirectProps;
+}
+
 export interface GenericResponse {
   location: HickoryLocation;
   key: string;
@@ -25,4 +34,12 @@ export interface Resolved {
   error: any;
   initial: any;
   every: any;
+}
+
+export interface RedirectProps {
+  name: string;
+  params?: Params;
+  hash?: string;
+  query?: any;
+  state?: any;
 }

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -1,7 +1,7 @@
 import { RegExpOptions, Key } from "path-to-regexp";
 
 import { LocationDetails } from "@hickory/root";
-import { Params, Response, Resolved } from "./response";
+import { Params, Response, Resolved, ResponseModifiers } from "./response";
 import { Interactions } from "./interaction";
 
 export type ParamParser = (input: string) => any;
@@ -15,30 +15,14 @@ export interface MatchedRouteProps {
   name: string;
 }
 
-export interface RedirectProps extends LocationDetails {
-  name: string;
-  params?: Params;
-  status?: number;
-}
-
-export interface ResponseSetters {
-  error: (err: any) => void;
-  redirect: (props: RedirectProps) => void;
-  data: (data: any) => void;
-  status: (status: number) => void;
-  body: (body: any) => void;
-  title: (title: string) => void;
-}
-
 export interface ResponseBuilder extends MatchedRouteProps {
   resolved: Resolved | null;
-  set: ResponseSetters;
   route: Interactions;
 }
 
 export type EveryMatchFn = (matched?: MatchedRouteProps) => Promise<any>;
 export type InitialMatchFn = () => Promise<any>;
-export type ResponseFn = (props: ResponseBuilder) => void;
+export type ResponseFn = (props: ResponseBuilder) => ResponseModifiers;
 
 export interface OnFns {
   initial?: InitialMatchFn;

--- a/packages/core/tests/curi.spec.ts
+++ b/packages/core/tests/curi.spec.ts
@@ -253,8 +253,10 @@ describe("curi", () => {
             {
               name: "All",
               path: "(.*)",
-              response: ({ set }) => {
-                set.data(Math.random());
+              response: () => {
+                return {
+                  data: Math.random()
+                };
               }
             }
           ];
@@ -305,8 +307,10 @@ describe("curi", () => {
             {
               name: "All",
               path: "(.*)",
-              response: ({ set }) => {
-                set.data(Math.random());
+              response: () => {
+                return {
+                  data: Math.random()
+                };
               }
             }
           ];
@@ -343,8 +347,12 @@ describe("curi", () => {
             {
               name: "Start",
               path: "",
-              response: ({ set }) => {
-                set.redirect({ name: "Other" });
+              response: () => {
+                return {
+                  redirectTo: {
+                    name: "Other"
+                  }
+                };
               }
             },
             {
@@ -369,8 +377,12 @@ describe("curi", () => {
             {
               name: "Start",
               path: "",
-              response: ({ set }) => {
-                set.redirect({ name: "Other" });
+              response: () => {
+                return {
+                  redirectTo: {
+                    name: "Other"
+                  }
+                };
               }
             },
             {
@@ -916,8 +928,13 @@ describe("curi", () => {
         {
           name: "A Route",
           path: "",
-          response: ({ set }) => {
-            set.redirect({ name: "B Route", status: 301 });
+          response: () => {
+            return {
+              status: 301,
+              redirectTo: {
+                name: "B Route"
+              }
+            };
           }
         },
         {

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -181,7 +181,7 @@ describe("route matching/response generation", () => {
       });
 
       describe("body", () => {
-        it("is undefined if it isn't set in response()", done => {
+        it("defaults to undefined", done => {
           const history = InMemory({ locations: ["/test"] });
           const routes = [
             {
@@ -196,15 +196,17 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is the value set with set.body", done => {
+        it("is the body value of the object returned by route.response()", done => {
           const history = InMemory({ locations: ["/test"] });
           const body = () => "anybody out there?";
           const routes = [
             {
               name: "Test",
               path: "test",
-              response: ({ set }) => {
-                set.body(body);
+              response: () => {
+                return {
+                  body: body
+                };
               }
             }
           ];
@@ -236,13 +238,15 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is the value set by calling status in the matching route's response() function", done => {
+        it("is the status value of object returned by route.response()", done => {
           const routes = [
             {
               name: "A Route",
               path: "",
-              response: ({ set }) => {
-                set.status(451);
+              response: () => {
+                return {
+                  status: 451
+                };
               }
             }
           ];
@@ -251,62 +255,6 @@ describe("route matching/response generation", () => {
           router.respond(({ response }) => {
             expect(response.status).toBe(451);
             done();
-          });
-        });
-
-        it("is set by calling set.redirect() in the matching response()", () => {
-          const routes = [
-            {
-              name: "New",
-              path: "new"
-            },
-            {
-              name: "302 Route",
-              path: "old",
-              response: ({ set }) => {
-                set.redirect({ name: "New", status: 302 });
-              }
-            }
-          ];
-          const history = InMemory({ locations: ["/old"] });
-          let firstCall = true;
-          const logger = ({ response }) => {
-            if (firstCall) {
-              expect(response.status).toBe(302);
-              firstCall = false;
-            }
-          };
-          const router = curi(history, routes, {
-            sideEffects: [{ fn: logger }]
-          });
-        });
-
-        it("is set to 301 by default when calling set.redirect() in response()", () => {
-          const routes = [
-            {
-              name: "New",
-              path: "new"
-            },
-            {
-              name: "301 Route",
-              path: "old",
-              response: ({ set }) => {
-                set.redirect({ name: "New" });
-              }
-            }
-          ];
-          const history = InMemory({ locations: ["/old"] });
-          let firstCall = true;
-          const logger = {
-            fn: ({ response }) => {
-              if (firstCall) {
-                expect(response.status).toBe(301);
-                firstCall = false;
-              }
-            }
-          };
-          const router = curi(history, routes, {
-            sideEffects: [logger]
           });
         });
       });
@@ -327,13 +275,17 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is the value set by calling set.data() in response()", done => {
+        it("is the data value of the object returned by route.response()", done => {
           const routes = [
             {
               name: "A Route",
               path: "",
-              response: ({ set }) => {
-                set.data({ test: "value" });
+              response: () => {
+                return {
+                  data: {
+                    test: "value"
+                  }
+                };
               }
             }
           ];
@@ -363,13 +315,15 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is the value set by calling set.title() in response()", done => {
+        it("is the title value of the object returned by route.response()", done => {
           const routes = [
             {
               name: "State",
               path: ":state",
-              response: ({ set }) => {
-                set.title("A State");
+              response: () => {
+                return {
+                  title: "A State"
+                };
               }
             }
           ];
@@ -578,13 +532,15 @@ describe("route matching/response generation", () => {
           });
         });
 
-        it("is set by calling the set.error() method from a matched route's response() function", done => {
+        it("is the error value on the object returned by route.response()", done => {
           const routes = [
             {
               name: "A Route",
               path: "",
-              response: ({ set }) => {
-                set.error("woops");
+              response: () => {
+                return {
+                  error: "woops"
+                };
               }
             }
           ];
@@ -598,16 +554,17 @@ describe("route matching/response generation", () => {
       });
 
       describe("redirectTo", () => {
-        it("is set by calling set.redirect() in a matching route's response()", () => {
+        it("is the redirectTo value of the object returned by route.response()", () => {
           const routes = [
             {
               name: "A Route",
               path: "",
-              response: ({ set }) => {
-                set.redirect({
-                  name: "B Route",
-                  status: 301
-                });
+              response: () => {
+                return {
+                  redirectTo: {
+                    name: "B Route"
+                  }
+                };
               }
             },
             {
@@ -947,29 +904,6 @@ describe("route matching/response generation", () => {
         });
       });
 
-      describe("set", () => {
-        it("receives the response set functions", () => {
-          const CatchAll = {
-            name: "Catch All",
-            path: ":anything",
-            response: ({ set }) => {
-              expect(set).toMatchObject(
-                expect.objectContaining({
-                  body: expect.any(Function),
-                  data: expect.any(Function),
-                  status: expect.any(Function),
-                  redirect: expect.any(Function),
-                  error: expect.any(Function)
-                })
-              );
-            }
-          };
-
-          const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, [CatchAll]);
-        });
-      });
-
       describe("route", () => {
         it("receives the registered route interactions object", () => {
           const CatchAll = {
@@ -1000,7 +934,7 @@ describe("route matching/response generation", () => {
             {
               name: "Old",
               path: "old/:id",
-              response: ({ route, name, set }) => {
+              response: ({ route, name }) => {
                 expect(route.reverse(name)).toBe("dlO");
               }
             }

--- a/packages/core/types/types/index.d.ts
+++ b/packages/core/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
-export { Route, RouteDescriptor, ParamParser, ParamParsers, MatchedRouteProps, ResponseSetters, ResponseBuilder, EveryMatchFn, InitialMatchFn, OnFns } from "./route";
-export { Response, RawParams, Params } from "./response";
+export { Route, RouteDescriptor, ParamParser, ParamParsers, MatchedRouteProps, ResponseBuilder, EveryMatchFn, InitialMatchFn, OnFns } from "./route";
+export { Response, RawParams, Params, ModifiableResponseProperties } from "./response";
 export { CuriRouter, RouterOptions, ResponseHandler, Emitted, RemoveResponseHandler, SideEffect, Cache, Navigation } from "./curi";

--- a/packages/core/types/types/response.d.ts
+++ b/packages/core/types/types/response.d.ts
@@ -5,6 +5,14 @@ export declare type RawParams = {
 export declare type Params = {
     [key: string]: any;
 };
+export interface ModifiableResponseProperties {
+    status?: number;
+    error?: any;
+    body?: any;
+    data?: any;
+    title?: string;
+    redirectTo?: RedirectProps;
+}
 export interface GenericResponse {
     location: HickoryLocation;
     key: string;
@@ -23,4 +31,11 @@ export interface Resolved {
     error: any;
     initial: any;
     every: any;
+}
+export interface RedirectProps {
+    name: string;
+    params?: Params;
+    hash?: string;
+    query?: any;
+    state?: any;
 }

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,6 +1,5 @@
 import { RegExpOptions, Key } from "path-to-regexp";
-import { LocationDetails } from "@hickory/root";
-import { Params, Resolved } from "./response";
+import { Resolved, ResponseModifiers } from "./response";
 import { Interactions } from "./interaction";
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
@@ -11,27 +10,13 @@ export interface MatchedRouteProps {
     location: object;
     name: string;
 }
-export interface RedirectProps extends LocationDetails {
-    name: string;
-    params?: Params;
-    status?: number;
-}
-export interface ResponseSetters {
-    error: (err: any) => void;
-    redirect: (props: RedirectProps) => void;
-    data: (data: any) => void;
-    status: (status: number) => void;
-    body: (body: any) => void;
-    title: (title: string) => void;
-}
 export interface ResponseBuilder extends MatchedRouteProps {
     resolved: Resolved | null;
-    set: ResponseSetters;
     route: Interactions;
 }
 export declare type EveryMatchFn = (matched?: MatchedRouteProps) => Promise<any>;
 export declare type InitialMatchFn = () => Promise<any>;
-export declare type ResponseFn = (props: ResponseBuilder) => void;
+export declare type ResponseFn = (props: ResponseBuilder) => ResponseModifiers;
 export interface OnFns {
     initial?: InitialMatchFn;
     every?: EveryMatchFn;


### PR DESCRIPTION
The `set` methods were a bit verbose. Instead, Curi will just use an object returned by `response()` to update the response that will be emitted.

```js
// before
response({ set }) {
  set.body(Home);
  set.data("Something or other");
}

// now
response() {
  return {
    body: Home,
    data: "Yadda yadda"
  };
}
```

Any invalid properties will be ignored.

`redirectTo` is transformed. It takes a route's `name` (and `params` if required) and generates a `pathname` which will be set on the response.
```js
response() {
  return {
    redirectTo: "Home"
  };
}
// response = { redirectTo: { pathname: "/" }, ... }
```