### PR TITLE
@curi/route-prefetch supports on.initial()

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Export `Resolved` type
+
 ## 1.0.0-beta.32
 
 * Remove `response.key` (still available as `response.location.key`).

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -18,6 +18,7 @@ export {
   Response,
   RawParams,
   Params,
+  Resolved,
   MatchResponseProperties,
   SettableResponseProperties
 } from "./response";

--- a/packages/core/types/types/index.d.ts
+++ b/packages/core/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
 export { Route, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, EveryMatchFn, InitialMatchFn, OnFns } from "./route";
-export { Response, RawParams, Params, MatchResponseProperties, SettableResponseProperties } from "./response";
+export { Response, RawParams, Params, Resolved, MatchResponseProperties, SettableResponseProperties } from "./response";
 export { CuriRouter, RouterOptions, Observer, Emitted, RemoveObserver, SideEffect, Navigation } from "./curi";

--- a/packages/interactions/route-prefetch/CHANGELOG.md
+++ b/packages/interactions/route-prefetch/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Next
+
+* If a requested route is not registered, Promise resolves object with `error` property instead
+  of throwing.
+* Support prefetching both `on.every()` _and_ `on.initial()`.
+
 ## 1.0.0-beta.8
 
 * Update type of props passed to `get()`.


### PR DESCRIPTION
Call both `on.initial()` and `on.every()` when you "prefetch" a route. Interaction will now resolve an object with an `error` instead of rejecting when the requested route has no `on.initial()` or `on.every()` functions.

```js
import prefetch from "@curi/route-prefetch";

const routes = [
  {
    name: "Initial Only",
    path: "initial",
    on: {
      initial: () => Promise.resolve("initial")
    }
  },
{
    name: "Every Only",
    path: "every",
    on: {
      every: () => Promise.resolve("every")
    }
  },
  {
    name: "Both",
    path: "both",
    on: {
      initial: () => Promise.resolve("initial"),
      every: () => Promise.resolve("every")
    }
  },
  {
    name: "Neither",
    path: "neither",
  }
];

const router = curi(history, routes, {
  route: [prefetch()]
});

router.route.prefetch("Initial Only")
  .then(resolved => {
    // { initial: "initial", every: undefined, error: null }
  });

router.route.prefetch("Every Only")
  .then(resolved => {
    // { initial: undefined, every: "every", error: null }
  });

router.route.prefetch("Both")
  .then(resolved => {
    // { initial: "initial", every: "every", error: null }
  });

router.route.prefetch("Neither")
  .then(resolved => {
    // { initial: null, every: null, error: "Could not prefetch data for Neither because it is not registered." }
  });
```