### PR TITLE
Add <curi-prefetch> to @curi/vue

### DIFF
--- a/packages/vue/package-lock.json
+++ b/packages/vue/package-lock.json
@@ -297,7 +297,7 @@
         "babylon": "6.18.0",
         "debug": "2.6.9",
         "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "invariant": "2.2.4",
         "lodash": "4.17.4"
       }
     },
@@ -845,7 +845,6 @@
         "ajv": {
           "version": "4.11.8",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "co": "4.6.0",
@@ -1795,9 +1794,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "1.3.1"
       }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -34,8 +34,6 @@
     "vue": "^2.5.2"
   },
   "devDependencies": {
-    "@curi/core": "^1.0.0-beta.34",
-    "@curi/route-active": "^1.0.0-beta.6",
     "@hickory/in-memory": "^1.0.0-beta.5",
     "@types/jest": "^22.0.1",
     "@types/node": "^8.0.53",
@@ -51,8 +49,10 @@
   },
   "dependencies": {
     "@curi/core": "^1.0.0-beta.34",
+    "@curi/route-prefetch": "^1.0.0-beta.10",
     "@hickory/root": "^1.0.0-beta.7",
     "@types/warning": "^3.0.0",
+    "invariant": "^2.2.4",
     "warning": "^3.0.0"
   }
 }

--- a/packages/vue/src/Link.ts
+++ b/packages/vue/src/Link.ts
@@ -1,6 +1,5 @@
 import Vue, { CreateElement, ComponentOptions } from "vue";
 import { HickoryLocation } from "@hickory/root";
