### PR TITLE
prefetch() can only call specified fns

### DIFF
--- a/documentation-website/src/client/pages/Packages/RoutePrefetch.js
+++ b/documentation-website/src/client/pages/Packages/RoutePrefetch.js
@@ -17,22 +17,27 @@ export default ({ name, version, globalName }) => (
     version={version}
     globalName={globalName}
     about={
-      <p>
-        The prefetch route interaction can be used to make data fetching calls
-        prior to navigation by calling a route's <IJS>on.every()</IJS> function.
-        This is different than calling the function while generating the
-        response because this is done without actually changing locations.
-      </p>
+      <div>
+        <p>
+          The prefetch route interaction can be used fetch data for a route
+          prior to navigating. The interaction will call a route's{" "}
+          <IJS>on.initial()</IJS> and <IJS>on.every()</IJS> functions (if they
+          exist on the route).
+        </p>
+        <p>
+          Prefetching data means that when users navigate, the new page will be
+          full rendered faster because we already have the data.
+        </p>
+      </div>
     }
   >
     <SideBySide>
       <Explanation>
         <Note>
-          You should only use this if you implement some sort of caching/lookup
-          in your functions. The <IJS>on.every()</IJS> function will be
-          re-called when the user actually navigates to the route, so the
-          benefit comes from the using a cached value instead of sending a new
-          request to your server.
+          You need to cache the results of <IJS>on.every()</IJS> because the
+          function will be re-called when the user navigates to that route.The
+          result of <IJS>on.initial()</IJS> is automatically re-used on
+          subsequent calls, so you do not have to worry about caching it.
         </Note>
       </Explanation>
     </SideBySide>
@@ -41,16 +46,9 @@ export default ({ name, version, globalName }) => (
         <SideBySide>
           <Explanation>
             <p>
-              The default export function is a route interaction factory that
-              will add an <IJS>prefetch</IJS> function to the router's{" "}
-              <IJS>route</IJS> property.
-            </p>
-            <p>
-              The prefetch route interaction allows you to call a route's{" "}
-              <IJS>on.every()</IJS> function manually. Why would you want to do
-              this? Prefetching data means that when users navigate, the new
-              page will be full rendered faster because we already have the
-              data.
+              The default export function is a route interaction factory. When
+              passed to a Curi router, a <IJS>route.prefetch()</IJS> will be
+              available for calling a route's <IJS>on</IJS> functions.
             </p>
           </Explanation>
 
@@ -79,28 +77,59 @@ const router = curi(history, routes, {
                   <tr>
                     <td>name</td>
                     <td>
-                      the name of the route whose <IJS>on.every()</IJS> function
+                      The name of the route whose <IJS>on.every()</IJS> function
                       should be called.
                     </td>
                   </tr>
                   <tr>
                     <td>match</td>
                     <td>
-                      route props that are used by the <IJS>on.every()</IJS>{" "}
+                      Route props that are used by the <IJS>on.every()</IJS>{" "}
                       function (the same ones that an <IJS>on.every()</IJS>{" "}
                       function expects).
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>which</td>
+                    <td>
+                      When provided, only the specified (value is{" "}
+                      <IJS>true</IJS>) functions will be called. When not
+                      provided, all available functions will be called.
                     </td>
                   </tr>
                 </tbody>
               </table>
               <p>
-                This route interaction will only register routes that have a{" "}
-                <IJS>on.every()</IJS> function.
+                This route interaction will only register routes that have an{" "}
+                <IJS>on.initial()</IJS> or <IJS>on.every()</IJS> function. If
+                you try calling this for any routes with neither of those,{" "}
+                <IJS>prefetch()</IJS> will resolve an object with an{" "}
+                <IJS>error</IJS> property.
               </p>
             </Explanation>
             <CodeBlock>
-              {`// call a route's load function manually
-router.route.prefetch('User', { params: { id: 2 }})`}
+              {`
+{
+  name: "User",
+  path: "u/:id",
+  on: {
+    initial: () => {...},
+    every: () => {...}
+  }
+}
+
+// call a route's on.initial() and on.every() functions
+router.route.prefetch(
+  'User',
+  { params: { id: 2 }}
+)
+
+// only call the route's on.initial() function
+router.route.prefetch(
+  'User',
+  { params: { id: 3 }},
+  { initial: true }
+);`}
             </CodeBlock>
           </SideBySide>
         </Subsection>

--- a/packages/interactions/route-prefetch/CHANGELOG.md
+++ b/packages/interactions/route-prefetch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `which` object argument to specify which async functions to call. If not provided, all available functions are called. When `which` is provided, only functions with `true` `which` properties will be called.
+
 ## 1.0.0-beta.9
 
 * If a requested route is not registered, Promise resolves object with `error` property instead

--- a/packages/interactions/route-prefetch/types/index.d.ts
+++ b/packages/interactions/route-prefetch/types/index.d.ts
@@ -1,3 +1,7 @@
 import { Interaction } from "@curi/core";
+export interface PrefetchType {
+    initial?: boolean;
+    every?: boolean;
+}
 declare function prefetchRoute(): Interaction;
 export default prefetchRoute;


### PR DESCRIPTION
By default, all `on` methods are called for a route. This adds a third argument to specify which methods to call.

```js
// call all on methods
router.route.prefetch("Home");

// only call on.initial()
router.route.prefetch("Home", null, { initial: true });

// only call on.every()
router.route.prefetch("User", { params: { id: 1 }}, { every: true });
```