### PR TITLE
Add Vue curi-focus directive

### DIFF
--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add a `curi-focus` directive to auto-focus an element when new responses are emitted.
+
 ## 1.0.0-beta.18
 
 * Add scoped slot to `<curi-link>` for accessing the link's `navigating` state.

--- a/packages/vue/scripts/build.js
+++ b/packages/vue/scripts/build.js
@@ -1,25 +1,30 @@
-const rollupBuild = require('../../../scripts/build');
+const rollupBuild = require("../../../scripts/build");
+
+// don't bundle dependencies for es/cjs builds
+const pkg = require("../package.json");
+const deps = Object.keys(pkg.dependencies).map(key => key);
+const depsString = deps.join(",");
 
 rollupBuild(
-  'ES',
-  { f: 'es', o: 'dist/curi-vue.es.js' },
-  { NODE_ENV: 'development', BABEL_ENV: 'build' }
+  "ES",
+  { f: "es", o: "dist/curi-vue.es.js", e: depsString },
+  { NODE_ENV: "development", BABEL_ENV: "build" }
 );
 
 rollupBuild(
-  'CommonJS',
-  { f: 'cjs', o: 'dist/curi-vue.common.js' },
-  { NODE_ENV: 'development', BABEL_ENV: 'build' }
+  "CommonJS",
+  { f: "cjs", o: "dist/curi-vue.common.js", e: depsString },
+  { NODE_ENV: "development", BABEL_ENV: "build" }
 );
 
 rollupBuild(
-  '<script> file',
-  { f: 'iife', o: 'dist/curi-vue.js' },
-  { NODE_ENV: 'development', BABEL_ENV: 'build' }
+  "<script> file",
+  { f: "iife", o: "dist/curi-vue.js" },
+  { NODE_ENV: "development", BABEL_ENV: "build" }
 );
 
 rollupBuild(
-  '<script> min file',
-  { f: 'iife', o: 'dist/curi-vue.min.js' },
-  { NODE_ENV: 'production', BABEL_ENV: 'build' }
+  "<script> min file",
+  { f: "iife", o: "dist/curi-vue.min.js" },
+  { NODE_ENV: "production", BABEL_ENV: "build" }
 );

