### PR TITLE
Side effect fn ->  effect

### DIFF
--- a/documentation-website/src/client/pages/Guides/UsingSideEffects.js
+++ b/documentation-website/src/client/pages/Guides/UsingSideEffects.js
@@ -32,13 +32,13 @@ export default ({ name }) => (
       <p>
         You add side effect functions to your router by adding a{" "}
         <IJS>sideEffects</IJS> array to the options object (the third agument)
-        of <IJS>curi</IJS>. A side effect is an object with an <IJS>fn</IJS>{" "}
+        of <IJS>curi</IJS>. A side effect is an object with an <IJS>effect</IJS>{" "}
         property whose values is a response handler function.
       </p>
 
       <PrismBlock lang="javascript">
         {`const router = curi(history, routes, {
-  sideEffects: [{ fn: logResponse }]
+  sideEffects: [{ effect: logResponse }]
 });`}
       </PrismBlock>
 
@@ -54,7 +54,7 @@ export default ({ name }) => (
 
       <PrismBlock lang="javascript">
         {`const router = curi(history, routes, {
-  sideEffects: [{ fn: logResponse, after: true }]
+  sideEffects: [{ effect: logResponse, after: true }]
 });`}
       </PrismBlock>
 
@@ -93,7 +93,7 @@ export default ({ name }) => (
 }
 
 const router = curi(history, routes, {
-  sideEffects: [{ fn: mySideEffect }]
+  sideEffects: [{ effect: mySideEffect }]
 });`}
       </PrismBlock>
 

--- a/documentation-website/src/client/pages/Packages/SideEffectScroll.js
+++ b/documentation-website/src/client/pages/Packages/SideEffectScroll.js
@@ -48,7 +48,7 @@ import createScrollSideEffect from '@curi/side-effect-scroll';
 const scrollTo = createScrollSideEffect();
 
 const router = curi(history, routes, {
-  sideEffects: [{ fn: scrollTo, after: true }]
+  sideEffects: [{ effect: scrollTo, after: true }]
 });`}
         </PrismBlock>
       </Section>

--- a/documentation-website/src/client/pages/Packages/SideEffectTitle.js
+++ b/documentation-website/src/client/pages/Packages/SideEffectTitle.js
@@ -35,7 +35,7 @@ const setTitle = createTitleSideEffect({
 });
 
 const router = curi(history, routes, {
-  sideEffects: [{ fn: setTitle }]
+  sideEffects: [{ effect: setTitle }]
 });`}
         </PrismBlock>
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Side effect response handlers are registered with `effect` instead of `fn`.
+
 ## 1.0.0-beta.29
 
 * `route.response()` returns object with properties to update and removes `set` from the properties passed to the function. `redirectTo` will auto-generate the location from the provided `name` and `params` while all of the other properties will be copied directly.

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -44,9 +44,9 @@ function createRouter(
   const afterSideEffects: Array<ResponseHandler> = [];
   sideEffects.forEach(se => {
     if (se.after) {
-      afterSideEffects.push(se.fn);
+      afterSideEffects.push(se.effect);
     } else {
-      beforeSideEffects.push(se.fn);
+      beforeSideEffects.push(se.effect);
     }
   });
 

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -25,7 +25,7 @@ export interface RespondOptions {
 export type RemoveResponseHandler = () => void;
 
 export interface SideEffect {
-  fn: ResponseHandler;
+  effect: ResponseHandler;
   after?: boolean;
 }
 

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -1,7 +1,12 @@
 import { RegExpOptions, Key } from "path-to-regexp";
 
 import { LocationDetails } from "@hickory/root";
-import { Params, Response, Resolved, ResponseModifiers } from "./response";
+import {
+  Params,
+  Response,
+  Resolved,
+  ModifiableResponseProperties
+} from "./response";
 import { Interactions } from "./interaction";
 
 export type ParamParser = (input: string) => any;
@@ -22,7 +27,9 @@ export interface ResponseBuilder extends MatchedRouteProps {
 
 export type EveryMatchFn = (matched?: MatchedRouteProps) => Promise<any>;
 export type InitialMatchFn = () => Promise<any>;
-export type ResponseFn = (props: ResponseBuilder) => ResponseModifiers;
+export type ResponseFn = (
+  props: ResponseBuilder
+) => ModifiableResponseProperties;
 
 export interface OnFns {
   initial?: InitialMatchFn;

--- a/packages/core/tests/curi.spec.ts
+++ b/packages/core/tests/curi.spec.ts
@@ -1,7 +1,7 @@
 import "jest";
 import curi from "../src/curi";
 import InMemory from "@hickory/in-memory";
-import { Interaction, Response } from "../src/types";
+import { Interaction, Response, RemoveResponseHandler } from "../src/types";
 
 describe("curi", () => {
   let history;
@@ -172,7 +172,7 @@ describe("curi", () => {
           const sideEffect = jest.fn();
 
           const router = curi(history, routes, {
-            sideEffects: [{ fn: sideEffect }]
+            sideEffects: [{ effect: sideEffect }]
           });
           router.respond(({ response, navigation }) => {
             expect(sideEffect.mock.calls.length).toBe(1);
@@ -190,8 +190,8 @@ describe("curi", () => {
 
           const router = curi(history, routes, {
             sideEffects: [
-              { fn: sideEffect1, after: false },
-              { fn: sideEffect2 }
+              { effect: sideEffect1, after: false },
+              { effect: sideEffect2 }
             ]
           });
 
@@ -220,7 +220,7 @@ describe("curi", () => {
           };
 
           const router = curi(history, routes, {
-            sideEffects: [{ fn: sideEffect, after: true }]
+            sideEffects: [{ effect: sideEffect, after: true }]
           });
           router.respond(responseHandler);
         });
@@ -241,7 +241,7 @@ describe("curi", () => {
           };
 
           const router = curi(history, routes, {
-            sideEffects: [{ fn: sideEffect, after: true }]
+            sideEffects: [{ effect: sideEffect, after: true }]
           });
           router.respond(responseHandler);
         });
@@ -368,7 +368,7 @@ describe("curi", () => {
             }
           };
           const router = curi(history, routes, {
-            sideEffects: [{ fn: logger }]
+            sideEffects: [{ effect: logger }]
           });
         });
 
@@ -594,7 +594,10 @@ describe("curi", () => {
 
       // wait for the first response to be generated to ensure that both
       // response handler functions are called when subscribing
-      const unsub1 = router.respond(sub1, { observe: true, initial: false });
+      const unsub1 = router.respond(sub1, {
+        observe: true,
+        initial: false
+      }) as RemoveResponseHandler;
       const unsub2 = router.respond(sub2, { observe: true, initial: false });
 
       expect(sub1.mock.calls.length).toBe(0);
@@ -949,7 +952,7 @@ describe("curi", () => {
         done();
       });
       let emissionDetector = {
-        fn: () => {
+        effect: () => {
           hasEmitted = true;
         }
       };

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -141,6 +141,7 @@ describe("route matching/response generation", () => {
           response: ({ resolved }) => {
             expect(resolved.error).toBe("This is an error");
             done();
+            return {};
           },
           on: {
             every: () => {
@@ -575,7 +576,7 @@ describe("route matching/response generation", () => {
           const history = InMemory({ locations: ["/"] });
           let firstCall = true;
           const logger = {
-            fn: ({ response }) => {
+            effect: ({ response }) => {
               if (firstCall) {
                 expect(response.redirectTo).toMatchObject({ pathname: "/b" });
                 firstCall = false;
@@ -685,6 +686,7 @@ describe("route matching/response generation", () => {
               expect(everySpy.mock.calls.length).toBe(2);
               expect(responseSpy.mock.calls.length).toBe(0);
               done();
+              return {};
             },
             on: {
               // re-use the every spy so that this route's response
@@ -707,6 +709,7 @@ describe("route matching/response generation", () => {
             path: ":anything",
             response: ({ resolved }) => {
               expect(resolved).toBe(null);
+              return {};
             }
           };
 
@@ -722,6 +725,7 @@ describe("route matching/response generation", () => {
               expect(resolved).toHaveProperty("error");
               expect(resolved).toHaveProperty("initial");
               expect(resolved).toHaveProperty("every");
+              return {};
             },
             on: {
               initial: () => Promise.resolve(1)
@@ -808,6 +812,7 @@ describe("route matching/response generation", () => {
                     expect(resolved.initial).toBe(random);
                     done();
                   }
+                  return {};
                 },
                 on: {
                   initial: () => {
@@ -896,6 +901,7 @@ describe("route matching/response generation", () => {
                   query: "one=two"
                 }
               });
+              return {};
             }
           };
 
@@ -911,6 +917,7 @@ describe("route matching/response generation", () => {
             path: ":anything",
             response: ({ route }) => {
               expect(typeof route.pathname).toBe("function");
+              return {};
             }
           };
 
@@ -936,6 +943,7 @@ describe("route matching/response generation", () => {
               path: "old/:id",
               response: ({ route, name }) => {
                 expect(route.reverse(name)).toBe("dlO");
+                return {};
               }
             }
           ];

--- a/packages/core/types/types/curi.d.ts
+++ b/packages/core/types/types/curi.d.ts
@@ -19,7 +19,7 @@ export interface RespondOptions {
 }
 export declare type RemoveResponseHandler = () => void;
 export interface SideEffect {
-    fn: ResponseHandler;
+    effect: ResponseHandler;
     after?: boolean;
 }
 export interface Cache {

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,5 +1,5 @@
 import { RegExpOptions, Key } from "path-to-regexp";
-import { Resolved, ResponseModifiers } from "./response";
+import { Resolved, ModifiableResponseProperties } from "./response";
 import { Interactions } from "./interaction";
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
@@ -16,7 +16,7 @@ export interface ResponseBuilder extends MatchedRouteProps {
 }
 export declare type EveryMatchFn = (matched?: MatchedRouteProps) => Promise<any>;
 export declare type InitialMatchFn = () => Promise<any>;
-export declare type ResponseFn = (props: ResponseBuilder) => ResponseModifiers;
+export declare type ResponseFn = (props: ResponseBuilder) => ModifiableResponseProperties;
 export interface OnFns {
     initial?: InitialMatchFn;
     every?: EveryMatchFn;


### PR DESCRIPTION
`fn` is vague, `effect` is more explicit.

```js
const scroll = createScrollSideEffect();

const router = curi(history, routes, {
  sideEffects: [
    { effect: scroll, after: true }
  ]
});
```