### PR TITLE
Remove response.key

### DIFF
--- a/documentation-website/src/client/pages/Guides/Responses.js
+++ b/documentation-website/src/client/pages/Guides/Responses.js
@@ -27,9 +27,6 @@ export default ({ name }) => (
     >
       <PrismBlock lang="javascript">
         {`{
-  // The location key
-  key: '1.0',
-
   // The location object used to generate the response.
   location: { pathname: '/photos/6789/12345', ... },
 

--- a/documentation-website/src/client/pages/Home/index.js
+++ b/documentation-website/src/client/pages/Home/index.js
@@ -160,7 +160,6 @@ location = {
     pathname: '/photos/6789/12345',
     ...
   },
-  key: '1.0',
 
   // set by matched route's response() function
   body: function Photo() {...},

--- a/documentation-website/src/client/pages/Tutorials/ReactBasics.js
+++ b/documentation-website/src/client/pages/Tutorials/ReactBasics.js
@@ -344,7 +344,6 @@ registerServiceWorker();`}
   body: undefined,
   data: undefined,
   error: undefined,
-  key: '1.0',
   location: { pathname: '/', ... },
   name: 'Home',
   params: {},

--- a/documentation-website/src/client/pages/Tutorials/VueBasics.js
+++ b/documentation-website/src/client/pages/Tutorials/VueBasics.js
@@ -366,7 +366,6 @@ new Vue({
   body: undefined,
   data: undefined,
   error: undefined,
-  key: '1.0',
   location: { pathname: '/', ... },
   name: 'Home',
   params: {},

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Remove `response.key` (still available as `response.location.key`).
 * Remove the `cache` option from the router.
 
 ## 1.0.0-beta.31

--- a/packages/core/src/types/response.ts
+++ b/packages/core/src/types/response.ts
@@ -7,7 +7,6 @@ export type Params = { [key: string]: any };
 
 export interface MatchResponseProperties {
   location: HickoryLocation;
-  key: string;
   name: string;
   params: Params;
   partials: Array<string>;

--- a/packages/core/src/utils/match.ts
+++ b/packages/core/src/utils/match.ts
@@ -72,7 +72,6 @@ function createMatch(
     route: bestMatch.route,
     match: {
       location,
-      key: location.key as string, // fix hickory location type?
       name: bestMatch.route.public.name,
       params,
       partials

--- a/packages/core/tests/route-matching.spec.ts
+++ b/packages/core/tests/route-matching.spec.ts
@@ -134,18 +134,6 @@ describe("route matching/response generation", () => {
 
   describe("response", () => {
     describe("properties", () => {
-      describe("key", () => {
-        it("is the key property from the location", done => {
-          const routes = [{ name: "Catch All", path: "(.*)" }];
-          const history = InMemory({ locations: ["/other-page"] });
-          const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.key).toBe(history.location.key);
-            done();
-          });
-        });
-      });
-
       describe("location", () => {
         it("is the location used to match routes", done => {
           const routes = [{ name: "Catch All", path: "(.*)" }];
@@ -878,8 +866,7 @@ describe("route matching/response generation", () => {
                 location: {
                   pathname: "/hello",
                   query: "one=two"
-                },
-                key: "0.0"
+                }
               });
               return {};
             }

--- a/packages/core/types/types/response.d.ts
+++ b/packages/core/types/types/response.d.ts
@@ -7,7 +7,6 @@ export declare type Params = {
 };
 export interface MatchResponseProperties {
     location: HickoryLocation;
-    key: string;
     name: string;
     params: Params;
     partials: Array<string>;


### PR DESCRIPTION
`response.key` was just an alias for `response.location.key`. This property isn't particularly useful except for some small things (i.e. animation keys), so it doesn't warrant its own top-level property.