--- a/packages/vue/src/focus.ts
+++ b/packages/vue/src/focus.ts
@@ -7,7 +7,7 @@ const focusDirection: DirectiveOptions = {
   inserted(el, binding) {
     warning(
       el.hasAttribute("tabIndex") || el.tabIndex !== -1,
-      'The component that is passed the directive must have a "tabIndex" prop or ' +
+      'The element that is passed the "v-curi-focus" directive must have a "tabIndex" prop or ' +
         "be focusable by default in order to be focused. " +
         "Otherwise, the document's <body> will be focused instead."
     );

--- a/packages/vue/src/focus.ts
+++ b/packages/vue/src/focus.ts
@@ -1,0 +1,22 @@
+import Vue, { DirectiveOptions } from "vue";
+import warning from "warning";
+
+export interface FocusComponent extends Vue {}
+
+const focusDirection: DirectiveOptions = {
+  inserted(el, binding) {
+    warning(
+      el.hasAttribute("tabIndex") || el.tabIndex !== -1,
+      'The component that is passed the ref must have a "tabIndex" prop or be focusable by default in order to be focused. ' +
+        "Otherwise, the document's <body> will be focused instead."
+    );
+    el.focus();
+  },
+  componentUpdated(el, binding) {
+    if (binding.value !== binding.oldValue) {
+      el.focus();
+    }
+  }
+};
+
+export default focusDirection;

--- a/packages/vue/src/focus.ts
+++ b/packages/vue/src/focus.ts
@@ -7,12 +7,13 @@ const focusDirection: DirectiveOptions = {
   inserted(el, binding) {
     warning(
       el.hasAttribute("tabIndex") || el.tabIndex !== -1,
-      'The component that is passed the ref must have a "tabIndex" prop or be focusable by default in order to be focused. ' +
+      'The component that is passed the directive must have a "tabIndex" prop or ' +
+        "be focusable by default in order to be focused. " +
         "Otherwise, the document's <body> will be focused instead."
     );
     el.focus();
   },
-  componentUpdated(el, binding) {
+  update(el, binding) {
     if (binding.value !== binding.oldValue) {
       el.focus();
     }

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -3,6 +3,8 @@ import Vue, { PluginObject, VueConstructor } from "vue";
 import Link from "./Link";
 import Block from "./Block";
 
+import focus from "./focus";
+
 import { CuriRouter } from "@curi/core";
 import { ReactiveResponse } from "./interface";
 
@@ -14,6 +16,8 @@ const CuriPlugin: PluginObject<CuriPluginOptions> = {
   install: function(_Vue: typeof Vue, options: CuriPluginOptions) {
     _Vue.component(Link.name, Link);
     _Vue.component(Block.name, Block);
+
+    _Vue.directive("curi-focus", focus);
 
     // create a reactive object so that components will receive
     // the new response/navigation when a new response is emitted

--- a/packages/vue/tests/focus.spec.ts
+++ b/packages/vue/tests/focus.spec.ts
@@ -1,0 +1,188 @@
+import "jest";
+import { createLocalVue } from "@vue/test-utils";
+import InMemory from "@hickory/in-memory";
+import curi from "@curi/core";
+import CuriPlugin from "../src/plugin";
+
+describe("curi-focus directive", () => {
+  const history = InMemory();
+  const mockConfirmWith = jest.fn();
+  const mockRemoveConfirmation = jest.fn();
+
+  const routes = [
+    { name: "Place", path: "/place/:name" },
+    { name: "Catch All", path: "(.*)" }
+  ];
+  const router = curi(history, routes);
+
+  const Vue = createLocalVue();
+  Vue.use(CuriPlugin, { router });
+
+  let node;
+  beforeEach(() => {
+    node = document.createElement("div");
+    document.body.appendChild(node);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("focuses when it renders", () => {
+    const wrapper = new Vue({
+      template: `
+        <div>
+          <main v-curi-focus="$curi.response" tabIndex="-1" id="test" />
+        </div>
+      `,
+      el: node
+    });
+    const div = document.body.querySelector("#test");
+    expect(document.activeElement).toBe(div);
+  });
+
+  it("does not re-focus for regular re-renders", () => {
+    const vueWrapper = new Vue({
+      template: `
+        <div>
+          <main v-curi-focus="$curi.response" tabIndex="-1" id="test">
+            <input :type="type" />
+          </main>
+        </div>
+      `,
+      el: node,
+      data: {
+        type: "text"
+      }
+    });
+    const wrapper = document.querySelector("#test");
+    const initialFocus = document.activeElement;
+    expect(initialFocus).toBe(wrapper);
+
+    const input = document.querySelector("input");
+    // steal the focus
+    input.focus();
+    const stolenFocus = document.activeElement;
+    expect(stolenFocus).toBe(input);
+
+    vueWrapper.type = "number";
+
+    expect(stolenFocus).toBe(input);
+  });
+
+  it("re-focuses for new response re-renders", done => {
+    new Vue({
+      template: `
+        <div>
+          <main v-curi-focus="$curi.response" tabIndex="-1" id="test">
+            <input />
+          </main>
+        </div>
+      `,
+      el: node
+    });
+    const input = document.querySelector("input");
+    const wrapper = input.parentElement;
+    const initialFocused = document.activeElement;
+
+    expect(initialFocused).toBe(wrapper);
+
+    // steal the focus
+    input.focus();
+    const stolenFocus = document.activeElement;
+    expect(stolenFocus).toBe(input);
+
+    // navigate and verify wrapper is re-focused
+    router.navigate({ name: "Place", params: { name: "Hawaii" } });
+
+    // need to wait a tick
+    Vue.nextTick(() => {
+      const postNavFocus = document.activeElement;
+      expect(postNavFocus).toBe(wrapper);
+      done();
+    });
+  });
+
+  it("isn't affected by prop changes", done => {
+    const vueWrapper = new Vue({
+      template: `
+        <div>
+          <main v-curi-focus="$curi.response" tabIndex="-1" :class="wat">
+            <input />
+          </main>
+        </div>
+      `,
+      el: node,
+      data: {
+        wat: "no"
+      }
+    });
+    const input = document.querySelector("input");
+    const wrapper = input.parentElement;
+    const initialFocused = document.activeElement;
+
+    expect(initialFocused).toBe(wrapper);
+    expect(wrapper.className).toBe("no");
+
+    // steal the focus
+    input.focus();
+    const stolenFocus = document.activeElement;
+    expect(stolenFocus).toBe(input);
+
+    vueWrapper.wat = "yes";
+
+    Vue.nextTick(() => {
+      const postUpdateFocus = document.activeElement;
+      expect(postUpdateFocus).toBe(input);
+
+      expect(wrapper.className).toBe("yes");
+      done();
+    });
+  });
+
+  describe("tabIndex", () => {
+    it("warns when ref element does not have a tabIndex attribute", () => {
+      const realWarn = console.error;
+      const fakeWarn = (console.error = jest.fn());
+
+      const wrapper = new Vue({
+        template: `
+          <div>
+            <main v-curi-focus="$curi.response" id="test" />
+          </div>
+        `,
+        el: node
+      });
+      expect(fakeWarn.mock.calls.length).toBe(1);
+      expect(document.activeElement).toBe(document.body);
+      console.error = realWarn;
+    });
+
+    it("does not warn when ref element does not have a tabIndex attribute, but ele is already focusable", () => {
+      const realWarn = console.error;
+      const fakeWarn = (console.error = jest.fn());
+
+      const wrapper = new Vue({
+        template: `
+          <div>
+            <input
+              type="text"
+              v-curi-focus="$curi.response"
+              id="test"
+            />
+          </div>
+        `,
+        el: node,
+        data: {
+          response: {
+            name: "Test"
+          }
+        }
+      });
+      expect(fakeWarn.mock.calls.length).toBe(0);
+      const input = document.body.querySelector("input");
+      expect(document.activeElement).toBe(input);
+      console.error = realWarn;
+    });
+  });
+});

--- a/packages/vue/tests/focus.spec.ts
+++ b/packages/vue/tests/focus.spec.ts
@@ -5,6 +5,7 @@ import curi from "@curi/core";
 import CuriPlugin from "../src/plugin";
 
 describe("curi-focus directive", () => {
+  let vueWrapper;
   const history = InMemory();
   const mockConfirmWith = jest.fn();
   const mockRemoveConfirmation = jest.fn();
@@ -25,27 +26,34 @@ describe("curi-focus directive", () => {
   });
 
   afterEach(() => {
+    vueWrapper.$destroy();
     document.body.innerHTML = "";
   });
 
   it("focuses when it renders", () => {
-    const wrapper = new Vue({
+    vueWrapper = new Vue({
       template: `
         <div>
-          <main v-curi-focus="$curi.response" tabIndex="-1" id="test" />
+          <main
+            v-curi-focus="$curi.response"
+            tabIndex="-1"
+          />
         </div>
       `,
       el: node
     });
-    const div = document.body.querySelector("#test");
-    expect(document.activeElement).toBe(div);
+    const main = document.querySelector("main");
+    expect(document.activeElement).toBe(main);
   });
 
   it("does not re-focus for regular re-renders", () => {
-    const vueWrapper = new Vue({
+    vueWrapper = new Vue({
       template: `
         <div>
-          <main v-curi-focus="$curi.response" tabIndex="-1" id="test">
+          <main
+            v-curi-focus="$curi.response"
+            tabIndex="-1"
+          >
             <input :type="type" />
           </main>
         </div>
@@ -55,7 +63,7 @@ describe("curi-focus directive", () => {
         type: "text"
       }
     });
-    const wrapper = document.querySelector("#test");
+    const wrapper = document.querySelector("main");
     const initialFocus = document.activeElement;
     expect(initialFocus).toBe(wrapper);
 
@@ -71,10 +79,13 @@ describe("curi-focus directive", () => {
   });
 
   it("re-focuses for new response re-renders", done => {
-    new Vue({
+    vueWrapper = new Vue({
       template: `
         <div>
-          <main v-curi-focus="$curi.response" tabIndex="-1" id="test">
+          <main
+            v-curi-focus="$curi.response"
+            tabIndex="-1"
+          >
             <input />
           </main>
         </div>
@@ -104,7 +115,7 @@ describe("curi-focus directive", () => {
   });
 
   it("isn't affected by prop changes", done => {
-    const vueWrapper = new Vue({
+    vueWrapper = new Vue({
       template: `
         <div>
           <main v-curi-focus="$curi.response" tabIndex="-1" :class="wat">
@@ -141,14 +152,14 @@ describe("curi-focus directive", () => {
   });
 
   describe("tabIndex", () => {
-    it("warns when ref element does not have a tabIndex attribute", () => {
+    it("warns when element with directive does not have a tabIndex attribute", () => {
       const realWarn = console.error;
       const fakeWarn = (console.error = jest.fn());
 
-      const wrapper = new Vue({
+      vueWrapper = new Vue({
         template: `
           <div>
-            <main v-curi-focus="$curi.response" id="test" />
+            <main v-curi-focus="$curi.response" />
           </div>
         `,
         el: node
@@ -158,17 +169,16 @@ describe("curi-focus directive", () => {
       console.error = realWarn;
     });
 
-    it("does not warn when ref element does not have a tabIndex attribute, but ele is already focusable", () => {
+    it("does not warn when element with directive does not have a tabIndex attribute, but ele is already focusable", () => {
       const realWarn = console.error;
       const fakeWarn = (console.error = jest.fn());
 
-      const wrapper = new Vue({
+      vueWrapper = new Vue({
         template: `
           <div>
             <input
               type="text"
               v-curi-focus="$curi.response"
-              id="test"
             />
           </div>
         `,

--- a/packages/vue/types/focus.d.ts
+++ b/packages/vue/types/focus.d.ts
@@ -1,0 +1,5 @@
+import Vue, { DirectiveOptions } from 'vue';
+export interface FocusComponent extends Vue {
+}
+declare const focusDirection: DirectiveOptions;
+export default focusDirection;

--- a/packages/vue/types/focus.d.ts
+++ b/packages/vue/types/focus.d.ts
@@ -1,4 +1,4 @@
-import Vue, { DirectiveOptions } from 'vue';
+import Vue, { DirectiveOptions } from "vue";
 export interface FocusComponent extends Vue {
 }
 declare const focusDirection: DirectiveOptions;

--- a/website/src/client/pages/Packages/Vue.js
+++ b/website/src/client/pages/Packages/Vue.js
@@ -216,6 +216,39 @@ Vue.use(CuriPlugin, { router });`}
           </CodeBlock>
         </SideBySide>
       </Section>
+
+      <Section title={<IJS>curi-focus</IJS>} id="curi-focus">
+        <SideBySide>
+          <Explanation>
+            <p>
+              The <IJS>curi-focus</IJS> directive is used to specify an element
+              that should be focused when a new response is emitted.
+            </p>
+            <p>
+              The DOM component that gets the ref should either already be
+              "focusable", like an <Cmp>input</Cmp>, or be given a{" "}
+              <IJS>tabIndex</IJS> prop (usually with the value of <IJS>-1</IJS>).
+              If neither of these conditions is met, then the document's{" "}
+              <Cmp>body</Cmp> will be focused.
+            </p>
+            <p>
+              The focused element will have an outline (the exact style varies
+              by browser). You can remove this visual with a CSS outline of{" "}
+              <IJS>"none"</IJS>.
+            </p>
+            <Note>
+              You should only have one focused element rendered at a time.
+            </Note>
+          </Explanation>
+          <CodeBlock lang="html">
+            {`<template>
+  <main :tabIndex="-1" v-curi-focus="$curi.response">
+    <component :is="$curi.response.body" />
+  </main>
+</template>`}
+          </CodeBlock>
+        </SideBySide>
+      </Section>
     </APIBlock>
 
     <Section title="Usage" id="usage">


### PR DESCRIPTION
A Vue directive to automatically focus an element when new responses are emitted.
```html
<main :tabIndex="-1" v-curi-focus="$curi.response">
  <component :is="$curi.response.body" />
</main>
```
Warns if the element the directive is attached to isn't natively-focusable or doesn't have a `tabIndex` of `-1` set on it.

The current `response` is passed to the directive so that it can detect when there is a new response and re-focus.