### PR TITLE
React(-Native) <Link>s forward ref

### DIFF
--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Forward `<Link>` ref to actual component (e.g. `<TouchableHighlight>`).
+
 ## 1.0.0-beta.5
 
 * TypeScript fix

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -28,6 +28,7 @@ export interface LinkProps {
 export interface BaseLinkProps extends LinkProps {
   router: CuriRouter;
   response: Response;
+  forwardedRef: React.Ref<any> | undefined;
 }
 
 class BaseLink extends React.Component<BaseLinkProps> {
@@ -67,19 +68,25 @@ class BaseLink extends React.Component<BaseLinkProps> {
       router,
       response,
       method,
+      forwardedRef,
       ...rest
     } = this.props;
 
-    return <Anchor {...rest} onPress={this.pressHandler} />;
+    return <Anchor {...rest} onPress={this.pressHandler} ref={forwardedRef} />;
   }
 }
 
-const Link = (props: LinkProps) => (
+const Link = React.forwardRef((props: LinkProps, ref) => (
   <Curious>
     {({ router, response }: Emitted) => (
-      <BaseLink {...props} router={router} response={response} />
+      <BaseLink
+        {...props}
+        router={router}
+        response={response}
+        forwardedRef={ref}
+      />
     )}
   </Curious>
-);
+));
 
 export default Link;

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -150,6 +150,31 @@ describe("<Link>", () => {
     });
   });
 
+  describe("ref", () => {
+    it("returns the anchor's ref, not the link's", () => {
+      const history = InMemory({ locations: ["/the-initial-location"] });
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+      const routes = [
+        { name: "Parks", path: "/parks" },
+        { name: "Catch All", path: "(.*)" }
+      ];
+      const router = curi(history, routes);
+      const ref = React.createRef();
+      const tree = renderer.create(
+        <CuriProvider router={router}>
+          {() => (
+            <Link to="Parks" ref={ref}>
+              <Text>Test</Text>
+            </Link>
+          )}
+        </CuriProvider>
+      );
+      const anchor = tree.root.findByType(TouchableHighlight);
+      expect(anchor.instance).toBe(ref.current);
+    });
+  });
+
   describe("pressing a link", () => {
     describe("navigation method", () => {
       let history, mockNavigate, mockPush, mockReplace;

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Forward `<Link>` ref to actual component (e.g. `<a>`).
+
 ## 1.0.0-beta.23
 
 * TypeScript fix

--- a/packages/react/src/Active.tsx
+++ b/packages/react/src/Active.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { ReactElement, ReactNode } from "react";
 import invariant from "invariant";
 import { Curious } from "./Context";
 
+import { ReactNode } from "react";
 import { CuriRouter, Response } from "@curi/core";
 import { HickoryLocation } from "@hickory/root";
 
@@ -18,7 +18,7 @@ const Active = (props: ActiveProps): ReactNode => (
     {({ router, response }) => {
       invariant(
         router.route.active,
-        'You are attempting to use the "active" prop, but have not included the "active" ' +
+        'You are attempting to use the "active" function, but have not included the "active" ' +
           "route interaction (@curi/route-active) in your Curi router."
       );
 

--- a/packages/react/src/Link.tsx
+++ b/packages/react/src/Link.tsx
@@ -32,6 +32,7 @@ export interface LinkProps
 export interface BaseLinkProps extends LinkProps {
   router: CuriRouter;
   response: Response;
+  forwardedRef: React.Ref<any> | undefined;
 }
 
 class BaseLink extends React.Component<BaseLinkProps> {
@@ -65,31 +66,43 @@ class BaseLink extends React.Component<BaseLinkProps> {
       anchor,
       router,
       response,
+      forwardedRef,
       ...rest
     } = this.props;
     const Anchor: React.ReactType = anchor ? anchor : "a";
-
-    const pathname = to
-      ? router.route.pathname(to, params)
-      : response.location.pathname;
-    const location = {
+    const href: string = router.history.toHref({
       hash,
       query,
       state,
-      pathname
-    };
-    const href: string = router.history.toHref(location);
+      pathname: to
+        ? router.route.pathname(to, params)
+        : response.location.pathname
+    });
 
-    return <Anchor {...rest} onClick={this.clickHandler} href={href} />;
+    return (
+      <Anchor
+        {...rest}
+        onClick={this.clickHandler}
+        href={href}
+        ref={forwardedRef}
+      />
+    );
   }
 }
 
-const Link = (props: LinkProps): React.ReactElement<any> => (
+const Link = React.forwardRef((props: LinkProps, ref): React.ReactElement<
+  any
+> => (
   <Curious>
     {({ router, response }) => (
-      <BaseLink {...props} router={router} response={response} />
+      <BaseLink
+        {...props}
+        router={router}
+        response={response}
+        forwardedRef={ref}
+      />
     )}
   </Curious>
-);
+));
 
 export default Link;

--- a/packages/react/tests/Active.spec.tsx
+++ b/packages/react/tests/Active.spec.tsx
@@ -50,7 +50,7 @@ describe("<Active>", () => {
           node
         );
       }).toThrow(
-        'You are attempting to use the "active" prop, but have not included the "active" ' +
+        'You are attempting to use the "active" function, but have not included the "active" ' +
           "route interaction (@curi/route-active) in your Curi router."
       );
       console.error = realError;

--- a/packages/react/tests/Link.spec.tsx
+++ b/packages/react/tests/Link.spec.tsx
@@ -166,6 +166,29 @@ describe("<Link>", () => {
     });
   });
 
+  describe("ref", () => {
+    it("returns the anchor's ref, not the link's", () => {
+      const history = InMemory();
+      const router = curi(history, [
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const ref = React.createRef();
+      ReactDOM.render(
+        <CuriProvider router={router}>
+          {() => (
+            <Link to="Test" ref={ref}>
+              Test
+            </Link>
+          )}
+        </CuriProvider>,
+        node
+      );
+      const a = node.querySelector("a");
+      expect(a).toBe(ref.current);
+    });
+  });
+
   describe("clicking a link", () => {
     it("calls history.navigate", () => {
       const history = InMemory();

--- a/packages/react/types/Link.d.ts
+++ b/packages/react/types/Link.d.ts
@@ -13,6 +13,7 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>
 export interface BaseLinkProps extends LinkProps {
     router: CuriRouter;
     response: Response;
+    forwardedRef: React.Ref<any>;
 }
-declare const Link: (props: LinkProps) => React.ReactElement<any>;
+declare const Link: React.ComponentType<LinkProps & React.ClassAttributes<{}>>;
 export default Link;


### PR DESCRIPTION
Use `React.forwardRef()` to forward link refs to "host" component.
```jsx
// @curi/react
const ref = React.createRef();
<Link to="Home" ref={ref}>Home</Link>
// ref.current = <a href="/">Home</a>
```