### PR TITLE
Add cancelled/finished callbacks to router.navigate()

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Add `cancelled` property to `router.navigate()`, which is a function to be called if the navigation is cancelled.
+* Add `cancelled` and `finished` properties to `router.navigate()`, which are functions to be called if the navigation is cancelled/when the navigation is finished.
 
 ## 1.0.0-beta.34
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `cancelled` property to `router.navigate()`, which is a function to be called if the navigation is cancelled.
+
 ## 1.0.0-beta.34
 
 * Bug fix: actually pass arguments object to `on.initial()`.

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -141,10 +141,6 @@ function createRouter(
     if (activeResponse) {
       activeResponse.cancel(pendingNav.action);
       activeResponse.cancelled = true;
-      if (cancelCallback) {
-        cancelCallback();
-        cancelCallback = undefined;
-      }
     }
     activeResponse = pendingNav;
 
@@ -214,6 +210,9 @@ function createRouter(
       return mostRecent;
     },
     navigate(details: NavigationDetails): void {
+      if (cancelCallback) {
+        cancelCallback();
+      }
       let { name, params, hash, query, state, method = "ANCHOR" } = details;
       const pathname =
         name != null

--- a/packages/core/src/curi.ts
+++ b/packages/core/src/curi.ts
@@ -161,6 +161,7 @@ function createRouter(
       );
       pendingNav.finish();
       cancelCallback = undefined;
+      finishCallback = undefined;
       return;
     }
 
@@ -212,6 +213,7 @@ function createRouter(
     navigate(details: NavigationDetails): void {
       if (cancelCallback) {
         cancelCallback();
+        finishCallback = undefined;
       }
       let { name, params, hash, query, state, method = "ANCHOR" } = details;
       const pathname =
@@ -221,12 +223,10 @@ function createRouter(
       if (method !== "ANCHOR" && method !== "PUSH" && method !== "REPLACE") {
         method = "ANCHOR";
       }
-      if (details.cancelled) {
-        cancelCallback = details.cancelled;
-      }
-      if (details.finished) {
-        finishCallback = details.finished;
-      }
+
+      cancelCallback = details.cancelled;
+      finishCallback = details.finished;
+
       history.navigate(
         {
           pathname,

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -48,6 +48,7 @@ export interface NavigationDetails {
   query?: any;
   state?: any;
   method?: NavType;
+  cancelled?: () => void;
 }
 
 export interface CuriRouter {

--- a/packages/core/src/types/curi.ts
+++ b/packages/core/src/types/curi.ts
@@ -49,6 +49,7 @@ export interface NavigationDetails {
   state?: any;
   method?: NavType;
   cancelled?: () => void;
+  finished?: () => void;
 }
 
 export interface CuriRouter {

--- a/packages/core/types/types/curi.d.ts
+++ b/packages/core/types/types/curi.d.ts
@@ -40,6 +40,7 @@ export interface NavigationDetails {
     state?: any;
     method?: NavType;
     cancelled?: () => void;
+    finished?: () => void;
 }
 export interface CuriRouter {
     replaceRoutes: (routeArray: Array<RouteDescriptor>) => void;

--- a/packages/core/types/types/curi.d.ts
+++ b/packages/core/types/types/curi.d.ts
@@ -39,6 +39,7 @@ export interface NavigationDetails {
     query?: any;
     state?: any;
     method?: NavType;
+    cancelled?: () => void;
 }
 export interface CuriRouter {
     replaceRoutes: (routeArray: Array<RouteDescriptor>) => void;

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* `<Link>` children can be a render-invoked prop that receives the link's loading state.
 * Warn when the `ref` passed to `<Prefetch>`'s render-invoked function is `null` after mounting.
 * Pass the object resolved by `route.prefetch()` to `<Prefetch>`'s `children` render-invoked function.
 

--- a/packages/react/types/Link.d.ts
+++ b/packages/react/types/Link.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="react" />
 import React from "react";
 import { CuriRouter, Response } from "@curi/core";
+export declare type LoadingChildren = (loading: boolean) => React.ReactNode;
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     to?: string;
     params?: object;
@@ -9,11 +10,15 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>
     state?: any;
     onClick?: (e: React.MouseEvent<HTMLElement>) => void;
     anchor?: React.ReactType;
+    children: LoadingChildren | React.ReactNode;
 }
 export interface BaseLinkProps extends LinkProps {
     router: CuriRouter;
     response: Response;
     forwardedRef: React.Ref<any> | undefined;
+}
+export interface LinkState {
+    loading: boolean;
 }
 declare const Link: React.ComponentType<LinkProps & React.ClassAttributes<{}>>;
 export default Link;

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.0-beta.17
 
+* Add scoped slot to `<curi-link>` for accessing the link's `loading` state.
 * Add `hash`, `query`, and `state` props to `<curi-link>`, remove `details`.
 * Remove `active` prop from `<curi-link>`.
 

--- a/packages/vue/src/Link.ts
+++ b/packages/vue/src/Link.ts
@@ -11,6 +11,7 @@ export interface LinkComponent extends Vue {
   location: HickoryLocation;
   href: string;
   click(e: MouseEvent): void;
+  loading: boolean;
 }
 
 const canNavigate = (event: MouseEvent) => {
@@ -43,6 +44,12 @@ const Link: ComponentOptions<LinkComponent> = {
     }
   },
 
+  data: function() {
+    return {
+      loading: false
+    };
+  },
+
   methods: {
     clickHandler: function(event: MouseEvent) {
       if (this.click) {
@@ -50,7 +57,22 @@ const Link: ComponentOptions<LinkComponent> = {
       }
       if (canNavigate(event)) {
         event.preventDefault();
-        this.$router.history.navigate(this.location);
+        let cancelled, finished;
+        if (this.$scopedSlots.default) {
+          cancelled = finished = () => {
+            this.loading = false;
+          };
+          this.loading = true;
+        }
+        this.$router.navigate({
+          name: this.to,
+          params: this.params,
+          hash: this.hash,
+          query: this.query,
+          state: this.state,
+          cancelled,
+          finished
+        });
       }
     }
   },
@@ -62,7 +84,11 @@ const Link: ComponentOptions<LinkComponent> = {
         attrs: { href: this.href },
         on: { click: this.clickHandler }
       },
-      this.$slots.default
+      this.$scopedSlots.default
+        ? this.$scopedSlots.default({
+            loading: this.loading
+          })
+        : this.$slots.default
     );
   }
 };

--- a/packages/vue/types/Link.d.ts
+++ b/packages/vue/types/Link.d.ts
@@ -9,6 +9,7 @@ export interface LinkComponent extends Vue {
     location: HickoryLocation;
     href: string;
     click(e: MouseEvent): void;
+    loading: boolean;
 }
 declare const Link: ComponentOptions<LinkComponent>;
 export default Link;


### PR DESCRIPTION
These functions provide escape hatches to render showing navigation status.

`finished` is a function that will be called once the navigation has been completed.

`cancelled` is a function that will be called if a navigation is cancelled (because another navigation superseded it).

```js
router.navigate({
  name: "User",
  params: { id: 1 },
  cancelled: () => {
    // update UI to acknowledge link is no longer navigation
  },
  finished: () => {
    // update UI to acknowledge link has finished navigating
    // this is mostly useful for persistent links
  }
})
```

This PR also make @curi/react's `<Link>` `children` an optional render-invoked prop. If `children` is a function, it will be called with the `<Link>`'s `loading` state (default `false`, `true` while navigating, `false` after navigation finishes or is cancelled).

```jsx
<Link to="User" params={{ id: 2 }}>
  {loading => (
    <React.Fragment>
      User 2
      { loading ? <Spinner /> : null }
    </React.Fragment>
  )}
</Link>
```