### PR TITLE
Warn when <Prefetch> ref is null

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Warn when the `ref` passed to `<Prefetch>`'s render-invoked function is `null` after mounting.
 * Pass the object resolved by `route.prefetch()` to `<Prefetch>`'s `children` render-invoked function.
 
 ## 1.0.0-beta.25

--- a/packages/react/src/Prefetch.tsx
+++ b/packages/react/src/Prefetch.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import invariant from "invariant";
+import warning from "warning";
 import { Curious } from "./Context";
 
 import { ReactNode } from "react";
@@ -86,6 +87,10 @@ class PrefetchWhenVisible extends React.Component<
   }
 
   componentDidMount() {
+    warning(
+      this.intersectionRef.current,
+      "The ref provided to the children function is null. Did you forget to pass it to a component?"
+    );
     if (this.intersectionRef.current != null) {
       this.obs.observe(this.intersectionRef.current);
     }

--- a/packages/react/tests/Prefetch.spec.tsx
+++ b/packages/react/tests/Prefetch.spec.tsx
@@ -449,6 +449,53 @@ describe("prefetch", () => {
           node
         );
       });
+
+      it("warns if ref if null after mounting", () => {
+        const realWarn = console.error;
+        const mockWarn = (console.error = jest.fn());
+
+        const history = InMemory();
+        const match = { name: "Prefetch" };
+        const prefetchRoute = {
+          name: "Prefetch",
+          path: "prefetch",
+          on: {
+            initial: jest.fn(),
+            every: jest.fn()
+          }
+        };
+        const routes = [
+          {
+            name: "Home",
+            path: "",
+            response() {
+              return {
+                body: () => (
+                  <Prefetch match={match}>
+                    {ref => <Link to="Prefetch">Prefetch</Link>}
+                  </Prefetch>
+                )
+              };
+            }
+          },
+          prefetchRoute,
+          { name: "Not Found", path: "(.*)" }
+        ];
+        const router = curi(history, routes, {
+          route: [prefetchInteraction()]
+        });
+
+        ReactDOM.render(
+          <CuriProvider router={router}>{childrenResponse}</CuriProvider>,
+          node
+        );
+        expect(mockWarn.mock.calls.length).toBe(1);
+        expect(mockWarn.mock.calls[0][0]).toBe(
+          "Warning: The ref provided to the children function is null. Did you forget to pass it to a component?"
+        );
+
+        console.error = realWarn;
+      });
     });
 
     describe("resolved (second argument)", () => {


### PR DESCRIPTION
Help to catch when you forget to pass the `ref` to a component.

```jsx
<Prefetch>
  {ref => <div>...</div>}
</Prefetch>
// Warning: The ref provided to the children function is null.
// Did you forget to pass it to a component?
```