### PR TITLE
Add resolved object as second arg to <Prefetch> children

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Pass the object resolved by `route.prefetch()` to `<Prefetch>`'s `children` render-invoked function.
+
 ## 1.0.0-beta.25
 
 * Fix `<Prefetch>` on the server and don't change refs.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,7 +2,12 @@ export { ActiveProps } from "./Active";
 export { BlockProps } from "./Block";
 export { LinkProps } from "./Link";
 export { CuriProviderProps, CuriRenderFn } from "./CuriProvider";
-export { PrefetchProps, WhichOnFns, MatchData } from "./Prefetch";
+export {
+  PrefetchProps,
+  WhichOnFns,
+  MatchData,
+  MaybeResolved
+} from "./Prefetch";
 
 import Active from "./Active";
 import Block from "./Block";

--- a/packages/react/types/Prefetch.d.ts
+++ b/packages/react/types/Prefetch.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="react" />
 import React from "react";
+import { Resolved } from "@curi/core";
 import { HickoryLocation } from "@hickory/root";
 export interface WhichOnFns {
     initial?: boolean;
@@ -11,8 +12,9 @@ export interface MatchData {
     location?: HickoryLocation;
     partials?: Array<string>;
 }
+export declare type MaybeResolved = Resolved | null;
 export interface PrefetchProps {
-    children: (ref: React.RefObject<any>) => React.ReactElement<any>;
+    children: (ref: React.RefObject<any>, resolved: MaybeResolved) => React.ReactElement<any>;
     match: MatchData;
     which?: WhichOnFns;
     forwardedRef?: React.RefObject<any>;

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -2,7 +2,7 @@ export { ActiveProps } from "./Active";
 export { BlockProps } from "./Block";
 export { LinkProps } from "./Link";
 export { CuriProviderProps, CuriRenderFn } from "./CuriProvider";
-export { PrefetchProps, WhichOnFns, MatchData } from "./Prefetch";
+export { PrefetchProps, WhichOnFns, MatchData, MaybeResolved } from "./Prefetch";
 import Active from "./Active";
 import Block from "./Block";
 import CuriProvider from "./CuriProvider";


### PR DESCRIPTION
This makes the resolved object available once data for the route has been prefetched. Useful for adding an indicator once the data has been prefetched or even filling in data for a thumbnail.

```jsx
<Prefetch match={{ name: "User", params: { id: 1 } }}>
  {(ref, resolved) => (
    <Link to="User" params={{ id: 1 }} ref={ref}>
      User 1 {resolved ? "✓" : "..."}
    </Link>
  )}
</Prefetch>
```