-import warning from "warning";
 
 export interface LinkComponent extends Vue {
   to: string;

--- a/packages/vue/src/Prefetch.ts
+++ b/packages/vue/src/Prefetch.ts
@@ -22,6 +22,7 @@ export type MaybeResolved = Resolved | null;
 export interface PrefetchComponent extends Vue {
   match: MatchData;
   which?: WhichOnFns;
+  resolved: MaybeResolved;
 }
 
 const Prefetch: ComponentOptions<PrefetchComponent> = {

--- a/packages/vue/src/Prefetch.ts
+++ b/packages/vue/src/Prefetch.ts
@@ -1,0 +1,82 @@
+import Vue from "vue";
+import invariant from "invariant";
+
+import { CreateElement, ComponentOptions, VNode } from "vue";
+import { HickoryLocation } from "@hickory/root";
+import { Resolved } from "@curi/core";
+
+export interface WhichOnFns {
+  initial?: boolean;
+  every?: boolean;
+}
+
+export interface MatchData {
+  name: string;
+  params?: object;
+  location?: HickoryLocation;
+  partials?: Array<string>;
+}
+
+export type MaybeResolved = Resolved | null;
+
+export interface PrefetchComponent extends Vue {
+  match: MatchData;
+  which?: WhichOnFns;
+}
+
+const Prefetch: ComponentOptions<PrefetchComponent> = {
+  name: "curi-prefetch",
+
+  props: ["match", "which"],
+
+  data() {
+    return {
+      resolved: null,
+      obs: undefined
+    };
+  },
+
+  render: function(h: CreateElement) {
+    return this.$scopedSlots.default({
+      resolved: this.resolved
+    });
+  },
+
+  beforeCreate: function() {
+    invariant(
+      this.$router.route.prefetch,
+      'You are attempting to use the "prefetch" function, but have not included the "prefetch" ' +
+        "route interaction (@curi/route-prefetch) in your Curi router."
+    );
+  },
+
+  beforeMount: function() {
+    if (typeof window !== "undefined" && IntersectionObserver) {
+      this.obs = new IntersectionObserver(entries => {
+        const ref = this.$vnode.elm;
+        entries.forEach(entry => {
+          if (ref === entry.target && entry.intersectionRatio > 0) {
+            this.obs.unobserve(ref);
+            this.obs.disconnect();
+            this.$router.route
+              .prefetch(this.match.name, this.match, this.which)
+              .then((resolved: Resolved) => {
+                this.resolved = resolved;
+              });
+          }
+        });
+      });
+    }
+  },
+
+  mounted: function() {
+    const ref = this.$vnode.elm;
+    this.obs.observe(ref);
+  },
+
+  destroyed: function() {
+    this.obs.disconnect();
+  }
+};
+
+export default Prefetch;

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,5 +1,11 @@
 export { BlockComponent } from "./Block";
 export { LinkComponent } from "./Link";
+export {
+  PrefetchComponent,
+  MatchData,
+  WhichOnFns,
+  MaybeResolved
+} from "./Prefetch";
 export { ReactiveResponse } from "./interface";
 export { CuriPluginOptions } from "./plugin";
 

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -2,6 +2,7 @@ import Vue, { PluginObject, VueConstructor } from "vue";
 
 import Link from "./Link";
 import Block from "./Block";
+import Prefetch from "./Prefetch";
 
 import { CuriRouter } from "@curi/core";
 import { ReactiveResponse } from "./interface";
@@ -14,6 +15,7 @@ const CuriPlugin: PluginObject<CuriPluginOptions> = {
   install: function(_Vue: typeof Vue, options: CuriPluginOptions) {
     _Vue.component(Link.name, Link);
     _Vue.component(Block.name, Block);
+    _Vue.component(Prefetch.name, Prefetch);
 
     // create a reactive object so that components will receive
     // the new response/navigation when a new response is emitted

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -1,6 +1,7 @@
 import "jest";
 import { createLocalVue } from "@vue/test-utils";
 import InMemory from "@hickory/in-memory";
+
 import curi from "@curi/core";
 import CuriPlugin from "../src/plugin";
 

--- a/packages/vue/tests/Prefetch.spec.ts
+++ b/packages/vue/tests/Prefetch.spec.ts
@@ -123,7 +123,7 @@ describe("prefetch", () => {
     });
   });
 
-  describe("scoped slot", () => {
+  describe("on fns", () => {
     const history = InMemory();
     const prefetchRoute = {
       name: "Prefetch",

--- a/packages/vue/tests/Prefetch.spec.ts
+++ b/packages/vue/tests/Prefetch.spec.ts
@@ -1,0 +1,468 @@
+import "jest";
+import { createLocalVue } from "@vue/test-utils";
+import InMemory from "@hickory/in-memory";
+import curi from "@curi/core";
+import prefetchInteraction from "@curi/route-prefetch";
+import CuriPlugin from "../src/plugin";
+
+// simulate IntersectionObserver
+// https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver
+function createIntersectionObserver() {
+  let entries = [];
+  // noop
+  let callback: (...any: Array<any>) => void = () => {};
+  let intersectionRatio = 1;
+  function flush() {
+    callback(entries);
+  }
+  const observe = jest.fn(target => {
+    entries.push({
+      target,
+      intersectionRatio
+    });
+    flush();
+  });
+  function update(target, ratio) {
+    entries = entries.map(
+      e =>
+        e.target !== target
+          ? e
+          : {
+              target,
+              intersectionRatio: ratio
+            }
+    );
+    flush();
+  }
+  const disconnect = jest.fn();
+  const unobserve = jest.fn();
+
+  return {
+    entries,
+    observe,
+    disconnect,
+    unobserve,
+    update,
+    setRatio(ratio) {
+      intersectionRatio = ratio;
+    },
+    io(fn) {
+      callback = fn;
+      return {
+        observe,
+        disconnect,
+        unobserve
+      };
+    }
+  };
+}
+
+describe("prefetch", () => {
+  let node, intersection;
+
+  beforeEach(() => {
+    node = document.createElement("div");
+    document.body.appendChild(node);
+    intersection = createIntersectionObserver();
+    global.IntersectionObserver = intersection.io;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.resetAllMocks();
+  });
+
+  describe("no prefetch interaction", () => {
+    it("throws if @curi/route-prefetch is not present", () => {
+      const realError = console.error;
+      console.error = jest.fn();
+
+      const history = InMemory();
+      const match = { name: "Prefetch" };
+      const prefetchRoute = {
+        name: "Prefetch",
+        path: "prefetch",
+        on: {
+          initial: jest.fn(),
+          every: jest.fn()
+        }
+      };
+      const routes = [
+        {
+          name: "Home",
+          path: ""
+        },
+        prefetchRoute,
+        { name: "Not Found", path: "(.*)" }
+      ];
+      const router = curi(history, routes);
+
+      const Vue = createLocalVue();
+      Vue.use(CuriPlugin, { router });
+
+      const wrapper = new Vue({
+        el: node,
+        template: `
+          <div>
+            <curi-prefetch :match="{ name: 'Prefetch' }">
+              <span slot-scope="prefetch">
+                Test
+              </span>
+            </curi-prefetch>
+          </div>
+        `,
+        errorCaptured: function(error) {
+          expect(error.message).toBe(
+            'You are attempting to use the "prefetch" function, but have not included the "prefetch" ' +
+              "route interaction (@curi/route-prefetch) in your Curi router."
+          );
+        }
+      });
+
+      console.error = realError;
+    });
+  });
+
+  describe("scoped slot", () => {
+    const history = InMemory();
+    const prefetchRoute = {
+      name: "Prefetch",
+      path: "prefetch",
+      on: {
+        // use on.every instead of on.initial so that the routes
+        // can be re-used (on.initial() is only called once)
+        every: jest.fn()
+      }
+    };
+    const routes = [
+      {
+        name: "Home",
+        path: ""
+      },
+      prefetchRoute,
+      { name: "Not Found", path: "(.*)" }
+    ];
+    const router = curi(history, routes, {
+      route: [prefetchInteraction()]
+    });
+
+    const Vue = createLocalVue();
+    Vue.use(CuriPlugin, { router });
+
+    afterEach(() => {
+      prefetchRoute.on.every.mockReset();
+    });
+
+    it('calls "on" fns immediately if the element is immediately visible', () => {
+      const wrapper = new Vue({
+        el: node,
+        template: `
+          <div>
+            <curi-prefetch :match="{ name: 'Prefetch' }">
+              <span slot-scope="prefetch" id="5">
+                Test
+              </span>
+            </curi-prefetch>
+          </div>
+        `
+      });
+      expect(prefetchRoute.on.every.mock.calls.length).toBe(1);
+    });
+
+    it('does not call "on" fns immediately if the element is not visible', () => {
+      intersection.setRatio(0);
+      const wrapper = new Vue({
+        el: node,
+        template: `
+          <div>
+            <curi-prefetch :match="{ name: 'Prefetch' }">
+              <span slot-scope="prefetch">
+                Test
+              </span>
+            </curi-prefetch>
+          </div>
+        `
+      });
+      expect(prefetchRoute.on.every.mock.calls.length).toBe(0);
+    });
+
+    it('calls "on" fns when element becomes visible', () => {
+      intersection.setRatio(0);
+      const wrapper = new Vue({
+        el: node,
+        template: `
+          <div>
+            <curi-prefetch :match="{ name: 'Prefetch' }">
+              <span slot-scope="prefetch" id="test">
+                Test
+              </span>
+            </curi-prefetch>
+          </div>
+        `
+      });
+      expect(prefetchRoute.on.every.mock.calls.length).toBe(0);
+      const ref = document.querySelector("#test");
+      intersection.update(ref, 1);
+      expect(prefetchRoute.on.every.mock.calls.length).toBe(1);
+    });
+
+    it("stops observing ref and disconnects observer after calling callback", () => {
+      expect(intersection.unobserve.mock.calls.length).toBe(0);
+      expect(intersection.disconnect.mock.calls.length).toBe(0);
+      const wrapper = new Vue({
+        el: node,
+        template: `
+          <div>
+            <curi-prefetch :match="{ name: 'Prefetch' }">
+              <span slot-scope="prefetch" id="test">
+                Test
+              </span>
+            </curi-prefetch>
+          </div>
+        `
+      });
+      expect(prefetchRoute.on.every.mock.calls.length).toBe(1);
+      expect(intersection.unobserve.mock.calls.length).toBe(1);
+      expect(intersection.disconnect.mock.calls.length).toBe(1);
+      const div = document.querySelector("#test");
+      expect(intersection.unobserve.mock.calls[0][0]).toBe(div);
+    });
+  });
+
+  describe("match", () => {
+    let history, router, Vue;
+
+    const match = { name: "Prefetch" };
+    const prefetchRoute = {
+      name: "Prefetch",
+      path: "prefetch",
+      on: {
+        initial: jest.fn(),
+        every: jest.fn()
+      }
+    };
+    const routes = [
+      {
+        name: "Home",
+        path: ""
+      },
+      prefetchRoute,
+      { name: "Not Found", path: "(.*)" }
+    ];
+
+    beforeEach(() => {
+      history = InMemory();
+      router = curi(history, routes, {
+        route: [prefetchInteraction()]
+      });
+      Vue = createLocalVue();
+      Vue.use(CuriPlugin, { router });
+    });
+
+    afterEach(() => {
+      prefetchRoute.on.every.mockReset();
+    });
+
+    it('passes match object to "on" fns', () => {
+      const wrapper = new Vue({
+        el: node,
+        template: `
+          <div>
+            <curi-prefetch :match="{ name: 'Prefetch' }">
+              <span slot-scope="prefetch" id="test">
+                Test
+              </span>
+            </curi-prefetch>
+          </div>
+        `
+      });
+      expect(prefetchRoute.on.initial.mock.calls[0][0]).toMatchObject(match);
+      expect(prefetchRoute.on.every.mock.calls[0][0]).toMatchObject(match);
+    });
+  });
+
+  describe("which", () => {
+    let history, router, Vue;
+    const match = { name: "Prefetch" };
+    const prefetchRoute = {
+      name: "Prefetch",
+      path: "prefetch",
+      on: {
+        initial: jest.fn(),
+        every: jest.fn()
+      }
+    };
+    const routes = [
+      {
+        name: "Home",
+        path: ""
+      },
+      prefetchRoute,
+      { name: "Not Found", path: "(.*)" }
+    ];
+
+    beforeEach(() => {
+      history = InMemory();
+      router = curi(history, routes, {
+        route: [prefetchInteraction()]
+      });
+      Vue = createLocalVue();
+      Vue.use(CuriPlugin, { router });
+    });
+
+    afterEach(() => {
+      prefetchRoute.on.every.mockReset();
+    });
+
+    it("calls both on.initial() and on.every() by default", () => {
+      const wrapper = new Vue({
+        el: node,
+        template: `
+          <div>
+            <curi-prefetch :match="{ name: 'Prefetch' }">
+              <span slot-scope="prefetch" id="test">
+                Test
+              </span>
+            </curi-prefetch>
+          </div>
+        `
+      });
+      expect(prefetchRoute.on.initial.mock.calls.length).toBe(1);
+      expect(prefetchRoute.on.every.mock.calls.length).toBe(1);
+    });
+
+    describe("{ initial: true } (implicit every=false)", () => {
+      it("calls on.initial(), does not call on.every()", () => {
+        const wrapper = new Vue({
+          el: node,
+          template: `
+            <div>
+              <curi-prefetch
+                :match="{ name: 'Prefetch' }"
+                :which="{ initial: true }"
+              >
+                <span slot-scope="prefetch" id="test">
+                  Test
+                </span>
+              </curi-prefetch>
+            </div>
+          `
+        });
+
+        expect(prefetchRoute.on.initial.mock.calls.length).toBe(1);
+        expect(prefetchRoute.on.every.mock.calls.length).toBe(0);
+      });
+    });
+
+    describe("{ every: true } (implicit initial=false)", () => {
+      it("calls on.initial(), does not call on.every()", () => {
+        const wrapper = new Vue({
+          el: node,
+          template: `
+            <div>
+              <curi-prefetch
+                :match="{ name: 'Prefetch' }"
+                :which="{ every: true }"
+              >
+                <span slot-scope="prefetch" id="test">
+                  Test
+                </span>
+              </curi-prefetch>
+            </div>
+          `
+        });
+
+        expect(prefetchRoute.on.initial.mock.calls.length).toBe(0);
+        expect(prefetchRoute.on.every.mock.calls.length).toBe(1);
+      });
+    });
+  });
+
+  describe("scoped slot", () => {
+    let history, router, Vue;
+    const match = { name: "Prefetch" };
+    const prefetchRoute = {
+      name: "Prefetch",
+      path: "prefetch",
+      on: {
+        initial: () => Promise.resolve("initial"),
+        every: () => Promise.resolve("every")
+      }
+    };
+    const routes = [
+      {
+        name: "Home",
+        path: ""
+      },
+      prefetchRoute,
+      { name: "Not Found", path: "(.*)" }
+    ];
+
+    beforeEach(() => {
+      history = InMemory();
+      router = curi(history, routes, {
+        route: [prefetchInteraction()]
+      });
+      Vue = createLocalVue();
+      Vue.use(CuriPlugin, { router });
+    });
+
+    describe("resolved", () => {
+      it("starts out null", () => {
+        intersection.setRatio(0);
+        const CheckPrefetch = {
+          props: ["resolved"],
+          render() {
+            expect(this.resolved).toBe(null);
+            return null;
+          }
+        };
+
+        const wrapper = new Vue({
+          el: node,
+          components: { CheckPrefetch },
+          template: `
+            <div>
+              <curi-prefetch
+                :match="{ name: 'Prefetch' }"
+                :which="{ every: true }"
+              >
+                <CheckPrefetch slot-scope="prefetch" :resolved="prefetch.resolved" />
+              </curi-prefetch>
+            </div>
+          `
+        });
+      });
+
+      it("is the prefetch results once prefetched", done => {
+        const CheckPrefetch = {
+          props: ["resolved"],
+          render(h) {
+            // need to reference resolved to update
+            return h("div", this.resolved && this.resolved.toString());
+          },
+          updated: function() {
+            expect(this.resolved).toMatchObject({
+              initial: "initial",
+              every: "every",
+              error: null
+            });
+            done();
+          }
+        };
+
+        const wrapper = new Vue({
+          el: node,
+          components: { CheckPrefetch },
+          template: `
+            <div>
+              <curi-prefetch :match="{ name: 'Prefetch' }">
+                <CheckPrefetch slot-scope="prefetch" :resolved="prefetch.resolved" />
+              </curi-prefetch>
+            </div>
+          `
+        });
+      });
+    });
+  });
+});

--- a/packages/vue/types/Prefetch.d.ts
+++ b/packages/vue/types/Prefetch.d.ts
@@ -1,0 +1,23 @@
+/// <reference types="react" />
+import Vue from "vue";
+import { ComponentOptions, VNode } from "vue";
+import { HickoryLocation } from "@hickory/root";
+import { Resolved } from "@curi/core";
+export interface WhichOnFns {
+    initial?: boolean;
+    every?: boolean;
+}
+export interface MatchData {
+    name: string;
+    params?: object;
+    location?: HickoryLocation;
+    partials?: Array<string>;
+}
+export declare type MaybeResolved = Resolved | null;
+export interface PrefetchComponent extends Vue {
+    match: MatchData;
+    which?: WhichOnFns;
+    render: (ref: React.RefObject<any>, resolved: MaybeResolved) => VNode;
+}
+declare const Prefetch: ComponentOptions<PrefetchComponent>;
+export default Prefetch;

--- a/packages/vue/types/Prefetch.d.ts
+++ b/packages/vue/types/Prefetch.d.ts
@@ -1,6 +1,5 @@
-/// <reference types="react" />
 import Vue from "vue";
-import { ComponentOptions, VNode } from "vue";
+import { ComponentOptions } from "vue";
 import { HickoryLocation } from "@hickory/root";
 import { Resolved } from "@curi/core";
 export interface WhichOnFns {
@@ -17,7 +16,6 @@ export declare type MaybeResolved = Resolved | null;
 export interface PrefetchComponent extends Vue {
     match: MatchData;
     which?: WhichOnFns;
-    render: (ref: React.RefObject<any>, resolved: MaybeResolved) => VNode;
 }
 declare const Prefetch: ComponentOptions<PrefetchComponent>;
 export default Prefetch;

--- a/packages/vue/types/Prefetch.d.ts
+++ b/packages/vue/types/Prefetch.d.ts
@@ -16,6 +16,7 @@ export declare type MaybeResolved = Resolved | null;
 export interface PrefetchComponent extends Vue {
     match: MatchData;
     which?: WhichOnFns;
+    resolved: MaybeResolved;
 }
 declare const Prefetch: ComponentOptions<PrefetchComponent>;
 export default Prefetch;

--- a/packages/vue/types/index.d.ts
+++ b/packages/vue/types/index.d.ts
@@ -1,5 +1,6 @@
 export { BlockComponent } from "./Block";
 export { LinkComponent } from "./Link";
+export { PrefetchComponent, MatchData, WhichOnFns, MaybeResolved } from "./Prefetch";
 export { ReactiveResponse } from "./interface";
 export { CuriPluginOptions } from "./plugin";
 import CuriPlugin from "./plugin";


### PR DESCRIPTION
A wrapper component to add route prefetching when a component is visible in the page. 

```jsx
<curi-prefetch :match="{ name: 'User', params: { id: 1 } }">
  <curi-link
    slot-scope="prefetch"
    to="User"
    :params="{ id: 1 }"
  >
    User 1
  </curi-link>
</curi-prefetch>
```

This is somewhat limited compared to the React equivalent because Vue does not have callback refs, so the immediate child is the element that will be monitored. `<curi-prefetch>` also relies on its immediate child being a scoped slot.