### PR TITLE
One more route.response() cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- stable
+- "9"
 cache:
   directories:
   - node_modules

--- a/documentation-website/src/client/pages/Guides/AllAboutRoutes.js
+++ b/documentation-website/src/client/pages/Guides/AllAboutRoutes.js
@@ -88,6 +88,11 @@ export default ({ name }) => (
             Webpack using <IJS>import()</IJS>, you can load the modules in{" "}
             <IJS>on.initial()</IJS>.
           </p>
+          <p>
+            The <IJS>initial</IJS> function will be passed the matched route
+            properties: <IJS>name</IJS>, <IJS>params</IJS>, <IJS>partials</IJS>,{" "}
+            <IJS>location</IJS>, and <IJS>key</IJS>.
+          </p>
           <PrismBlock lang="javascript">
             {`const about = {
   name: 'About',
@@ -102,15 +107,13 @@ export default ({ name }) => (
         <Subsection tag="h5" title="on.every()" id="every">
           <p>
             <IJS>on.every()</IJS> will be called every time a route matches.
-            Like <IJS>on.initial()</IJS>, <IJS>on.every()</IJS> should return a
-            Promise.
+            This can be useful for data fetching. Like <IJS>on.initial()</IJS>,{" "}
+            <IJS>on.every()</IJS> should return a Promise.
           </p>
           <p>
-            This can be useful for data fetching. The <IJS>every</IJS> function
-            will be passed the a "route" object containing the <IJS>params</IJS>{" "}
-            parsed from the location's pathname (using the route and its
-            ancestor's paths), the current <IJS>location</IJS>, and the{" "}
-            <IJS>name</IJS> of the matched route.
+            The <IJS>every</IJS> function will be passed the matched route
+            properties: <IJS>name</IJS>, <IJS>params</IJS>, <IJS>partials</IJS>,{" "}
+            <IJS>location</IJS>, and <IJS>key</IJS>.
           </p>
           <PrismBlock lang="javascript">
             {`// fetch user data
@@ -259,31 +262,35 @@ const routes = [
         </p>
         <PrismBlock lang="javascript">
           {`{
-  response: ({ name, params location, resolved, route }) => {
+  response: ({ match, resolved }) => {
     // ...
   }
 }`}
         </PrismBlock>
         <ul>
-          <Subsection tag="li" title="name" id="response-name">
-            <p>
-              The name of the matched route. This is mostly useful is{" "}
-              <IJS>response()</IJS> is defined in a separate file from where the
-              route is.
-            </p>
+          <Subsection tag="li" title="match" id="response-match">
+            <p>An object with the matched route properties of a response.</p>
+            <ul>
+              <li>
+                <IJS>name</IJS> - the name of the matched route
+              </li>
+              <li>
+                <IJS>params</IJS> - route parameters parsed from the location
+              </li>
+              <li>
+                <IJS>partials</IJS> - the names of any ancestor routes of the
+                matched route
+              </li>
+              <li>
+                <IJS>location</IJS> - the location that was used to match the
+                route
+              </li>
+              <li>
+                <IJS>key</IJS> - the location's <IJS>key</IJS>, which is a
+                unique identifier
+              </li>
+            </ul>
           </Subsection>
-          <Subsection tag="li" title="params" id="response-params">
-            <p>
-              An object of route <IJS>params</IJS> parsed from the location's{" "}
-              <IJS>pathname</IJS>.
-            </p>
-          </Subsection>
-          <Subsection tag="li" title="location" id="response-location">
-            <p>
-              The <IJS>location</IJS> that this route was matched with.
-            </p>
-          </Subsection>
-
           <Subsection tag="li" title="resolved" id="response-resolved">
             <p>
               <IJS>resolved</IJS> is an object with the values resolved by the{" "}
@@ -319,13 +326,6 @@ const user = {
   }
 }`}
             </PrismBlock>
-          </Subsection>
-          <Subsection tag="li" title="route" id="response-route">
-            <p>
-              The route interactions that have been registered with Curi are
-              available to the <IJS>response</IJS> function, including the
-              built-in <IJS>pathname</IJS> interaction.
-            </p>
           </Subsection>
         </ul>
       </Subsection>

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Next
+
+* Only the matched route properties (`name`, `params`, `partials`, `location`, and `key`) are guaranteed to exist on a response. The other properties only exist if provided on a `route.response()` return object.
+* `on.initial()` receives full matched route properties object.
+* `on.every()` receives full matched route properties object.
+* remove `route` interactions from `route.response()`
+* re-group `name`, `params`, and `location` with other matched route properties under `match` property passed to `route.response()`.
+
 ## 1.0.0-beta.30
 
 * Side effect response handlers are registered with `effect` instead of `fn`.

--- a/packages/core/src/finishResponse.ts
+++ b/packages/core/src/finishResponse.ts
@@ -31,8 +31,7 @@ export default function finishResponse(
 
   const responseModifiers = route.response({
     resolved,
-    match,
-    route: interactions
+    match
   });
   if (!responseModifiers) {
     return match as Response;

--- a/packages/core/src/finishResponse.ts
+++ b/packages/core/src/finishResponse.ts
@@ -2,16 +2,15 @@ import { Interactions } from "./types/interaction";
 import {
   Response,
   Resolved,
-  GenericResponse,
-  ModifiableResponseProperties
+  SettableResponseProperties
 } from "./types/response";
 import { Match } from "./types/match";
-import { ToArgument } from "@hickory/root";
+import { PartialLocation } from "@hickory/root";
 
 function createRedirect(
   redirectTo: any,
   interactions: Interactions
-): ToArgument {
+): PartialLocation {
   const { name, params, ...rest } = redirectTo;
   const pathname = interactions.pathname(name, params);
   return {
@@ -21,24 +20,22 @@ function createRedirect(
 }
 
 export default function finishResponse(
-  match: Match,
+  routeMatch: Match,
   interactions: Interactions,
   resolved: Resolved | null
 ): Response {
-  const { route, response } = match;
+  const { route, match } = routeMatch;
   if (!route.response) {
-    return response as Response;
+    return match as Response;
   }
 
   const responseModifiers = route.response({
     resolved,
-    name: response.name,
-    params: { ...response.params },
-    location: response.location,
+    match,
     route: interactions
   });
   if (!responseModifiers) {
-    return response as Response;
+    return match as Response;
   }
 
   const settableProperties = [
@@ -49,9 +46,10 @@ export default function finishResponse(
     "title",
     "redirectTo"
   ];
+  const response: Response = match;
   // only merge the valid properties onto the response
   settableProperties.forEach(
-    (p: keyof GenericResponse & keyof ModifiableResponseProperties) => {
+    (p: keyof Response & keyof SettableResponseProperties) => {
       if (responseModifiers.hasOwnProperty(p)) {
         if (p === "redirectTo") {
           // special case

--- a/packages/core/src/resolveMatchedRoute.ts
+++ b/packages/core/src/resolveMatchedRoute.ts
@@ -6,16 +6,11 @@ import { Resolved } from "./types/response";
  * This will call any initial/every match functions for the matching route
  */
 export default function resolveRoute(match: Match): Promise<Resolved> {
-  const response = match.response;
+  const response = match.match;
   const { on } = match.route.public;
   return Promise.all([
-    on.initial && on.initial(),
-    on.every &&
-      on.every({
-        name: response.name,
-        params: { ...response.params },
-        location: response.location
-      })
+    on.initial && on.initial(match.match),
+    on.every && on.every(match.match)
   ]).then(
     ([initial, every]) => ({ error: null, initial, every }),
     error => ({ error, initial: null, every: null })

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -9,7 +9,6 @@ export {
   RouteDescriptor,
   ParamParser,
   ParamParsers,
-  MatchedRouteProps,
   ResponseBuilder,
   EveryMatchFn,
   InitialMatchFn,
@@ -19,7 +18,8 @@ export {
   Response,
   RawParams,
   Params,
-  ModifiableResponseProperties
+  MatchResponseProperties,
+  SettableResponseProperties
 } from "./response";
 export {
   CuriRouter,

--- a/packages/core/src/types/match.ts
+++ b/packages/core/src/types/match.ts
@@ -1,5 +1,5 @@
 import { InternalRoute } from "./route";
-import { Params, GenericResponse } from "./response";
+import { Params, MatchResponseProperties } from "./response";
 
 export interface MatchingRoute {
   route: InternalRoute;
@@ -8,12 +8,12 @@ export interface MatchingRoute {
 
 export interface MissMatch {
   route: undefined;
-  response: undefined;
+  match: undefined;
 }
 
 export interface Match {
   route: InternalRoute;
-  response: GenericResponse;
+  match: MatchResponseProperties;
 }
 
 export type PossibleMatch = Match | MissMatch;

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -1,11 +1,19 @@
-import { HickoryLocation, ToArgument } from "@hickory/root";
+import { HickoryLocation, PartialLocation } from "@hickory/root";
 
 import { InternalRoute } from "./route";
 
 export type RawParams = { [key: string]: string };
 export type Params = { [key: string]: any };
 
-export interface ModifiableResponseProperties {
+export interface MatchResponseProperties {
+  location: HickoryLocation;
+  key: string;
+  name: string;
+  params: Params;
+  partials: Array<string>;
+}
+
+export interface SettableResponseProperties {
   status?: number;
   error?: any;
   body?: any;
@@ -14,21 +22,14 @@ export interface ModifiableResponseProperties {
   redirectTo?: RedirectProps;
 }
 
-export interface GenericResponse {
-  location: HickoryLocation;
-  key: string;
-  status: number;
-  title: string;
-  name: string;
-  params: Params;
-  partials: Array<string>;
-  body: any;
-  data: any;
+export interface Response extends MatchResponseProperties {
+  status?: number;
   error?: any;
-  redirectTo?: ToArgument;
+  body?: any;
+  data?: any;
+  title?: string;
+  redirectTo?: PartialLocation;
 }
-
-export type Response = GenericResponse;
 
 export interface Resolved {
   error: any;

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -17,7 +17,6 @@ export interface ParamParsers {
 
 export interface ResponseBuilder {
   resolved: Resolved | null;
-  route: Interactions;
   match: MatchResponseProperties;
 }
 

--- a/packages/core/src/types/route.ts
+++ b/packages/core/src/types/route.ts
@@ -5,7 +5,8 @@ import {
   Params,
   Response,
   Resolved,
-  ModifiableResponseProperties
+  MatchResponseProperties,
+  SettableResponseProperties
 } from "./response";
 import { Interactions } from "./interaction";
 
@@ -14,23 +15,18 @@ export interface ParamParsers {
   [key: string]: ParamParser;
 }
 
-export interface MatchedRouteProps {
-  params: object;
-  location: object;
-  name: string;
-}
-
-export interface ResponseBuilder extends MatchedRouteProps {
+export interface ResponseBuilder {
   resolved: Resolved | null;
   route: Interactions;
+  match: MatchResponseProperties;
 }
 
-export type EveryMatchFn = (matched?: MatchedRouteProps) => Promise<any>;
-export type InitialMatchFn = () => Promise<any>;
-export type ResponseFn = (
-  props: ResponseBuilder
-) => ModifiableResponseProperties;
+export type ResponseFn = (props: ResponseBuilder) => SettableResponseProperties;
 
+export type EveryMatchFn = (matched?: MatchResponseProperties) => Promise<any>;
+export type InitialMatchFn = (
+  matched?: MatchResponseProperties
+) => Promise<any>;
 export interface OnFns {
   initial?: InitialMatchFn;
   every?: EveryMatchFn;

--- a/packages/core/src/utils/match.ts
+++ b/packages/core/src/utils/match.ts
@@ -70,16 +70,12 @@ function createMatch(
 
   return {
     route: bestMatch.route,
-    response: {
+    match: {
       location,
       key: location.key,
       name: bestMatch.route.public.name,
       params,
-      partials,
-      status: 200,
-      body: undefined,
-      data: undefined,
-      title: ""
+      partials
     }
   };
 }
@@ -101,6 +97,6 @@ export default function matchLocation(
   // no matching route
   return {
     route: undefined,
-    response: undefined
+    match: undefined
   };
 }

--- a/packages/core/types/finishResponse.d.ts
+++ b/packages/core/types/finishResponse.d.ts
@@ -1,4 +1,4 @@
 import { Interactions } from "./types/interaction";
 import { Response, Resolved } from "./types/response";
 import { Match } from "./types/match";
-export default function finishResponse(match: Match, interactions: Interactions, resolved: Resolved | null): Response;
+export default function finishResponse(routeMatch: Match, interactions: Interactions, resolved: Resolved | null): Response;

--- a/packages/core/types/types/index.d.ts
+++ b/packages/core/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
-export { Route, RouteDescriptor, ParamParser, ParamParsers, MatchedRouteProps, ResponseBuilder, EveryMatchFn, InitialMatchFn, OnFns } from "./route";
-export { Response, RawParams, Params, ModifiableResponseProperties } from "./response";
+export { Route, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, EveryMatchFn, InitialMatchFn, OnFns } from "./route";
+export { Response, RawParams, Params, MatchResponseProperties, SettableResponseProperties } from "./response";
 export { CuriRouter, RouterOptions, ResponseHandler, Emitted, RemoveResponseHandler, SideEffect, Cache, Navigation } from "./curi";

--- a/packages/core/types/types/match.d.ts
+++ b/packages/core/types/types/match.d.ts
@@ -1,15 +1,15 @@
 import { InternalRoute } from "./route";
-import { Params, GenericResponse } from "./response";
+import { Params, MatchResponseProperties } from "./response";
 export interface MatchingRoute {
     route: InternalRoute;
     params: Params;
 }
 export interface MissMatch {
     route: undefined;
-    response: undefined;
+    match: undefined;
 }
 export interface Match {
     route: InternalRoute;
-    response: GenericResponse;
+    match: MatchResponseProperties;
 }
 export declare type PossibleMatch = Match | MissMatch;

--- a/packages/core/types/types/response.d.ts
+++ b/packages/core/types/types/response.d.ts
@@ -1,11 +1,18 @@
-import { HickoryLocation, ToArgument } from "@hickory/root";
+import { HickoryLocation, PartialLocation } from "@hickory/root";
 export declare type RawParams = {
     [key: string]: string;
 };
 export declare type Params = {
     [key: string]: any;
 };
-export interface ModifiableResponseProperties {
+export interface MatchResponseProperties {
+    location: HickoryLocation;
+    key: string;
+    name: string;
+    params: Params;
+    partials: Array<string>;
+}
+export interface SettableResponseProperties {
     status?: number;
     error?: any;
     body?: any;
@@ -13,20 +20,14 @@ export interface ModifiableResponseProperties {
     title?: string;
     redirectTo?: RedirectProps;
 }
-export interface GenericResponse {
-    location: HickoryLocation;
-    key: string;
-    status: number;
-    title: string;
-    name: string;
-    params: Params;
-    partials: Array<string>;
-    body: any;
-    data: any;
+export interface Response extends MatchResponseProperties {
+    status?: number;
     error?: any;
-    redirectTo?: ToArgument;
+    body?: any;
+    data?: any;
+    title?: string;
+    redirectTo?: PartialLocation;
 }
-export declare type Response = GenericResponse;
 export interface Resolved {
     error: any;
     initial: any;

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,13 +1,11 @@
 import { RegExpOptions, Key } from "path-to-regexp";
 import { Resolved, MatchResponseProperties, SettableResponseProperties } from "./response";
-import { Interactions } from "./interaction";
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
     [key: string]: ParamParser;
 }
 export interface ResponseBuilder {
     resolved: Resolved | null;
-    route: Interactions;
     match: MatchResponseProperties;
 }
 export declare type ResponseFn = (props: ResponseBuilder) => SettableResponseProperties;

--- a/packages/core/types/types/route.d.ts
+++ b/packages/core/types/types/route.d.ts
@@ -1,22 +1,18 @@
 import { RegExpOptions, Key } from "path-to-regexp";
-import { Resolved, ModifiableResponseProperties } from "./response";
+import { Resolved, MatchResponseProperties, SettableResponseProperties } from "./response";
 import { Interactions } from "./interaction";
 export declare type ParamParser = (input: string) => any;
 export interface ParamParsers {
     [key: string]: ParamParser;
 }
-export interface MatchedRouteProps {
-    params: object;
-    location: object;
-    name: string;
-}
-export interface ResponseBuilder extends MatchedRouteProps {
+export interface ResponseBuilder {
     resolved: Resolved | null;
     route: Interactions;
+    match: MatchResponseProperties;
 }
-export declare type EveryMatchFn = (matched?: MatchedRouteProps) => Promise<any>;
-export declare type InitialMatchFn = () => Promise<any>;
-export declare type ResponseFn = (props: ResponseBuilder) => ModifiableResponseProperties;
+export declare type ResponseFn = (props: ResponseBuilder) => SettableResponseProperties;
+export declare type EveryMatchFn = (matched?: MatchResponseProperties) => Promise<any>;
+export declare type InitialMatchFn = (matched?: MatchResponseProperties) => Promise<any>;
 export interface OnFns {
     initial?: InitialMatchFn;
     every?: EveryMatchFn;

--- a/packages/interactions/route-prefetch/CHANGELOG.md
+++ b/packages/interactions/route-prefetch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Update type of props passed to `get()`.
+
 ## 1.0.0-beta.7
 
 * Moved to `@curi/route-prefetch`.

--- a/packages/interactions/route-prefetch/src/index.ts
+++ b/packages/interactions/route-prefetch/src/index.ts
@@ -1,4 +1,4 @@
-import { Interaction, Route, MatchedRouteProps } from "@curi/core";
+import { Interaction, Route, MatchResponseProperties } from "@curi/core";
 import { HickoryLocation } from "@hickory/root";
 
 function prefetchRoute(): Interaction {
@@ -21,7 +21,7 @@ function prefetchRoute(): Interaction {
         loaders[name] = on.every;
       }
     },
-    get: (name: string, props?: MatchedRouteProps) => {
+    get: (name: string, props?: MatchResponseProperties) => {
       if (loaders[name] == null) {
         return Promise.reject(
           `Could not prefetch data for ${name} because it is not registered.`


### PR DESCRIPTION
1. Re-grouped the `name`, `params`, and `location` passed to `route.response()` under `match`. `match` also contains the `partials` array of partial matches (any ancestors of the matched route) and the `key` of the `location` (probably not useful, but used to uniquely identify the response).
```js
{
  response({ match }) {
    const { name, params, location, key, partials } = match;
  }
}
```

2. Removed the `route` interactions from being passed to `route.response()`. The initial reason these were added was to generate the pathname of a location to redirect to. That is now handled for the user when they provide the `name`/`params` to `redirectTo`. The `active` and `prefetch` interactions don't make sense to use here. The `ancestors` interaction is covered by `match.partials`. Custom interactions shouldn't need to be called in `route.response()` either.

3. Pass the entirety of the `match` properties to `on.every()`. I'm not sure if they are necessary, but there isn't a good reason not to.

4. Pass the `match` properties to `on.initial()`. This is probably unnecessary, but it might as well be made available.