### PR TITLE
Add @curi/sitemap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,14 +22,14 @@
 				"@babel/template": "7.0.0-beta.49",
 				"@babel/traverse": "7.0.0-beta.49",
 				"@babel/types": "7.0.0-beta.49",
-				"convert-source-map": "1.5.1",
-				"debug": "3.1.0",
-				"json5": "0.5.1",
-				"lodash": "4.17.10",
-				"micromatch": "2.3.11",
-				"resolve": "1.7.1",
-				"semver": "5.5.0",
-				"source-map": "0.5.7"
+				"convert-source-map": "^1.1.0",
+				"debug": "^3.1.0",
+				"json5": "^0.5.0",
+				"lodash": "^4.17.5",
+				"micromatch": "^2.3.11",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -45,10 +45,10 @@
 			"integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
 			"requires": {
 				"@babel/types": "7.0.0-beta.49",
-				"jsesc": "2.5.1",
-				"lodash": "4.17.10",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.5",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -75,15 +75,6 @@
 				"@babel/types": "7.0.0-beta.49"
 			}
 		},
-		"@babel/helper-builder-react-jsx": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.49.tgz",
-			"integrity": "sha1-5sNfjIjpAJMTn6ezAn0FzOtH9D0=",
-			"requires": {
-				"@babel/types": "7.0.0-beta.49",
-				"esutils": "2.0.2"
-			}
-		},
 		"@babel/helper-call-delegate": {
 			"version": "7.0.0-beta.49",
 			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.49.tgz",
@@ -101,7 +92,7 @@
 			"requires": {
 				"@babel/helper-function-name": "7.0.0-beta.49",
 				"@babel/types": "7.0.0-beta.49",
-				"lodash": "4.17.10"
+				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
@@ -153,7 +144,7 @@
 			"integrity": "sha1-QdfVmJEBbEk0MqRvdGREZVKJDHU=",
 			"requires": {
 				"@babel/types": "7.0.0-beta.49",
-				"lodash": "4.17.10"
+				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/helper-module-transforms": {
@@ -166,7 +157,7 @@
 				"@babel/helper-split-export-declaration": "7.0.0-beta.49",
 				"@babel/template": "7.0.0-beta.49",
 				"@babel/types": "7.0.0-beta.49",
-				"lodash": "4.17.10"
+				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -187,7 +178,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.49.tgz",
 			"integrity": "sha1-/yRPGcKi8Wf/SzFlpjawj9ZBgWs=",
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -220,7 +211,7 @@
 			"requires": {
 				"@babel/template": "7.0.0-beta.49",
 				"@babel/types": "7.0.0-beta.49",
-				"lodash": "4.17.10"
+				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -257,9 +248,9 @@
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
 			"integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
 			"requires": {
-				"chalk": "2.4.1",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"@babel/parser": {
@@ -283,19 +274,6 @@
 				"@babel/helper-plugin-utils": "7.0.0-beta.49",
 				"@babel/helper-remap-async-to-generator": "7.0.0-beta.49",
 				"@babel/plugin-syntax-async-generators": "7.0.0-beta.49"
-			}
-		},
-		"@babel/plugin-proposal-class-properties": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.49.tgz",
-			"integrity": "sha1-Un6Qr3XSP9XjuuGiGNwKbZI2tfE=",
-			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.49",
-				"@babel/helper-member-expression-to-functions": "7.0.0-beta.49",
-				"@babel/helper-optimise-call-expression": "7.0.0-beta.49",
-				"@babel/helper-plugin-utils": "7.0.0-beta.49",
-				"@babel/helper-replace-supers": "7.0.0-beta.49",
-				"@babel/plugin-syntax-class-properties": "7.0.0-beta.49"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
@@ -323,37 +301,13 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "7.0.0-beta.49",
 				"@babel/helper-regex": "7.0.0-beta.49",
-				"regexpu-core": "4.1.5"
+				"regexpu-core": "^4.1.4"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
 			"version": "7.0.0-beta.49",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.49.tgz",
 			"integrity": "sha1-UO6UMAKu3JqzqNEikr013Z7bHfg=",
-			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.49"
-			}
-		},
-		"@babel/plugin-syntax-class-properties": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.49.tgz",
-			"integrity": "sha1-ahT6R86qMrU+FOZkgyblLaswaQQ=",
-			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.49"
-			}
-		},
-		"@babel/plugin-syntax-dynamic-import": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.49.tgz",
-			"integrity": "sha1-8K96xrU2dqSWCT1KbiouxlXAe3g=",
-			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.49"
-			}
-		},
-		"@babel/plugin-syntax-jsx": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.49.tgz",
-			"integrity": "sha1-FbgyUEtJ8Rb5xITo5ApeF8VC7RM=",
 			"requires": {
 				"@babel/helper-plugin-utils": "7.0.0-beta.49"
 			}
@@ -406,7 +360,7 @@
 			"integrity": "sha1-3Vqd3ZhndciyDPW2EGWvs92eqsk=",
 			"requires": {
 				"@babel/helper-plugin-utils": "7.0.0-beta.49",
-				"lodash": "4.17.10"
+				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/plugin-transform-classes": {
@@ -421,7 +375,7 @@
 				"@babel/helper-plugin-utils": "7.0.0-beta.49",
 				"@babel/helper-replace-supers": "7.0.0-beta.49",
 				"@babel/helper-split-export-declaration": "7.0.0-beta.49",
-				"globals": "11.5.0"
+				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
@@ -447,7 +401,7 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "7.0.0-beta.49",
 				"@babel/helper-regex": "7.0.0-beta.49",
-				"regexpu-core": "4.1.5"
+				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -556,48 +510,12 @@
 				"@babel/helper-plugin-utils": "7.0.0-beta.49"
 			}
 		},
-		"@babel/plugin-transform-react-display-name": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.49.tgz",
-			"integrity": "sha1-JCoAa/QSKpOyc/ad/mw5Sg/Oxjg=",
-			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.49"
-			}
-		},
-		"@babel/plugin-transform-react-jsx": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.49.tgz",
-			"integrity": "sha1-DyeJ/eMFw8FBUYSPhRSirxRBr1g=",
-			"requires": {
-				"@babel/helper-builder-react-jsx": "7.0.0-beta.49",
-				"@babel/helper-plugin-utils": "7.0.0-beta.49",
-				"@babel/plugin-syntax-jsx": "7.0.0-beta.49"
-			}
-		},
-		"@babel/plugin-transform-react-jsx-self": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.49.tgz",
-			"integrity": "sha1-oRgoujgDXBqpP9RAmbmJcBn6VGw=",
-			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.49",
-				"@babel/plugin-syntax-jsx": "7.0.0-beta.49"
-			}
-		},
-		"@babel/plugin-transform-react-jsx-source": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.49.tgz",
-			"integrity": "sha1-Bbt0KbbdRMvcppWFSBNHqAnKqMo=",
-			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.49",
-				"@babel/plugin-syntax-jsx": "7.0.0-beta.49"
-			}
-		},
 		"@babel/plugin-transform-regenerator": {
 			"version": "7.0.0-beta.49",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.49.tgz",
 			"integrity": "sha1-1O15ZwM/T1tJNjwgNQOJm4NXyuI=",
 			"requires": {
-				"regenerator-transform": "0.12.4"
+				"regenerator-transform": "^0.12.3"
 			},
 			"dependencies": {
 				"regenerator-transform": {
@@ -605,7 +523,7 @@
 					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.4.tgz",
 					"integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
 					"requires": {
-						"private": "0.1.8"
+						"private": "^0.1.6"
 					}
 				}
 			}
@@ -659,7 +577,7 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "7.0.0-beta.49",
 				"@babel/helper-regex": "7.0.0-beta.49",
-				"regexpu-core": "4.1.5"
+				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/preset-env": {
@@ -703,55 +621,9 @@
 				"@babel/plugin-transform-template-literals": "7.0.0-beta.49",
 				"@babel/plugin-transform-typeof-symbol": "7.0.0-beta.49",
 				"@babel/plugin-transform-unicode-regex": "7.0.0-beta.49",
-				"browserslist": "3.2.8",
-				"invariant": "2.2.4",
-				"semver": "5.5.0"
-			}
-		},
-		"@babel/preset-react": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.49.tgz",
-			"integrity": "sha1-DIZ3D254pJr2+GlC9ZgL61/rdsU=",
-			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.49",
-				"@babel/plugin-transform-react-display-name": "7.0.0-beta.49",
-				"@babel/plugin-transform-react-jsx": "7.0.0-beta.49",
-				"@babel/plugin-transform-react-jsx-self": "7.0.0-beta.49",
-				"@babel/plugin-transform-react-jsx-source": "7.0.0-beta.49"
-			}
-		},
-		"@babel/register": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.49.tgz",
-			"integrity": "sha1-V+gjpQYuPd0lVIOY6fUHfBeZHwg=",
-			"requires": {
-				"core-js": "2.5.7",
-				"find-cache-dir": "1.0.0",
-				"home-or-tmp": "3.0.0",
-				"lodash": "4.17.10",
-				"mkdirp": "0.5.1",
-				"pirates": "3.0.2",
-				"source-map-support": "0.4.18"
-			},
-			"dependencies": {
-				"home-or-tmp": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-					"integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"source-map-support": {
-					"version": "0.4.18",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-					"requires": {
-						"source-map": "0.5.7"
-					}
-				}
+				"browserslist": "^3.0.0",
+				"invariant": "^2.2.2",
+				"semver": "^5.3.0"
 			}
 		},
 		"@babel/template": {
@@ -762,7 +634,7 @@
 				"@babel/code-frame": "7.0.0-beta.49",
 				"@babel/parser": "7.0.0-beta.49",
 				"@babel/types": "7.0.0-beta.49",
-				"lodash": "4.17.10"
+				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/traverse": {
@@ -776,10 +648,10 @@
 				"@babel/helper-split-export-declaration": "7.0.0-beta.49",
 				"@babel/parser": "7.0.0-beta.49",
 				"@babel/types": "7.0.0-beta.49",
-				"debug": "3.1.0",
-				"globals": "11.5.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.10"
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.17.5"
 			}
 		},
 		"@babel/types": {
@@ -787,56 +659,17 @@
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
 			"integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
 			"requires": {
-				"esutils": "2.0.2",
-				"lodash": "4.17.10",
-				"to-fast-properties": "2.0.0"
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.5",
+				"to-fast-properties": "^2.0.0"
 			}
-		},
-		"@curi/addon-ancestors": {
-			"version": "1.0.0-beta.5",
-			"resolved": "https://registry.npmjs.org/@curi/addon-ancestors/-/addon-ancestors-1.0.0-beta.5.tgz",
-			"integrity": "sha512-muBAA3w/7RJlhatnDkYbQ3135pUo9nJIKBcbSSl0gbXMIiMlauCHFYSEIQQxuI0S8jNOuOUZBDC1a/Aml4GVPw==",
-			"requires": {
-				"@curi/core": "1.0.0-beta.36"
-			}
-		},
-		"@curi/core": {
-			"version": "1.0.0-beta.36",
-			"resolved": "https://registry.npmjs.org/@curi/core/-/core-1.0.0-beta.36.tgz",
-			"integrity": "sha512-s5IWn08MM6KRTKKgV11duJwEWsggmCjxexghaP6dVHkXiwkLzkN5PzQSVceopIogy8tZ4QCCr5I978Uo+5jl4g==",
-			"requires": {
-				"@curi/router": "1.0.0-beta.36"
-			}
-		},
-		"@curi/router": {
-			"version": "1.0.0-beta.36",
-			"resolved": "https://registry.npmjs.org/@curi/router/-/router-1.0.0-beta.36.tgz",
-			"integrity": "sha512-4zz7oi6/NYD1Cn2K+GS6QKZdtryhE0bBXZGOeUspwX2eF1I+v+VOgeBwR7Ag6zNqP/14y1t08BVF3OOcHwzNTg==",
-			"requires": {
-				"@hickory/root": "1.0.0-beta.8",
-				"path-to-regexp": "2.2.1"
-			}
-		},
-		"@hickory/browser": {
-			"version": "1.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@hickory/browser/-/browser-1.0.0-beta.7.tgz",
-			"integrity": "sha512-/C69RdMaQSiXZZdXopK4RPEoY16EiVzA3BJTSsolvX4B6GIL9CFhGiYQDNGeo6BFm82krrQGBSr4Rz57Z3Dixw==",
-			"requires": {
-				"@hickory/dom-utils": "1.0.0-beta.2",
-				"@hickory/root": "1.0.0-beta.8"
-			}
-		},
-		"@hickory/dom-utils": {
-			"version": "1.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/@hickory/dom-utils/-/dom-utils-1.0.0-beta.2.tgz",
-			"integrity": "sha512-DIn2PrhYH2z8h899uE73ssMrEYB2NMYb8z+n7xGsjrOWO7ip4dmg2hIgKVVrMPTGbReJWHxe8iPGYwpyEnFFRg=="
 		},
 		"@hickory/in-memory": {
 			"version": "1.0.0-beta.5",
 			"resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-1.0.0-beta.5.tgz",
 			"integrity": "sha512-OkLkmPbDrbLns8OCdCt6tV1orvPI1PUnhvWCNBqOendcjq9PRfWt1p/8rXbM0iOajDNSlK4kktEdk63QHcsRNw==",
 			"requires": {
-				"@hickory/root": "1.0.0-beta.8"
+				"@hickory/root": "^1.0.0-beta.8"
 			}
 		},
 		"@hickory/location-utils": {
@@ -849,7 +682,7 @@
 			"resolved": "https://registry.npmjs.org/@hickory/root/-/root-1.0.0-beta.8.tgz",
 			"integrity": "sha512-DkQyLxigG5Cm4WU9fwpHIllAp+2XOnLKUGlORApVcw/xbM2TO2SeXoWyyT1VTwApsOyeo4k2W9GSHl7zDGWkHw==",
 			"requires": {
-				"@hickory/location-utils": "1.0.0-beta.2"
+				"@hickory/location-utils": "^1.0.0-beta.2"
 			}
 		},
 		"@types/cheerio": {
@@ -862,8 +695,8 @@
 			"resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-2.8.12.tgz",
 			"integrity": "sha512-yiUV6c6f2heD1rnw5jQjRNrszS1fEFLWorrMGa3CKfCLI/a6eInzHuTrlT6GzFq8HbzdRYUeYXABNP1QKMDVLQ==",
 			"requires": {
-				"@types/cheerio": "0.22.7",
-				"@types/react": "16.3.17"
+				"@types/cheerio": "*",
+				"@types/react": "*"
 			}
 		},
 		"@types/estree": {
@@ -891,7 +724,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.17.tgz",
 			"integrity": "sha512-f2ZTOSF7l9sRdXSbzLI84Z2wsVnj3qUjfJhtDLSi7lTWFMo1WSou7eQ2vkQga8100zhzzDjSyGbj+Viz7i927g==",
 			"requires": {
-				"csstype": "2.5.3"
+				"csstype": "^2.2.0"
 			}
 		},
 		"@types/react-dom": {
@@ -899,8 +732,8 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.6.tgz",
 			"integrity": "sha512-M+1zmwa5KxUpkCuxA4whlDJKYTGNvNQW4pIoCLH16xGbClicD9CzPry4y94kTjCCk/bJZCZ/GVqUsP7eKcO/mQ==",
 			"requires": {
-				"@types/node": "8.10.18",
-				"@types/react": "16.3.17"
+				"@types/node": "*",
+				"@types/react": "*"
 			}
 		},
 		"@types/react-native": {
@@ -908,7 +741,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.52.25.tgz",
 			"integrity": "sha512-JwrONoGfasRORI3QUILXar8xG9Q3rCS2EpfB2abGIvqWRISuRPKpjJOm4OL0tEBTPL/9r6hcngRrmYZSbvDDtw==",
 			"requires": {
-				"@types/react": "16.3.17"
+				"@types/react": "*"
 			}
 		},
 		"@vue/test-utils": {
@@ -916,7 +749,7 @@
 			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.16.tgz",
 			"integrity": "sha512-TF9ae3zhs8qBN98Bix2Bh3IrwkhscEV3HRthPgtzJPNG0YHUyNTlZNXH36vbP0nuSAs9Om8XjVd8/MDj8ehpEA==",
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.17.4"
 			}
 		},
 		"JSONStream": {
@@ -924,28 +757,14 @@
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
 			"integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
 			"requires": {
-				"jsonparse": "1.3.1",
-				"through": "2.3.8"
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
 			}
 		},
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
 			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
-		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-		},
-		"accepts": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-			"requires": {
-				"mime-types": "2.1.18",
-				"negotiator": "0.6.1"
-			}
 		},
 		"acorn": {
 			"version": "5.6.2",
@@ -957,7 +776,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"requires": {
-				"acorn": "5.6.2"
+				"acorn": "^5.0.0"
 			}
 		},
 		"add-stream": {
@@ -970,31 +789,21 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
-		},
-		"ajv-keywords": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
 		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
 			}
-		},
-		"alphanum-sort": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
 		},
 		"amdefine": {
 			"version": "1.0.1",
@@ -1016,7 +825,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
-				"color-convert": "1.9.1"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"anymatch": {
@@ -1024,8 +833,8 @@
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "3.1.10",
-				"normalize-path": "2.1.1"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -1043,16 +852,16 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1060,7 +869,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1078,13 +887,13 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1092,7 +901,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -1100,7 +909,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1108,7 +917,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1116,7 +925,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1126,7 +935,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1134,7 +943,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1144,9 +953,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -1161,14 +970,14 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1176,7 +985,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -1184,7 +993,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1194,10 +1003,10 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1205,7 +1014,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1215,7 +1024,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -1223,7 +1032,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -1231,9 +1040,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-number": {
@@ -1241,7 +1050,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1249,7 +1058,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1269,19 +1078,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"normalize-path": {
@@ -1289,7 +1098,7 @@
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"requires": {
-						"remove-trailing-separator": "1.1.0"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				}
 			}
@@ -1299,7 +1108,7 @@
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
 			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
 			"requires": {
-				"default-require-extensions": "2.0.0"
+				"default-require-extensions": "^2.0.0"
 			}
 		},
 		"aproba": {
@@ -1312,8 +1121,8 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"requires": {
-				"delegates": "1.0.0",
-				"readable-stream": "2.3.6"
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
 			}
 		},
 		"argparse": {
@@ -1321,7 +1130,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
@@ -1329,7 +1138,7 @@
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"requires": {
-				"arr-flatten": "1.1.0"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-flatten": {
@@ -1352,11 +1161,6 @@
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
 		},
-		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -1367,7 +1171,7 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -1415,11 +1219,6 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
-		"async-foreach": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
-		},
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
@@ -1434,30 +1233,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
 			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
-		},
-		"autoprefixer": {
-			"version": "7.2.6",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
-			"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
-			"requires": {
-				"browserslist": "2.11.3",
-				"caniuse-lite": "1.0.30000848",
-				"normalize-range": "0.1.2",
-				"num2fraction": "1.2.2",
-				"postcss": "6.0.22",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "2.11.3",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-					"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-					"requires": {
-						"caniuse-lite": "1.0.30000848",
-						"electron-to-chromium": "1.3.48"
-					}
-				}
-			}
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -1474,9 +1249,9 @@
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -1489,11 +1264,11 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -1504,59 +1279,23 @@
 			}
 		},
 		"babel-core": {
-			"version": "6.26.3",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.1",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.1",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
-			}
+			"version": "7.0.0-bridge.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+			"integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
 		},
 		"babel-generator": {
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.10",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"detect-indent": {
@@ -1564,7 +1303,7 @@
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"jsesc": {
@@ -1579,24 +1318,14 @@
 				}
 			}
 		},
-		"babel-helper-builder-binary-assignment-operator-visitor": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
 		"babel-helper-builder-react-jsx": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"esutils": "2.0.2"
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"esutils": "^2.0.2"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -1604,10 +1333,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-define-map": {
@@ -1615,20 +1344,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.10"
-			}
-		},
-		"babel-helper-explode-assignable-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-function-name": {
@@ -1636,11 +1355,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -1648,8 +1367,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -1657,8 +1376,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -1666,30 +1385,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-regex": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.10"
-			}
-		},
-		"babel-helper-remap-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -1697,12 +1394,12 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
@@ -1710,8 +1407,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-jest": {
@@ -1719,18 +1416,8 @@
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
 			"integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
 			"requires": {
-				"babel-plugin-istanbul": "4.1.6",
-				"babel-preset-jest": "22.4.4"
-			}
-		},
-		"babel-loader": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
-			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
-			"requires": {
-				"find-cache-dir": "1.0.0",
-				"loader-utils": "1.1.0",
-				"mkdirp": "0.5.1"
+				"babel-plugin-istanbul": "^4.1.5",
+				"babel-preset-jest": "^22.4.4"
 			}
 		},
 		"babel-messages": {
@@ -1738,7 +1425,7 @@
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -1746,15 +1433,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-dynamic-import-node": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.2.0.tgz",
-			"integrity": "sha512-yeDwKaLgGdTpXL7RgGt5r6T4LmnTza/hUn5Ul8uZSGGMtEjYo13Nxai7SQaGCTEzUtg9Zq9qJn0EjEr7SeSlTQ==",
-			"requires": {
-				"babel-plugin-syntax-dynamic-import": "6.18.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -1762,10 +1441,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"test-exclude": "4.2.1"
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+				"find-up": "^2.1.0",
+				"istanbul-lib-instrument": "^1.10.1",
+				"test-exclude": "^4.2.1"
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -1778,7 +1457,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
 			"integrity": "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.6.1"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -1795,16 +1474,6 @@
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
 			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
-		},
-		"babel-plugin-syntax-exponentiation-operator": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-		},
-		"babel-plugin-syntax-export-extensions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
@@ -1826,25 +1495,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
 			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
 		},
-		"babel-plugin-transform-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.26.0"
-			}
-		},
 		"babel-plugin-transform-class-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-plugin-syntax-class-properties": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-plugin-syntax-class-properties": "^6.8.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1852,15 +1511,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoped-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1868,11 +1519,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.10"
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1880,15 +1531,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"requires": {
-				"babel-helper-define-map": "6.26.0",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-define-map": "^6.24.1",
+				"babel-helper-function-name": "^6.24.1",
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1896,8 +1547,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1905,16 +1556,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-duplicate-keys": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1922,7 +1564,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1930,9 +1572,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1940,17 +1582,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-amd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1958,39 +1590,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-systemjs": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-umd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-object-super": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-types": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1998,12 +1601,12 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -2011,8 +1614,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -2020,17 +1623,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-sticky-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -2038,74 +1631,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-typeof-symbol": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-unicode-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-				},
-				"regexpu-core": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-					"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-					"requires": {
-						"regenerate": "1.4.0",
-						"regjsgen": "0.2.0",
-						"regjsparser": "0.1.5"
-					}
-				},
-				"regjsgen": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-				},
-				"regjsparser": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-					"requires": {
-						"jsesc": "0.5.0"
-					}
-				}
-			}
-		},
-		"babel-plugin-transform-exponentiation-operator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-export-extensions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
-			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-			"requires": {
-				"babel-plugin-syntax-export-extensions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -2113,8 +1639,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"requires": {
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-flow": "^6.18.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-object-assign": {
@@ -2122,7 +1648,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
 			"integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -2130,8 +1656,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
+				"babel-runtime": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
@@ -2139,7 +1665,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -2147,18 +1673,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"requires": {
-				"babel-helper-builder-react-jsx": "6.26.0",
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-react-jsx-self": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-builder-react-jsx": "^6.24.1",
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
@@ -2166,8 +1683,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -2175,97 +1692,16 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"requires": {
-				"regenerator-transform": "0.10.1"
+				"regenerator-transform": "^0.10.0"
 			}
-		},
-		"babel-plugin-transform-require-ignore": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-require-ignore/-/babel-plugin-transform-require-ignore-0.1.1.tgz",
-			"integrity": "sha512-A7EmlVd3ZYWJI3eg3dklAXn1yfq8Y5omHMQgAUo0FwGLYRuL5daLR6+LtCVHi4f9+fStr7HuPkW9rmKtcmY67w=="
 		},
 		"babel-plugin-transform-strict-mode": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-preset-env": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-			"integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0",
-				"browserslist": "3.2.8",
-				"invariant": "2.2.4",
-				"semver": "5.5.0"
-			}
-		},
-		"babel-preset-es2015": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0"
-			}
-		},
-		"babel-preset-flow": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-			"requires": {
-				"babel-plugin-transform-flow-strip-types": "6.22.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-preset-jest": {
@@ -2273,21 +1709,8 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
 			"integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
 			"requires": {
-				"babel-plugin-jest-hoist": "22.4.4",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0"
-			}
-		},
-		"babel-preset-react": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-plugin-transform-react-display-name": "6.25.0",
-				"babel-plugin-transform-react-jsx": "6.24.1",
-				"babel-plugin-transform-react-jsx-self": "6.22.0",
-				"babel-plugin-transform-react-jsx-source": "6.22.0",
-				"babel-preset-flow": "6.23.0"
+				"babel-plugin-jest-hoist": "^22.4.4",
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
 		"babel-preset-react-native": {
@@ -2295,37 +1718,37 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-4.0.0.tgz",
 			"integrity": "sha512-Wfbo6x244nUbBxjr7hQaNFdjj7FDYU+TVT7cFVPEdVPI68vhN52iLvamm+ErhNdHq6M4j1cMT6AJBYx7Wzdr0g==",
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-react-transform": "3.0.0",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-plugin-syntax-class-properties": "6.13.0",
-				"babel-plugin-syntax-dynamic-import": "6.18.0",
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-class-properties": "6.24.1",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-flow-strip-types": "6.22.0",
-				"babel-plugin-transform-object-assign": "6.22.0",
-				"babel-plugin-transform-object-rest-spread": "6.26.0",
-				"babel-plugin-transform-react-display-name": "6.25.0",
-				"babel-plugin-transform-react-jsx": "6.24.1",
-				"babel-plugin-transform-react-jsx-source": "6.22.0",
-				"babel-plugin-transform-regenerator": "6.26.0",
-				"babel-template": "6.26.0",
-				"react-transform-hmr": "1.0.4"
+				"babel-plugin-check-es2015-constants": "^6.5.0",
+				"babel-plugin-react-transform": "^3.0.0",
+				"babel-plugin-syntax-async-functions": "^6.5.0",
+				"babel-plugin-syntax-class-properties": "^6.5.0",
+				"babel-plugin-syntax-dynamic-import": "^6.18.0",
+				"babel-plugin-syntax-flow": "^6.5.0",
+				"babel-plugin-syntax-jsx": "^6.5.0",
+				"babel-plugin-syntax-trailing-function-commas": "^6.5.0",
+				"babel-plugin-transform-class-properties": "^6.5.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.5.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.5.0",
+				"babel-plugin-transform-es2015-classes": "^6.5.0",
+				"babel-plugin-transform-es2015-computed-properties": "^6.5.0",
+				"babel-plugin-transform-es2015-destructuring": "^6.5.0",
+				"babel-plugin-transform-es2015-for-of": "^6.5.0",
+				"babel-plugin-transform-es2015-function-name": "^6.5.0",
+				"babel-plugin-transform-es2015-literals": "^6.5.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.5.0",
+				"babel-plugin-transform-es2015-parameters": "^6.5.0",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.5.0",
+				"babel-plugin-transform-es2015-spread": "^6.5.0",
+				"babel-plugin-transform-es2015-template-literals": "^6.5.0",
+				"babel-plugin-transform-flow-strip-types": "^6.5.0",
+				"babel-plugin-transform-object-assign": "^6.5.0",
+				"babel-plugin-transform-object-rest-spread": "^6.5.0",
+				"babel-plugin-transform-react-display-name": "^6.5.0",
+				"babel-plugin-transform-react-jsx": "^6.5.0",
+				"babel-plugin-transform-react-jsx-source": "^6.5.0",
+				"babel-plugin-transform-regenerator": "^6.5.0",
+				"babel-template": "^6.24.1",
+				"react-transform-hmr": "^1.0.4"
 			}
 		},
 		"babel-register": {
@@ -2333,13 +1756,54 @@
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"requires": {
-				"babel-core": "6.26.3",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.7",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.10",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
+			},
+			"dependencies": {
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
 			}
 		},
 		"babel-runtime": {
@@ -2347,8 +1811,8 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "2.5.7",
-				"regenerator-runtime": "0.11.1"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			}
 		},
 		"babel-template": {
@@ -2356,11 +1820,11 @@
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.10"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -2368,15 +1832,15 @@
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.10"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
 			},
 			"dependencies": {
 				"debug": {
@@ -2399,10 +1863,10 @@
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.10",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			},
 			"dependencies": {
 				"to-fast-properties": {
@@ -2427,13 +1891,13 @@
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2441,7 +1905,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -2449,7 +1913,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -2457,7 +1921,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -2465,9 +1929,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"isobject": {
@@ -2488,70 +1952,7 @@
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
-			}
-		},
-		"big.js": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
-		},
-		"block-stream": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-			"requires": {
-				"inherits": "2.0.3"
-			}
-		},
-		"bluebird": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-		},
-		"body-parser": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-			"requires": {
-				"bytes": "3.0.0",
-				"content-type": "1.0.4",
-				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"http-errors": "1.6.3",
-				"iconv-lite": "0.4.19",
-				"on-finished": "2.3.0",
-				"qs": "6.5.1",
-				"raw-body": "2.3.2",
-				"type-is": "1.6.16"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.19",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-				},
-				"qs": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-				}
-			}
-		},
-		"boom": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"requires": {
-				"hoek": "2.16.3"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"brace-expansion": {
@@ -2559,7 +1960,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -2568,9 +1969,9 @@
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"browser-process-hrtime": {
@@ -2598,8 +1999,8 @@
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
 			"integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
 			"requires": {
-				"caniuse-lite": "1.0.30000848",
-				"electron-to-chromium": "1.3.48"
+				"caniuse-lite": "^1.0.30000844",
+				"electron-to-chromium": "^1.3.47"
 			}
 		},
 		"bser": {
@@ -2607,7 +2008,7 @@
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"requires": {
-				"node-int64": "0.4.0"
+				"node-int64": "^0.4.0"
 			}
 		},
 		"buffer-from": {
@@ -2625,25 +2026,20 @@
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
 			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
-		"bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -2669,9 +2065,9 @@
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 			"requires": {
-				"camelcase": "4.1.0",
-				"map-obj": "2.0.0",
-				"quick-lru": "1.1.0"
+				"camelcase": "^4.1.0",
+				"map-obj": "^2.0.0",
+				"quick-lru": "^1.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -2680,33 +2076,6 @@
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
-		},
-		"caniuse-api": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
-			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-db": "1.0.30000849",
-				"lodash.memoize": "4.1.2",
-				"lodash.uniq": "4.5.0"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"requires": {
-						"caniuse-db": "1.0.30000849",
-						"electron-to-chromium": "1.3.48"
-					}
-				}
-			}
-		},
-		"caniuse-db": {
-			"version": "1.0.30000849",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000849.tgz",
-			"integrity": "sha1-1FL1PX3PuE5/X9NMB3wwrSt7nHs="
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000848",
@@ -2718,7 +2087,7 @@
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
 			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
 			"requires": {
-				"rsvp": "3.6.2"
+				"rsvp": "^3.3.3"
 			}
 		},
 		"capture-stack-trace": {
@@ -2737,8 +2106,8 @@
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"optional": true,
 			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
 			}
 		},
 		"chalk": {
@@ -2746,9 +2115,9 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.4.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"chardet": {
@@ -2761,47 +2130,15 @@
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
 			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
 		},
-		"clap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-			"requires": {
-				"chalk": "1.1.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2809,7 +2146,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"isobject": {
@@ -2819,17 +2156,12 @@
 				}
 			}
 		},
-		"classnames": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-			"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
-		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-width": {
@@ -2843,8 +2175,8 @@
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 			"optional": true,
 			"requires": {
-				"center-align": "0.1.3",
-				"right-align": "0.1.3",
+				"center-align": "^0.1.1",
+				"right-align": "^0.1.1",
 				"wordwrap": "0.0.2"
 			},
 			"dependencies": {
@@ -2861,53 +2193,19 @@
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
 			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 		},
-		"clone-deep": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
-			"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
-			"requires": {
-				"for-own": "1.0.0",
-				"is-plain-object": "2.0.4",
-				"kind-of": "6.0.2",
-				"shallow-clone": "1.0.0"
-			},
-			"dependencies": {
-				"for-own": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"requires": {
-						"for-in": "1.0.2"
-					}
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
-			}
-		},
 		"cmd-shim": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1"
+				"graceful-fs": "^4.1.2",
+				"mkdirp": "~0.5.0"
 			}
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-		},
-		"coa": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-			"requires": {
-				"q": "1.5.1"
-			}
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -2919,18 +2217,8 @@
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
-			}
-		},
-		"color": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-			"requires": {
-				"clone": "1.0.4",
-				"color-convert": "1.9.1",
-				"color-string": "0.3.0"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
 			}
 		},
 		"color-convert": {
@@ -2938,7 +2226,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -2946,36 +2234,13 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"color-string": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"colormin": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
-			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-			"requires": {
-				"color": "0.11.4",
-				"css-color-names": "0.0.4",
-				"has": "1.0.3"
-			}
-		},
-		"colors": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
-		},
 		"columnify": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 			"requires": {
-				"strip-ansi": "3.0.1",
-				"wcwidth": "1.0.1"
+				"strip-ansi": "^3.0.0",
+				"wcwidth": "^1.0.0"
 			}
 		},
 		"combined-stream": {
@@ -2983,7 +2248,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"command-join": {
@@ -2996,18 +2261,13 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
 			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
-		"commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-		},
 		"compare-func": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
 			"requires": {
-				"array-ify": "1.0.0",
-				"dot-prop": "3.0.0"
+				"array-ify": "^1.0.0",
+				"dot-prop": "^3.0.0"
 			}
 		},
 		"compare-versions": {
@@ -3030,10 +2290,10 @@
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
-				"buffer-from": "1.1.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6",
-				"typedarray": "0.0.6"
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"console-control-strings": {
@@ -3041,40 +2301,22 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
-		"consolidate": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
-			"integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
-			"requires": {
-				"bluebird": "3.5.1"
-			}
-		},
-		"content-disposition": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-		},
 		"conventional-changelog": {
 			"version": "1.1.24",
 			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
 			"integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
 			"requires": {
-				"conventional-changelog-angular": "1.6.6",
-				"conventional-changelog-atom": "0.2.8",
-				"conventional-changelog-codemirror": "0.3.8",
-				"conventional-changelog-core": "2.0.11",
-				"conventional-changelog-ember": "0.3.12",
-				"conventional-changelog-eslint": "1.0.9",
-				"conventional-changelog-express": "0.3.6",
-				"conventional-changelog-jquery": "0.1.0",
-				"conventional-changelog-jscs": "0.1.0",
-				"conventional-changelog-jshint": "0.3.8",
-				"conventional-changelog-preset-loader": "1.1.8"
+				"conventional-changelog-angular": "^1.6.6",
+				"conventional-changelog-atom": "^0.2.8",
+				"conventional-changelog-codemirror": "^0.3.8",
+				"conventional-changelog-core": "^2.0.11",
+				"conventional-changelog-ember": "^0.3.12",
+				"conventional-changelog-eslint": "^1.0.9",
+				"conventional-changelog-express": "^0.3.6",
+				"conventional-changelog-jquery": "^0.1.0",
+				"conventional-changelog-jscs": "^0.1.0",
+				"conventional-changelog-jshint": "^0.3.8",
+				"conventional-changelog-preset-loader": "^1.1.8"
 			}
 		},
 		"conventional-changelog-angular": {
@@ -3082,8 +2324,8 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
 			"requires": {
-				"compare-func": "1.3.2",
-				"q": "1.5.1"
+				"compare-func": "^1.3.1",
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-atom": {
@@ -3091,7 +2333,7 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
 			"integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-cli": {
@@ -3099,11 +2341,11 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz",
 			"integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
 			"requires": {
-				"add-stream": "1.0.0",
-				"conventional-changelog": "1.1.24",
-				"lodash": "4.17.10",
-				"meow": "4.0.1",
-				"tempfile": "1.1.1"
+				"add-stream": "^1.0.0",
+				"conventional-changelog": "^1.1.24",
+				"lodash": "^4.2.1",
+				"meow": "^4.0.0",
+				"tempfile": "^1.1.1"
 			}
 		},
 		"conventional-changelog-codemirror": {
@@ -3111,7 +2353,7 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
 			"integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-core": {
@@ -3119,19 +2361,19 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
 			"integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
 			"requires": {
-				"conventional-changelog-writer": "3.0.9",
-				"conventional-commits-parser": "2.1.7",
-				"dateformat": "3.0.3",
-				"get-pkg-repo": "1.4.0",
-				"git-raw-commits": "1.3.6",
-				"git-remote-origin-url": "2.0.0",
-				"git-semver-tags": "1.3.6",
-				"lodash": "4.17.10",
-				"normalize-package-data": "2.4.0",
-				"q": "1.5.1",
-				"read-pkg": "1.1.0",
-				"read-pkg-up": "1.0.1",
-				"through2": "2.0.3"
+				"conventional-changelog-writer": "^3.0.9",
+				"conventional-commits-parser": "^2.1.7",
+				"dateformat": "^3.0.0",
+				"get-pkg-repo": "^1.0.0",
+				"git-raw-commits": "^1.3.6",
+				"git-remote-origin-url": "^2.0.0",
+				"git-semver-tags": "^1.3.6",
+				"lodash": "^4.2.1",
+				"normalize-package-data": "^2.3.5",
+				"q": "^1.5.1",
+				"read-pkg": "^1.1.0",
+				"read-pkg-up": "^1.0.1",
+				"through2": "^2.0.0"
 			},
 			"dependencies": {
 				"load-json-file": {
@@ -3139,11 +2381,11 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"parse-json": {
@@ -3151,7 +2393,7 @@
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"path-type": {
@@ -3159,9 +2401,9 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -3174,9 +2416,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"strip-bom": {
@@ -3184,7 +2426,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -3194,7 +2436,7 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
 			"integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-eslint": {
@@ -3202,7 +2444,7 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
 			"integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-express": {
@@ -3210,7 +2452,7 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
 			"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-jquery": {
@@ -3218,7 +2460,7 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.4.1"
 			}
 		},
 		"conventional-changelog-jscs": {
@@ -3226,7 +2468,7 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.4.1"
 			}
 		},
 		"conventional-changelog-jshint": {
@@ -3234,8 +2476,8 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
 			"integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
 			"requires": {
-				"compare-func": "1.3.2",
-				"q": "1.5.1"
+				"compare-func": "^1.3.1",
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-preset-loader": {
@@ -3248,16 +2490,16 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
 			"integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
 			"requires": {
-				"compare-func": "1.3.2",
-				"conventional-commits-filter": "1.1.6",
-				"dateformat": "3.0.3",
-				"handlebars": "4.0.11",
-				"json-stringify-safe": "5.0.1",
-				"lodash": "4.17.10",
-				"meow": "4.0.1",
-				"semver": "5.5.0",
-				"split": "1.0.1",
-				"through2": "2.0.3"
+				"compare-func": "^1.3.1",
+				"conventional-commits-filter": "^1.1.6",
+				"dateformat": "^3.0.0",
+				"handlebars": "^4.0.2",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.2.1",
+				"meow": "^4.0.0",
+				"semver": "^5.5.0",
+				"split": "^1.0.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"conventional-commits-filter": {
@@ -3265,8 +2507,8 @@
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
 			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
 			"requires": {
-				"is-subset": "0.1.1",
-				"modify-values": "1.0.1"
+				"is-subset": "^0.1.1",
+				"modify-values": "^1.0.0"
 			}
 		},
 		"conventional-commits-parser": {
@@ -3274,13 +2516,13 @@
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
 			"requires": {
-				"JSONStream": "1.3.3",
-				"is-text-path": "1.0.1",
-				"lodash": "4.17.10",
-				"meow": "4.0.1",
-				"split2": "2.2.0",
-				"through2": "2.0.3",
-				"trim-off-newlines": "1.0.1"
+				"JSONStream": "^1.0.4",
+				"is-text-path": "^1.0.0",
+				"lodash": "^4.2.1",
+				"meow": "^4.0.0",
+				"split2": "^2.0.0",
+				"through2": "^2.0.0",
+				"trim-off-newlines": "^1.0.0"
 			}
 		},
 		"conventional-recommended-bump": {
@@ -3288,13 +2530,13 @@
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
 			"requires": {
-				"concat-stream": "1.6.2",
-				"conventional-commits-filter": "1.1.6",
-				"conventional-commits-parser": "2.1.7",
-				"git-raw-commits": "1.3.6",
-				"git-semver-tags": "1.3.6",
-				"meow": "3.7.0",
-				"object-assign": "4.1.1"
+				"concat-stream": "^1.4.10",
+				"conventional-commits-filter": "^1.1.1",
+				"conventional-commits-parser": "^2.1.1",
+				"git-raw-commits": "^1.3.0",
+				"git-semver-tags": "^1.3.0",
+				"meow": "^3.3.0",
+				"object-assign": "^4.0.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -3307,8 +2549,8 @@
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"requires": {
-						"camelcase": "2.1.1",
-						"map-obj": "1.0.1"
+						"camelcase": "^2.0.0",
+						"map-obj": "^1.0.0"
 					}
 				},
 				"indent-string": {
@@ -3316,7 +2558,7 @@
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"map-obj": {
@@ -3329,16 +2571,16 @@
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"requires": {
-						"camelcase-keys": "2.1.0",
-						"decamelize": "1.2.0",
-						"loud-rejection": "1.6.0",
-						"map-obj": "1.0.1",
-						"minimist": "1.2.0",
-						"normalize-package-data": "2.4.0",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"redent": "1.0.0",
-						"trim-newlines": "1.0.0"
+						"camelcase-keys": "^2.0.0",
+						"decamelize": "^1.1.2",
+						"loud-rejection": "^1.0.0",
+						"map-obj": "^1.0.1",
+						"minimist": "^1.1.3",
+						"normalize-package-data": "^2.3.4",
+						"object-assign": "^4.0.1",
+						"read-pkg-up": "^1.0.1",
+						"redent": "^1.0.0",
+						"trim-newlines": "^1.0.0"
 					}
 				},
 				"minimist": {
@@ -3351,8 +2593,8 @@
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 					"requires": {
-						"indent-string": "2.1.0",
-						"strip-indent": "1.0.1"
+						"indent-string": "^2.1.0",
+						"strip-indent": "^1.0.1"
 					}
 				},
 				"strip-indent": {
@@ -3360,7 +2602,7 @@
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 					"requires": {
-						"get-stdin": "4.0.1"
+						"get-stdin": "^4.0.1"
 					}
 				},
 				"trim-newlines": {
@@ -3374,16 +2616,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
 			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
-		},
-		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -3400,50 +2632,12 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
-		"cosmiconfig": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-			"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
-			"requires": {
-				"is-directory": "0.3.1",
-				"js-yaml": "3.12.0",
-				"minimist": "1.2.0",
-				"object-assign": "4.1.1",
-				"os-homedir": "1.0.2",
-				"parse-json": "2.2.0",
-				"require-from-string": "1.2.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"requires": {
-						"error-ex": "1.3.1"
-					}
-				}
-			}
-		},
 		"create-error-class": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 			"requires": {
-				"capture-stack-trace": "1.0.0"
-			}
-		},
-		"cross-env": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.6.tgz",
-			"integrity": "sha512-VWTDq+G4v383SzgRS7jsAVWqEWF0aKZpDz1GVjhONvPRgHB1LnxP2sXUVFKbykHkPSnfRKS8YdiDevWFwZmQ9g==",
-			"requires": {
-				"cross-spawn": "5.1.0",
-				"is-windows": "1.0.2"
+				"capture-stack-trace": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -3451,291 +2645,9 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"requires": {
-				"lru-cache": "4.1.3",
-				"shebang-command": "1.2.0",
-				"which": "1.3.1"
-			}
-		},
-		"cryptiles": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"requires": {
-				"boom": "2.10.1"
-			}
-		},
-		"css-color-names": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
-		},
-		"css-loader": {
-			"version": "0.28.11",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
-			"integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
-			"requires": {
-				"babel-code-frame": "6.26.0",
-				"css-selector-tokenizer": "0.7.0",
-				"cssnano": "3.10.0",
-				"icss-utils": "2.1.0",
-				"loader-utils": "1.1.0",
-				"lodash.camelcase": "4.3.0",
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-modules-extract-imports": "1.2.0",
-				"postcss-modules-local-by-default": "1.2.0",
-				"postcss-modules-scope": "1.1.0",
-				"postcss-modules-values": "1.3.0",
-				"postcss-value-parser": "3.3.0",
-				"source-list-map": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"css-mqpacker": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/css-mqpacker/-/css-mqpacker-6.0.2.tgz",
-			"integrity": "sha512-01xogFCcK6KQmUS+EwSS5R5Sq/mp9rjLBw/7ej+xPZHKE0gzjsWk8uJpFuKOllQrVEOJqt7Y8H6rCNG+sMIg+Q==",
-			"requires": {
-				"minimist": "1.2.0",
-				"postcss": "6.0.22"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
-			}
-		},
-		"css-selector-tokenizer": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-			"requires": {
-				"cssesc": "0.1.0",
-				"fastparse": "1.1.1",
-				"regexpu-core": "1.0.0"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-				},
-				"regexpu-core": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-					"requires": {
-						"regenerate": "1.4.0",
-						"regjsgen": "0.2.0",
-						"regjsparser": "0.1.5"
-					}
-				},
-				"regjsgen": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-				},
-				"regjsparser": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-					"requires": {
-						"jsesc": "0.5.0"
-					}
-				}
-			}
-		},
-		"cssesc": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
-		},
-		"cssnano": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
-			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-			"requires": {
-				"autoprefixer": "6.7.7",
-				"decamelize": "1.2.0",
-				"defined": "1.0.0",
-				"has": "1.0.3",
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-calc": "5.3.1",
-				"postcss-colormin": "2.2.2",
-				"postcss-convert-values": "2.6.1",
-				"postcss-discard-comments": "2.0.4",
-				"postcss-discard-duplicates": "2.1.0",
-				"postcss-discard-empty": "2.1.0",
-				"postcss-discard-overridden": "0.1.1",
-				"postcss-discard-unused": "2.2.3",
-				"postcss-filter-plugins": "2.0.3",
-				"postcss-merge-idents": "2.1.7",
-				"postcss-merge-longhand": "2.0.2",
-				"postcss-merge-rules": "2.1.2",
-				"postcss-minify-font-values": "1.0.5",
-				"postcss-minify-gradients": "1.0.5",
-				"postcss-minify-params": "1.2.2",
-				"postcss-minify-selectors": "2.1.1",
-				"postcss-normalize-charset": "1.1.1",
-				"postcss-normalize-url": "3.0.8",
-				"postcss-ordered-values": "2.2.3",
-				"postcss-reduce-idents": "2.4.0",
-				"postcss-reduce-initial": "1.0.1",
-				"postcss-reduce-transforms": "1.0.4",
-				"postcss-svgo": "2.1.6",
-				"postcss-unique-selectors": "2.0.2",
-				"postcss-value-parser": "3.3.0",
-				"postcss-zindex": "2.2.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"autoprefixer": {
-					"version": "6.7.7",
-					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-					"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-					"requires": {
-						"browserslist": "1.7.7",
-						"caniuse-db": "1.0.30000849",
-						"normalize-range": "0.1.2",
-						"num2fraction": "1.2.2",
-						"postcss": "5.2.18",
-						"postcss-value-parser": "3.3.0"
-					}
-				},
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"requires": {
-						"caniuse-db": "1.0.30000849",
-						"electron-to-chromium": "1.3.48"
-					}
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"csso": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
-			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-			"requires": {
-				"clap": "1.2.3",
-				"source-map": "0.5.7"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"cssom": {
@@ -3748,7 +2660,7 @@
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
 			"integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
 			"requires": {
-				"cssom": "0.3.2"
+				"cssom": "0.3.x"
 			}
 		},
 		"csstype": {
@@ -3761,7 +2673,7 @@
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"dargs": {
@@ -3769,7 +2681,7 @@
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"dashdash": {
@@ -3777,7 +2689,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"data-urls": {
@@ -3785,9 +2697,9 @@
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
 			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
 			"requires": {
-				"abab": "1.0.4",
-				"whatwg-mimetype": "2.1.0",
-				"whatwg-url": "6.4.1"
+				"abab": "^1.0.4",
+				"whatwg-mimetype": "^2.0.0",
+				"whatwg-url": "^6.4.0"
 			}
 		},
 		"dateformat": {
@@ -3818,8 +2730,8 @@
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"requires": {
-				"decamelize": "1.2.0",
-				"map-obj": "1.0.1"
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
 			},
 			"dependencies": {
 				"map-obj": {
@@ -3854,7 +2766,7 @@
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
 			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
 			"requires": {
-				"strip-bom": "3.0.0"
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"defaults": {
@@ -3862,7 +2774,7 @@
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 			"requires": {
-				"clone": "1.0.4"
+				"clone": "^1.0.2"
 			}
 		},
 		"define-properties": {
@@ -3870,8 +2782,8 @@
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
 			}
 		},
 		"define-property": {
@@ -3879,8 +2791,8 @@
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -3888,7 +2800,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -3896,7 +2808,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -3904,9 +2816,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"isobject": {
@@ -3921,11 +2833,6 @@
 				}
 			}
 		},
-		"defined": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3935,16 +2842,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
 		"detect-indent": {
 			"version": "5.0.0",
@@ -3961,11 +2858,6 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
-		"dom-helpers": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
-		},
 		"dom-walk": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
@@ -3976,7 +2868,7 @@
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"requires": {
-				"webidl-conversions": "4.0.2"
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"dot-prop": {
@@ -3984,7 +2876,7 @@
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"duplexer": {
@@ -4003,43 +2895,20 @@
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
-		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
 			"version": "1.3.48",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
 			"integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
 		},
-		"emojis-list": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "0.4.23"
-			}
-		},
-		"epic-spinners": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/epic-spinners/-/epic-spinners-1.0.3.tgz",
-			"integrity": "sha512-xtBBuQeUSAc2dioKTdn2cBFoqAOPpD/ggQLiszGsHsnHfIT3z2b7hxGpQu6s7VHoJLhCQgdXDOU9R4rjnKPaxw==",
-			"requires": {
-				"vue": "2.5.16"
+				"iconv-lite": "~0.4.13"
 			}
 		},
 		"error-ex": {
@@ -4047,7 +2916,7 @@
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -4055,11 +2924,11 @@
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
 			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.1",
-				"has": "1.0.3",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -4067,15 +2936,10 @@
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
+				"is-callable": "^1.1.1",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.1"
 			}
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -4087,11 +2951,11 @@
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
 			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.6.1"
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -4127,17 +2991,12 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-		},
 		"exec-sh": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"requires": {
-				"merge": "1.2.0"
+				"merge": "^1.1.3"
 			}
 		},
 		"execa": {
@@ -4145,13 +3004,13 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 			"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit": {
@@ -4164,7 +3023,7 @@
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -4172,7 +3031,7 @@
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"requires": {
-				"fill-range": "2.2.4"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"expect": {
@@ -4180,74 +3039,12 @@
 			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
 			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"jest-diff": "22.4.3",
-				"jest-get-type": "22.4.3",
-				"jest-matcher-utils": "22.4.3",
-				"jest-message-util": "22.4.3",
-				"jest-regex-util": "22.4.3"
-			}
-		},
-		"express": {
-			"version": "4.16.3",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
-			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-			"requires": {
-				"accepts": "1.3.5",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.18.2",
-				"content-disposition": "0.5.2",
-				"content-type": "1.0.4",
-				"cookie": "0.3.1",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"etag": "1.8.1",
-				"finalhandler": "1.1.1",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "1.1.2",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.2",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "2.0.3",
-				"qs": "6.5.1",
-				"range-parser": "1.2.0",
-				"safe-buffer": "5.1.1",
-				"send": "0.16.2",
-				"serve-static": "1.13.2",
-				"setprototypeof": "1.1.0",
-				"statuses": "1.4.0",
-				"type-is": "1.6.16",
-				"utils-merge": "1.0.1",
-				"vary": "1.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"path-to-regexp": {
-					"version": "0.1.7",
-					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-				},
-				"qs": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-				},
-				"safe-buffer": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-				}
+				"ansi-styles": "^3.2.0",
+				"jest-diff": "^22.4.3",
+				"jest-get-type": "^22.4.3",
+				"jest-matcher-utils": "^22.4.3",
+				"jest-message-util": "^22.4.3",
+				"jest-regex-util": "^22.4.3"
 			}
 		},
 		"extend": {
@@ -4260,8 +3057,8 @@
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -4269,7 +3066,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -4279,9 +3076,9 @@
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"requires": {
-				"chardet": "0.4.2",
-				"iconv-lite": "0.4.23",
-				"tmp": "0.0.33"
+				"chardet": "^0.4.0",
+				"iconv-lite": "^0.4.17",
+				"tmp": "^0.0.33"
 			}
 		},
 		"extglob": {
@@ -4289,7 +3086,7 @@
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -4319,17 +3116,12 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
-		"fastparse": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
-		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"requires": {
-				"bser": "2.0.0"
+				"bser": "^2.0.0"
 			}
 		},
 		"fbjs": {
@@ -4337,13 +3129,13 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 			"requires": {
-				"core-js": "1.2.7",
-				"isomorphic-fetch": "2.2.1",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"promise": "7.3.1",
-				"setimmediate": "1.0.5",
-				"ua-parser-js": "0.7.18"
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.9"
 			},
 			"dependencies": {
 				"core-js": {
@@ -4358,7 +3150,7 @@
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"filename-regex": {
@@ -4371,8 +3163,8 @@
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"requires": {
-				"glob": "7.1.2",
-				"minimatch": "3.0.4"
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
 			}
 		},
 		"fill-range": {
@@ -4380,45 +3172,11 @@
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
 			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "3.0.0",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
-			}
-		},
-		"finalhandler": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.2",
-				"statuses": "1.4.0",
-				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
-		"find-cache-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-			"requires": {
-				"commondir": "1.0.1",
-				"make-dir": "1.3.0",
-				"pkg-dir": "2.0.0"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^3.0.0",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"find-up": {
@@ -4426,13 +3184,8 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
-		},
-		"flatten": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -4444,7 +3197,7 @@
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"foreach": {
@@ -4462,37 +3215,27 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.18"
+				"mime-types": "^2.1.12"
 			}
-		},
-		"forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"requires": {
-				"map-cache": "0.2.2"
+				"map-cache": "^0.2.2"
 			}
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"fs-extra": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "4.0.0",
-				"universalify": "0.1.1"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			}
 		},
 		"fs.realpath": {
@@ -4506,8 +3249,8 @@
 			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
 			"optional": true,
 			"requires": {
-				"nan": "2.10.0",
-				"node-pre-gyp": "0.10.0"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -4529,8 +3272,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
 				},
 				"balanced-match": {
@@ -4541,7 +3284,7 @@
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -4595,7 +3338,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
@@ -4608,14 +3351,14 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"glob": {
@@ -4623,12 +3366,12 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-unicode": {
@@ -4641,7 +3384,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "2.1.2"
+						"safer-buffer": "^2.1.0"
 					}
 				},
 				"ignore-walk": {
@@ -4649,7 +3392,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "3.0.4"
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
@@ -4657,8 +3400,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -4674,7 +3417,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"isarray": {
@@ -4686,7 +3429,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -4697,8 +3440,8 @@
 					"version": "2.2.4",
 					"bundled": true,
 					"requires": {
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
@@ -4706,7 +3449,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"mkdirp": {
@@ -4726,9 +3469,9 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.9",
-						"iconv-lite": "0.4.21",
-						"sax": "1.2.4"
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -4736,16 +3479,16 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.3",
-						"mkdirp": "0.5.1",
-						"needle": "2.2.0",
-						"nopt": "4.0.1",
-						"npm-packlist": "1.1.10",
-						"npmlog": "4.1.2",
-						"rc": "1.2.7",
-						"rimraf": "2.6.2",
-						"semver": "5.5.0",
-						"tar": "4.4.1"
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
 					}
 				},
 				"nopt": {
@@ -4753,8 +3496,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.1",
-						"osenv": "0.1.5"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
 					}
 				},
 				"npm-bundled": {
@@ -4767,8 +3510,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "3.0.1",
-						"npm-bundled": "1.0.3"
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
 					}
 				},
 				"npmlog": {
@@ -4776,10 +3519,10 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -4795,7 +3538,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
@@ -4813,8 +3556,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -4832,10 +3575,10 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.5.1",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.5.1",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -4850,13 +3593,13 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
@@ -4864,7 +3607,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
@@ -4900,9 +3643,9 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
@@ -4910,14 +3653,14 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -4930,13 +3673,13 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"chownr": "1.0.1",
-						"fs-minipass": "1.2.5",
-						"minipass": "2.2.4",
-						"minizlib": "1.1.0",
-						"mkdirp": "0.5.1",
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -4949,7 +3692,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2"
 					}
 				},
 				"wrappy": {
@@ -4962,17 +3705,6 @@
 				}
 			}
 		},
-		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"inherits": "2.0.3",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2"
-			}
-		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4983,14 +3715,14 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"requires": {
-				"aproba": "1.2.0",
-				"console-control-strings": "1.1.0",
-				"has-unicode": "2.0.1",
-				"object-assign": "4.1.1",
-				"signal-exit": "3.0.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wide-align": "1.1.3"
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -4998,7 +3730,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -5006,32 +3738,11 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
-			}
-		},
-		"gaze": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-			"requires": {
-				"globule": "1.2.1"
-			}
-		},
-		"generate-function": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-		},
-		"generate-object-property": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-			"requires": {
-				"is-property": "1.0.2"
 			}
 		},
 		"get-caller-file": {
@@ -5044,11 +3755,11 @@
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
 			"requires": {
-				"hosted-git-info": "2.6.0",
-				"meow": "3.7.0",
-				"normalize-package-data": "2.4.0",
-				"parse-github-repo-url": "1.4.1",
-				"through2": "2.0.3"
+				"hosted-git-info": "^2.1.4",
+				"meow": "^3.3.0",
+				"normalize-package-data": "^2.3.0",
+				"parse-github-repo-url": "^1.3.0",
+				"through2": "^2.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -5061,8 +3772,8 @@
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"requires": {
-						"camelcase": "2.1.1",
-						"map-obj": "1.0.1"
+						"camelcase": "^2.0.0",
+						"map-obj": "^1.0.0"
 					}
 				},
 				"indent-string": {
@@ -5070,7 +3781,7 @@
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"map-obj": {
@@ -5083,16 +3794,16 @@
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"requires": {
-						"camelcase-keys": "2.1.0",
-						"decamelize": "1.2.0",
-						"loud-rejection": "1.6.0",
-						"map-obj": "1.0.1",
-						"minimist": "1.2.0",
-						"normalize-package-data": "2.4.0",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"redent": "1.0.0",
-						"trim-newlines": "1.0.0"
+						"camelcase-keys": "^2.0.0",
+						"decamelize": "^1.1.2",
+						"loud-rejection": "^1.0.0",
+						"map-obj": "^1.0.1",
+						"minimist": "^1.1.3",
+						"normalize-package-data": "^2.3.4",
+						"object-assign": "^4.0.1",
+						"read-pkg-up": "^1.0.1",
+						"redent": "^1.0.0",
+						"trim-newlines": "^1.0.0"
 					}
 				},
 				"minimist": {
@@ -5105,8 +3816,8 @@
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 					"requires": {
-						"indent-string": "2.1.0",
-						"strip-indent": "1.0.1"
+						"indent-string": "^2.1.0",
+						"strip-indent": "^1.0.1"
 					}
 				},
 				"strip-indent": {
@@ -5114,7 +3825,7 @@
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 					"requires": {
-						"get-stdin": "4.0.1"
+						"get-stdin": "^4.0.1"
 					}
 				},
 				"trim-newlines": {
@@ -5149,7 +3860,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"git-raw-commits": {
@@ -5157,11 +3868,11 @@
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
 			"requires": {
-				"dargs": "4.1.0",
-				"lodash.template": "4.4.0",
-				"meow": "4.0.1",
-				"split2": "2.2.0",
-				"through2": "2.0.3"
+				"dargs": "^4.0.1",
+				"lodash.template": "^4.0.2",
+				"meow": "^4.0.0",
+				"split2": "^2.0.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"git-remote-origin-url": {
@@ -5169,8 +3880,8 @@
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 			"requires": {
-				"gitconfiglocal": "1.0.0",
-				"pify": "2.3.0"
+				"gitconfiglocal": "^1.0.0",
+				"pify": "^2.3.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -5185,8 +3896,8 @@
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
 			"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
 			"requires": {
-				"meow": "4.0.1",
-				"semver": "5.5.0"
+				"meow": "^4.0.0",
+				"semver": "^5.5.0"
 			}
 		},
 		"gitconfiglocal": {
@@ -5194,7 +3905,7 @@
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 			"requires": {
-				"ini": "1.3.5"
+				"ini": "^1.3.2"
 			}
 		},
 		"glob": {
@@ -5202,12 +3913,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
@@ -5215,8 +3926,8 @@
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			},
 			"dependencies": {
 				"glob-parent": {
@@ -5224,7 +3935,7 @@
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 					"requires": {
-						"is-glob": "2.0.1"
+						"is-glob": "^2.0.0"
 					}
 				},
 				"is-extglob": {
@@ -5237,7 +3948,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				}
 			}
@@ -5247,8 +3958,8 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"requires": {
-				"is-glob": "3.1.0",
-				"path-dirname": "1.0.2"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
 			}
 		},
 		"global": {
@@ -5256,8 +3967,8 @@
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
 			"requires": {
-				"min-document": "2.19.0",
-				"process": "0.5.2"
+				"min-document": "^2.19.0",
+				"process": "~0.5.1"
 			}
 		},
 		"globals": {
@@ -5270,11 +3981,11 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 			"requires": {
-				"array-union": "1.0.2",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"array-union": "^1.0.1",
+				"glob": "^7.0.3",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -5284,32 +3995,22 @@
 				}
 			}
 		},
-		"globule": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
-			"requires": {
-				"glob": "7.1.2",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4"
-			}
-		},
 		"got": {
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"requires": {
-				"create-error-class": "3.0.2",
-				"duplexer3": "0.1.4",
-				"get-stream": "3.0.0",
-				"is-redirect": "1.0.0",
-				"is-retry-allowed": "1.1.0",
-				"is-stream": "1.1.0",
-				"lowercase-keys": "1.0.1",
-				"safe-buffer": "5.1.2",
-				"timed-out": "4.0.1",
-				"unzip-response": "2.0.1",
-				"url-parse-lax": "1.0.0"
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -5327,7 +4028,7 @@
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
 			"integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
 			"requires": {
-				"duplexer": "0.1.1"
+				"duplexer": "^0.1.1"
 			}
 		},
 		"handlebars": {
@@ -5335,10 +4036,10 @@
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"async": "^1.4.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.4.4",
+				"uglify-js": "^2.6"
 			}
 		},
 		"har-schema": {
@@ -5351,8 +4052,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
@@ -5360,7 +4061,7 @@
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -5368,7 +4069,7 @@
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -5386,9 +4087,9 @@
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -5403,8 +4104,8 @@
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -5412,7 +4113,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -5420,7 +4121,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -5430,25 +4131,9 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
-			}
-		},
-		"hash-sum": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-			"integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ="
-		},
-		"hawk": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"requires": {
-				"boom": "2.10.1",
-				"cryptiles": "2.0.5",
-				"hoek": "2.16.3",
-				"sntp": "1.0.9"
 			}
 		},
 		"he": {
@@ -5456,18 +4141,13 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
 			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
 		},
-		"hoek": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
@@ -5475,28 +4155,12 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
 			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
 		},
-		"html-comment-regex": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
-			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
-		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"requires": {
-				"whatwg-encoding": "1.0.3"
-			}
-		},
-		"http-errors": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-			"requires": {
-				"depd": "1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": "1.4.0"
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"http-signature": {
@@ -5504,9 +4168,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"husky": {
@@ -5514,9 +4178,9 @@
 			"resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
 			"integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
 			"requires": {
-				"is-ci": "1.1.0",
-				"normalize-path": "1.0.0",
-				"strip-indent": "2.0.0"
+				"is-ci": "^1.0.10",
+				"normalize-path": "^1.0.0",
+				"strip-indent": "^2.0.0"
 			}
 		},
 		"iconv-lite": {
@@ -5524,20 +4188,7 @@
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
 			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 			"requires": {
-				"safer-buffer": "2.1.2"
-			}
-		},
-		"icss-replace-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
-		},
-		"icss-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
-			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
-			"requires": {
-				"postcss": "6.0.22"
+				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
 		"ignore": {
@@ -5550,8 +4201,8 @@
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -5559,28 +4210,18 @@
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
-		"in-publish": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
-		},
 		"indent-string": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
 			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-		},
-		"indexes-of": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -5598,20 +4239,20 @@
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.1",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.2.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.10",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^2.0.4",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rx-lite": "4.0.8",
-				"rx-lite-aggregates": "4.0.8",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rx-lite": "^4.0.8",
+				"rx-lite-aggregates": "^4.0.8",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -5624,7 +4265,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -5634,7 +4275,7 @@
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
@@ -5642,22 +4283,12 @@
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
-		"ipaddr.js": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
-		},
-		"is-absolute-url": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
-			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
-		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-arrayish": {
@@ -5675,7 +4306,7 @@
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
@@ -5688,7 +4319,7 @@
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"requires": {
-				"ci-info": "1.1.3"
+				"ci-info": "^1.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -5696,7 +4327,7 @@
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-date-object": {
@@ -5709,9 +4340,9 @@
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"requires": {
-				"is-accessor-descriptor": "0.1.6",
-				"is-data-descriptor": "0.1.4",
-				"kind-of": "5.1.0"
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5720,11 +4351,6 @@
 					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
-		},
-		"is-directory": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -5736,7 +4362,7 @@
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -5754,7 +4380,7 @@
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -5772,7 +4398,7 @@
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 			"requires": {
-				"is-extglob": "2.1.1"
+				"is-extglob": "^2.1.0"
 			}
 		},
 		"is-module": {
@@ -5780,29 +4406,12 @@
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
 		},
-		"is-my-ip-valid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-		},
-		"is-my-json-valid": {
-			"version": "2.17.2",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-			"requires": {
-				"generate-function": "2.0.0",
-				"generate-object-property": "1.2.0",
-				"is-my-ip-valid": "1.0.0",
-				"jsonpointer": "4.0.1",
-				"xtend": "4.0.1"
-			}
-		},
 		"is-number": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-obj": {
@@ -5815,7 +4424,7 @@
 			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"requires": {
-				"is-number": "4.0.0"
+				"is-number": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -5835,7 +4444,7 @@
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -5860,11 +4469,6 @@
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
-		"is-property": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
@@ -5875,7 +4479,7 @@
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"requires": {
-				"has": "1.0.3"
+				"has": "^1.0.1"
 			}
 		},
 		"is-retry-allowed": {
@@ -5893,14 +4497,6 @@
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
 			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
 		},
-		"is-svg": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
-			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-			"requires": {
-				"html-comment-regex": "1.1.1"
-			}
-		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
@@ -5911,7 +4507,7 @@
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"requires": {
-				"text-extensions": "1.7.0"
+				"text-extensions": "^1.0.0"
 			}
 		},
 		"is-typedarray": {
@@ -5952,8 +4548,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.4"
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
@@ -5966,18 +4562,18 @@
 			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
 			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
 			"requires": {
-				"async": "2.6.1",
-				"compare-versions": "3.2.1",
-				"fileset": "2.0.3",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.2.1",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.4",
-				"istanbul-lib-source-maps": "1.2.5",
-				"istanbul-reports": "1.3.0",
-				"js-yaml": "3.12.0",
-				"mkdirp": "0.5.1",
-				"once": "1.4.0"
+				"async": "^2.1.4",
+				"compare-versions": "^3.1.0",
+				"fileset": "^2.0.2",
+				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-hook": "^1.2.0",
+				"istanbul-lib-instrument": "^1.10.1",
+				"istanbul-lib-report": "^1.1.4",
+				"istanbul-lib-source-maps": "^1.2.4",
+				"istanbul-reports": "^1.3.0",
+				"js-yaml": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"once": "^1.4.0"
 			},
 			"dependencies": {
 				"async": {
@@ -5985,7 +4581,7 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"requires": {
-						"lodash": "4.17.10"
+						"lodash": "^4.17.10"
 					}
 				},
 				"istanbul-lib-source-maps": {
@@ -5993,11 +4589,11 @@
 					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
 					"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					}
 				},
 				"source-map": {
@@ -6017,7 +4613,7 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
 			"integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
 			"requires": {
-				"append-transform": "1.0.0"
+				"append-transform": "^1.0.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -6025,13 +4621,13 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
 			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.2.0",
-				"semver": "5.5.0"
+				"babel-generator": "^6.18.0",
+				"babel-template": "^6.16.0",
+				"babel-traverse": "^6.18.0",
+				"babel-types": "^6.18.0",
+				"babylon": "^6.18.0",
+				"istanbul-lib-coverage": "^1.2.0",
+				"semver": "^5.3.0"
 			}
 		},
 		"istanbul-lib-report": {
@@ -6039,10 +4635,10 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
 			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
 			"requires": {
-				"istanbul-lib-coverage": "1.2.0",
-				"mkdirp": "0.5.1",
-				"path-parse": "1.0.5",
-				"supports-color": "3.2.3"
+				"istanbul-lib-coverage": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"path-parse": "^1.0.5",
+				"supports-color": "^3.1.2"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -6055,7 +4651,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6065,11 +4661,11 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
 			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
 			"requires": {
-				"debug": "3.1.0",
-				"istanbul-lib-coverage": "1.2.0",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"source-map": "0.5.7"
+				"debug": "^3.1.0",
+				"istanbul-lib-coverage": "^1.1.2",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.6.1",
+				"source-map": "^0.5.3"
 			},
 			"dependencies": {
 				"source-map": {
@@ -6084,7 +4680,7 @@
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
 			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
 			"requires": {
-				"handlebars": "4.0.11"
+				"handlebars": "^4.0.3"
 			}
 		},
 		"jest": {
@@ -6092,8 +4688,8 @@
 			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz",
 			"integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
 			"requires": {
-				"import-local": "1.0.0",
-				"jest-cli": "22.4.4"
+				"import-local": "^1.0.0",
+				"jest-cli": "^22.4.4"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6111,9 +4707,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"jest-cli": {
@@ -6121,40 +4717,40 @@
 					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
 					"integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.1",
-						"exit": "0.1.2",
-						"glob": "7.1.2",
-						"graceful-fs": "4.1.11",
-						"import-local": "1.0.0",
-						"is-ci": "1.1.0",
-						"istanbul-api": "1.3.1",
-						"istanbul-lib-coverage": "1.2.0",
-						"istanbul-lib-instrument": "1.10.1",
-						"istanbul-lib-source-maps": "1.2.3",
-						"jest-changed-files": "22.4.3",
-						"jest-config": "22.4.4",
-						"jest-environment-jsdom": "22.4.3",
-						"jest-get-type": "22.4.3",
-						"jest-haste-map": "22.4.3",
-						"jest-message-util": "22.4.3",
-						"jest-regex-util": "22.4.3",
-						"jest-resolve-dependencies": "22.4.3",
-						"jest-runner": "22.4.4",
-						"jest-runtime": "22.4.4",
-						"jest-snapshot": "22.4.3",
-						"jest-util": "22.4.3",
-						"jest-validate": "22.4.4",
-						"jest-worker": "22.4.3",
-						"micromatch": "2.3.11",
-						"node-notifier": "5.2.1",
-						"realpath-native": "1.0.0",
-						"rimraf": "2.6.2",
-						"slash": "1.0.0",
-						"string-length": "2.0.0",
-						"strip-ansi": "4.0.0",
-						"which": "1.3.1",
-						"yargs": "10.1.2"
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"import-local": "^1.0.0",
+						"is-ci": "^1.0.10",
+						"istanbul-api": "^1.1.14",
+						"istanbul-lib-coverage": "^1.1.1",
+						"istanbul-lib-instrument": "^1.8.0",
+						"istanbul-lib-source-maps": "^1.2.1",
+						"jest-changed-files": "^22.2.0",
+						"jest-config": "^22.4.4",
+						"jest-environment-jsdom": "^22.4.1",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^22.4.2",
+						"jest-message-util": "^22.4.0",
+						"jest-regex-util": "^22.1.0",
+						"jest-resolve-dependencies": "^22.1.0",
+						"jest-runner": "^22.4.4",
+						"jest-runtime": "^22.4.4",
+						"jest-snapshot": "^22.4.0",
+						"jest-util": "^22.4.1",
+						"jest-validate": "^22.4.4",
+						"jest-worker": "^22.2.2",
+						"micromatch": "^2.3.11",
+						"node-notifier": "^5.2.1",
+						"realpath-native": "^1.0.0",
+						"rimraf": "^2.5.4",
+						"slash": "^1.0.0",
+						"string-length": "^2.0.0",
+						"strip-ansi": "^4.0.0",
+						"which": "^1.2.12",
+						"yargs": "^10.0.3"
 					}
 				},
 				"strip-ansi": {
@@ -6162,7 +4758,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"yargs": {
@@ -6170,18 +4766,18 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
 					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.1.0"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^8.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -6189,7 +4785,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
 					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -6199,7 +4795,7 @@
 			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
 			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
 			"requires": {
-				"throat": "4.1.0"
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
@@ -6207,17 +4803,17 @@
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
 			"integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
 			"requires": {
-				"chalk": "2.4.1",
-				"glob": "7.1.2",
-				"jest-environment-jsdom": "22.4.3",
-				"jest-environment-node": "22.4.3",
-				"jest-get-type": "22.4.3",
-				"jest-jasmine2": "22.4.4",
-				"jest-regex-util": "22.4.3",
-				"jest-resolve": "22.4.3",
-				"jest-util": "22.4.3",
-				"jest-validate": "22.4.4",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^22.4.1",
+				"jest-environment-node": "^22.4.1",
+				"jest-get-type": "^22.1.0",
+				"jest-jasmine2": "^22.4.4",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.2",
+				"jest-util": "^22.4.1",
+				"jest-validate": "^22.4.4",
+				"pretty-format": "^22.4.0"
 			}
 		},
 		"jest-diff": {
@@ -6225,10 +4821,10 @@
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
 			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
 			"requires": {
-				"chalk": "2.4.1",
-				"diff": "3.5.0",
-				"jest-get-type": "22.4.3",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"diff": "^3.2.0",
+				"jest-get-type": "^22.4.3",
+				"pretty-format": "^22.4.3"
 			}
 		},
 		"jest-docblock": {
@@ -6236,7 +4832,7 @@
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
 			"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
 			"requires": {
-				"detect-newline": "2.1.0"
+				"detect-newline": "^2.1.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -6244,9 +4840,9 @@
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
 			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
 			"requires": {
-				"jest-mock": "22.4.3",
-				"jest-util": "22.4.3",
-				"jsdom": "11.11.0"
+				"jest-mock": "^22.4.3",
+				"jest-util": "^22.4.3",
+				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
@@ -6254,8 +4850,8 @@
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
 			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
 			"requires": {
-				"jest-mock": "22.4.3",
-				"jest-util": "22.4.3"
+				"jest-mock": "^22.4.3",
+				"jest-util": "^22.4.3"
 			}
 		},
 		"jest-get-type": {
@@ -6268,13 +4864,13 @@
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
 			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
 			"requires": {
-				"fb-watchman": "2.0.0",
-				"graceful-fs": "4.1.11",
-				"jest-docblock": "22.4.3",
-				"jest-serializer": "22.4.3",
-				"jest-worker": "22.4.3",
-				"micromatch": "2.3.11",
-				"sane": "2.5.2"
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"jest-docblock": "^22.4.3",
+				"jest-serializer": "^22.4.3",
+				"jest-worker": "^22.4.3",
+				"micromatch": "^2.3.11",
+				"sane": "^2.0.0"
 			}
 		},
 		"jest-jasmine2": {
@@ -6282,17 +4878,17 @@
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
 			"integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
 			"requires": {
-				"chalk": "2.4.1",
-				"co": "4.6.0",
-				"expect": "22.4.3",
-				"graceful-fs": "4.1.11",
-				"is-generator-fn": "1.0.0",
-				"jest-diff": "22.4.3",
-				"jest-matcher-utils": "22.4.3",
-				"jest-message-util": "22.4.3",
-				"jest-snapshot": "22.4.3",
-				"jest-util": "22.4.3",
-				"source-map-support": "0.5.6"
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^22.4.0",
+				"graceful-fs": "^4.1.11",
+				"is-generator-fn": "^1.0.0",
+				"jest-diff": "^22.4.0",
+				"jest-matcher-utils": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-snapshot": "^22.4.0",
+				"jest-util": "^22.4.1",
+				"source-map-support": "^0.5.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -6305,8 +4901,8 @@
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
 					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 					"requires": {
-						"buffer-from": "1.1.0",
-						"source-map": "0.6.1"
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
 					}
 				}
 			}
@@ -6316,7 +4912,7 @@
 			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
 			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
 			"requires": {
-				"pretty-format": "22.4.3"
+				"pretty-format": "^22.4.3"
 			}
 		},
 		"jest-matcher-utils": {
@@ -6324,9 +4920,9 @@
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
 			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
 			"requires": {
-				"chalk": "2.4.1",
-				"jest-get-type": "22.4.3",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.4.3",
+				"pretty-format": "^22.4.3"
 			}
 		},
 		"jest-message-util": {
@@ -6334,11 +4930,11 @@
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
 			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.49",
-				"chalk": "2.4.1",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0",
-				"stack-utils": "1.0.1"
+				"@babel/code-frame": "^7.0.0-beta.35",
+				"chalk": "^2.0.1",
+				"micromatch": "^2.3.11",
+				"slash": "^1.0.0",
+				"stack-utils": "^1.0.1"
 			}
 		},
 		"jest-mock": {
@@ -6356,8 +4952,8 @@
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
 			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
 			"requires": {
-				"browser-resolve": "1.11.2",
-				"chalk": "2.4.1"
+				"browser-resolve": "^1.11.2",
+				"chalk": "^2.0.1"
 			}
 		},
 		"jest-resolve-dependencies": {
@@ -6365,7 +4961,7 @@
 			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
 			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
 			"requires": {
-				"jest-regex-util": "22.4.3"
+				"jest-regex-util": "^22.4.3"
 			}
 		},
 		"jest-runner": {
@@ -6373,17 +4969,17 @@
 			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
 			"integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
 			"requires": {
-				"exit": "0.1.2",
-				"jest-config": "22.4.4",
-				"jest-docblock": "22.4.3",
-				"jest-haste-map": "22.4.3",
-				"jest-jasmine2": "22.4.4",
-				"jest-leak-detector": "22.4.3",
-				"jest-message-util": "22.4.3",
-				"jest-runtime": "22.4.4",
-				"jest-util": "22.4.3",
-				"jest-worker": "22.4.3",
-				"throat": "4.1.0"
+				"exit": "^0.1.2",
+				"jest-config": "^22.4.4",
+				"jest-docblock": "^22.4.0",
+				"jest-haste-map": "^22.4.2",
+				"jest-jasmine2": "^22.4.4",
+				"jest-leak-detector": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-runtime": "^22.4.4",
+				"jest-util": "^22.4.1",
+				"jest-worker": "^22.2.2",
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-runtime": {
@@ -6391,32 +4987,58 @@
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
 			"integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
 			"requires": {
-				"babel-core": "6.26.3",
-				"babel-jest": "22.4.4",
-				"babel-plugin-istanbul": "4.1.6",
-				"chalk": "2.4.1",
-				"convert-source-map": "1.5.1",
-				"exit": "0.1.2",
-				"graceful-fs": "4.1.11",
-				"jest-config": "22.4.4",
-				"jest-haste-map": "22.4.3",
-				"jest-regex-util": "22.4.3",
-				"jest-resolve": "22.4.3",
-				"jest-util": "22.4.3",
-				"jest-validate": "22.4.4",
-				"json-stable-stringify": "1.0.1",
-				"micromatch": "2.3.11",
-				"realpath-native": "1.0.0",
-				"slash": "1.0.0",
+				"babel-core": "^6.0.0",
+				"babel-jest": "^22.4.4",
+				"babel-plugin-istanbul": "^4.1.5",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^22.4.4",
+				"jest-haste-map": "^22.4.2",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.2",
+				"jest-util": "^22.4.1",
+				"jest-validate": "^22.4.4",
+				"json-stable-stringify": "^1.0.1",
+				"micromatch": "^2.3.11",
+				"realpath-native": "^1.0.0",
+				"slash": "^1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "2.3.0",
-				"yargs": "10.1.2"
+				"write-file-atomic": "^2.1.0",
+				"yargs": "^10.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					}
 				},
 				"camelcase": {
 					"version": "4.1.0",
@@ -6428,17 +5050,30 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"yargs": {
@@ -6446,18 +5081,18 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
 					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.1.0"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^8.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -6465,7 +5100,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
 					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -6480,12 +5115,12 @@
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
 			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
 			"requires": {
-				"chalk": "2.4.1",
-				"jest-diff": "22.4.3",
-				"jest-matcher-utils": "22.4.3",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"jest-diff": "^22.4.3",
+				"jest-matcher-utils": "^22.4.3",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^22.4.3"
 			}
 		},
 		"jest-util": {
@@ -6493,13 +5128,13 @@
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
 			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
 			"requires": {
-				"callsites": "2.0.0",
-				"chalk": "2.4.1",
-				"graceful-fs": "4.1.11",
-				"is-ci": "1.1.0",
-				"jest-message-util": "22.4.3",
-				"mkdirp": "0.5.1",
-				"source-map": "0.6.1"
+				"callsites": "^2.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.11",
+				"is-ci": "^1.0.10",
+				"jest-message-util": "^22.4.3",
+				"mkdirp": "^0.5.1",
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -6514,11 +5149,11 @@
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
 			"integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
 			"requires": {
-				"chalk": "2.4.1",
-				"jest-config": "22.4.4",
-				"jest-get-type": "22.4.3",
-				"leven": "2.1.0",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"jest-config": "^22.4.4",
+				"jest-get-type": "^22.1.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^22.4.0"
 			}
 		},
 		"jest-worker": {
@@ -6526,13 +5161,8 @@
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
 			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
 			"requires": {
-				"merge-stream": "1.0.1"
+				"merge-stream": "^1.0.1"
 			}
-		},
-		"js-base64": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
-			"integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ=="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -6544,8 +5174,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -6559,32 +5189,32 @@
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
 			"integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
 			"requires": {
-				"abab": "1.0.4",
-				"acorn": "5.6.2",
-				"acorn-globals": "4.1.0",
-				"array-equal": "1.0.0",
-				"cssom": "0.3.2",
-				"cssstyle": "0.3.1",
-				"data-urls": "1.0.0",
-				"domexception": "1.0.1",
-				"escodegen": "1.9.1",
-				"html-encoding-sniffer": "1.0.2",
-				"left-pad": "1.3.0",
-				"nwsapi": "2.0.2",
+				"abab": "^1.0.4",
+				"acorn": "^5.3.0",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": ">= 0.3.1 < 0.4.0",
+				"data-urls": "^1.0.0",
+				"domexception": "^1.0.0",
+				"escodegen": "^1.9.0",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.2.0",
+				"nwsapi": "^2.0.0",
 				"parse5": "4.0.0",
-				"pn": "1.1.0",
-				"request": "2.87.0",
-				"request-promise-native": "1.0.5",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.4.2",
-				"w3c-hr-time": "1.0.1",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-mimetype": "2.1.0",
-				"whatwg-url": "6.4.1",
-				"ws": "4.1.0",
-				"xml-name-validator": "3.0.0"
+				"pn": "^1.1.0",
+				"request": "^2.83.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.3",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.1",
+				"ws": "^4.0.0",
+				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"jsesc": {
@@ -6612,7 +5242,7 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stringify-safe": {
@@ -6630,7 +5260,7 @@
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsonify": {
@@ -6642,11 +5272,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-		},
-		"jsonpointer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -6664,7 +5289,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"lazy-cache": {
@@ -6678,7 +5303,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"left-pad": {
@@ -6691,45 +5316,45 @@
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.11.0.tgz",
 			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
 			"requires": {
-				"async": "1.5.2",
-				"chalk": "2.4.1",
-				"cmd-shim": "2.0.2",
-				"columnify": "1.5.4",
-				"command-join": "2.0.0",
-				"conventional-changelog-cli": "1.3.22",
-				"conventional-recommended-bump": "1.2.1",
-				"dedent": "0.7.0",
-				"execa": "0.8.0",
-				"find-up": "2.1.0",
-				"fs-extra": "4.0.3",
-				"get-port": "3.2.0",
-				"glob": "7.1.2",
-				"glob-parent": "3.1.0",
-				"globby": "6.1.0",
-				"graceful-fs": "4.1.11",
-				"hosted-git-info": "2.6.0",
-				"inquirer": "3.3.0",
-				"is-ci": "1.1.0",
-				"load-json-file": "4.0.0",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"npmlog": "4.1.2",
-				"p-finally": "1.0.0",
-				"package-json": "4.0.1",
-				"path-exists": "3.0.0",
-				"read-cmd-shim": "1.0.1",
-				"read-pkg": "3.0.0",
-				"rimraf": "2.6.2",
-				"safe-buffer": "5.1.2",
-				"semver": "5.5.0",
-				"signal-exit": "3.0.2",
-				"slash": "1.0.0",
-				"strong-log-transformer": "1.0.6",
-				"temp-write": "3.4.0",
-				"write-file-atomic": "2.3.0",
-				"write-json-file": "2.3.0",
-				"write-pkg": "3.1.0",
-				"yargs": "8.0.2"
+				"async": "^1.5.0",
+				"chalk": "^2.1.0",
+				"cmd-shim": "^2.0.2",
+				"columnify": "^1.5.4",
+				"command-join": "^2.0.0",
+				"conventional-changelog-cli": "^1.3.13",
+				"conventional-recommended-bump": "^1.2.1",
+				"dedent": "^0.7.0",
+				"execa": "^0.8.0",
+				"find-up": "^2.1.0",
+				"fs-extra": "^4.0.1",
+				"get-port": "^3.2.0",
+				"glob": "^7.1.2",
+				"glob-parent": "^3.1.0",
+				"globby": "^6.1.0",
+				"graceful-fs": "^4.1.11",
+				"hosted-git-info": "^2.5.0",
+				"inquirer": "^3.2.2",
+				"is-ci": "^1.0.10",
+				"load-json-file": "^4.0.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"npmlog": "^4.1.2",
+				"p-finally": "^1.0.0",
+				"package-json": "^4.0.1",
+				"path-exists": "^3.0.0",
+				"read-cmd-shim": "^1.0.1",
+				"read-pkg": "^3.0.0",
+				"rimraf": "^2.6.1",
+				"safe-buffer": "^5.1.1",
+				"semver": "^5.4.1",
+				"signal-exit": "^3.0.2",
+				"slash": "^1.0.0",
+				"strong-log-transformer": "^1.0.6",
+				"temp-write": "^3.3.0",
+				"write-file-atomic": "^2.3.0",
+				"write-json-file": "^2.2.0",
+				"write-pkg": "^3.1.0",
+				"yargs": "^8.0.2"
 			}
 		},
 		"leven": {
@@ -6742,8 +5367,8 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -6751,34 +5376,19 @@
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "4.0.0",
-				"pify": "3.0.0",
-				"strip-bom": "3.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			}
-		},
-		"loader-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-			"requires": {
-				"big.js": "3.2.0",
-				"emojis-list": "2.1.0",
-				"json5": "0.5.1"
-			}
-		},
-		"loaders.css": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/loaders.css/-/loaders.css-0.1.2.tgz",
-			"integrity": "sha1-Op+0NybHMzSjgUKvnQYpAZtlh0M="
 		},
 		"locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -6791,48 +5401,18 @@
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
 		},
-		"lodash.assign": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-		},
-		"lodash.camelcase": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-		},
-		"lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-		},
-		"lodash.memoize": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-		},
-		"lodash.mergewith": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
-		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-		},
-		"lodash.tail": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
-			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ="
 		},
 		"lodash.template": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
 			"requires": {
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.templatesettings": "4.1.0"
+				"lodash._reinterpolate": "~3.0.0",
+				"lodash.templatesettings": "^4.0.0"
 			}
 		},
 		"lodash.templatesettings": {
@@ -6840,13 +5420,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
 			"requires": {
-				"lodash._reinterpolate": "3.0.0"
+				"lodash._reinterpolate": "~3.0.0"
 			}
-		},
-		"lodash.uniq": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 		},
 		"longest": {
 			"version": "1.0.1",
@@ -6858,7 +5433,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"loud-rejection": {
@@ -6866,8 +5441,8 @@
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"lowercase-keys": {
@@ -6880,8 +5455,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"magic-string": {
@@ -6889,7 +5464,7 @@
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
 			"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
 			"requires": {
-				"vlq": "0.2.3"
+				"vlq": "^0.2.2"
 			}
 		},
 		"make-dir": {
@@ -6897,7 +5472,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"makeerror": {
@@ -6905,7 +5480,7 @@
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"requires": {
-				"tmpl": "1.0.4"
+				"tmpl": "1.0.x"
 			}
 		},
 		"map-cache": {
@@ -6923,30 +5498,20 @@
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"requires": {
-				"object-visit": "1.0.1"
+				"object-visit": "^1.0.0"
 			}
-		},
-		"math-expression-evaluator": {
-			"version": "1.2.17",
-			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
 		},
 		"math-random": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
 			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
 		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"meow": {
@@ -6954,15 +5519,15 @@
 			"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 			"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 			"requires": {
-				"camelcase-keys": "4.2.0",
-				"decamelize-keys": "1.1.0",
-				"loud-rejection": "1.6.0",
-				"minimist": "1.2.0",
-				"minimist-options": "3.0.2",
-				"normalize-package-data": "2.4.0",
-				"read-pkg-up": "3.0.0",
-				"redent": "2.0.0",
-				"trim-newlines": "2.0.0"
+				"camelcase-keys": "^4.0.0",
+				"decamelize-keys": "^1.0.0",
+				"loud-rejection": "^1.0.0",
+				"minimist": "^1.1.3",
+				"minimist-options": "^3.0.1",
+				"normalize-package-data": "^2.3.4",
+				"read-pkg-up": "^3.0.0",
+				"redent": "^2.0.0",
+				"trim-newlines": "^2.0.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -6975,8 +5540,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				}
 			}
@@ -6986,42 +5551,32 @@
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
 			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"merge-stream": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"requires": {
-				"readable-stream": "2.3.6"
+				"readable-stream": "^2.0.1"
 			}
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -7034,7 +5589,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"normalize-path": {
@@ -7042,15 +5597,10 @@
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"requires": {
-						"remove-trailing-separator": "1.1.0"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				}
 			}
-		},
-		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
 			"version": "1.33.0",
@@ -7062,7 +5612,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.33.0"
+				"mime-db": "~1.33.0"
 			}
 		},
 		"mimic-fn": {
@@ -7075,7 +5625,7 @@
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
 			"requires": {
-				"dom-walk": "0.1.1"
+				"dom-walk": "^0.1.0"
 			}
 		},
 		"minimatch": {
@@ -7083,7 +5633,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -7096,8 +5646,8 @@
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 			"requires": {
-				"arrify": "1.0.1",
-				"is-plain-obj": "1.1.0"
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0"
 			}
 		},
 		"mixin-deep": {
@@ -7105,8 +5655,8 @@
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -7114,24 +5664,8 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
-				}
-			}
-		},
-		"mixin-object": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-			"requires": {
-				"for-in": "0.1.8",
-				"is-extendable": "0.1.1"
-			},
-			"dependencies": {
-				"for-in": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
 				}
 			}
 		},
@@ -7171,25 +5705,26 @@
 		"nan": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-odd": "2.0.0",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-odd": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -7214,50 +5749,13 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
-		"negotiator": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-		},
-		"neo-async": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
-			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
-		},
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
-			}
-		},
-		"node-gyp": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
-			"integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-			"requires": {
-				"fstream": "1.0.11",
-				"glob": "7.1.2",
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"nopt": "3.0.6",
-				"npmlog": "4.1.2",
-				"osenv": "0.1.5",
-				"request": "2.87.0",
-				"rimraf": "2.6.2",
-				"semver": "5.3.0",
-				"tar": "2.2.1",
-				"which": "1.3.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-				}
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-int64": {
@@ -7265,259 +5763,15 @@
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
 		},
-		"node-modules-regexp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
-		},
 		"node-notifier": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 			"requires": {
-				"growly": "1.3.0",
-				"semver": "5.5.0",
-				"shellwords": "0.1.1",
-				"which": "1.3.1"
-			}
-		},
-		"node-sass": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
-			"integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
-			"requires": {
-				"async-foreach": "0.1.3",
-				"chalk": "1.1.3",
-				"cross-spawn": "3.0.1",
-				"gaze": "1.1.3",
-				"get-stdin": "4.0.1",
-				"glob": "7.1.2",
-				"in-publish": "2.0.0",
-				"lodash.assign": "4.2.0",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.mergewith": "4.6.1",
-				"meow": "3.7.0",
-				"mkdirp": "0.5.1",
-				"nan": "2.10.0",
-				"node-gyp": "3.6.2",
-				"npmlog": "4.1.2",
-				"request": "2.79.0",
-				"sass-graph": "2.2.4",
-				"stdout-stream": "1.4.0",
-				"true-case-path": "1.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-				},
-				"camelcase-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"requires": {
-						"camelcase": "2.1.1",
-						"map-obj": "1.0.1"
-					}
-				},
-				"caseless": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-					"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					}
-				},
-				"cross-spawn": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.1"
-					}
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.6",
-						"mime-types": "2.1.18"
-					}
-				},
-				"har-validator": {
-					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-					"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-					"requires": {
-						"chalk": "1.1.3",
-						"commander": "2.15.1",
-						"is-my-json-valid": "2.17.2",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"http-signature": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.1",
-						"sshpk": "1.14.1"
-					}
-				},
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"requires": {
-						"repeating": "2.0.1"
-					}
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-				},
-				"meow": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"requires": {
-						"camelcase-keys": "2.1.0",
-						"decamelize": "1.2.0",
-						"loud-rejection": "1.6.0",
-						"map-obj": "1.0.1",
-						"minimist": "1.2.0",
-						"normalize-package-data": "2.4.0",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"redent": "1.0.0",
-						"trim-newlines": "1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-				},
-				"qs": {
-					"version": "6.3.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-					"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
-				},
-				"redent": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"requires": {
-						"indent-string": "2.1.0",
-						"strip-indent": "1.0.1"
-					}
-				},
-				"request": {
-					"version": "2.79.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-					"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.7.0",
-						"caseless": "0.11.0",
-						"combined-stream": "1.0.6",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "2.0.6",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.18",
-						"oauth-sign": "0.8.2",
-						"qs": "6.3.2",
-						"stringstream": "0.0.6",
-						"tough-cookie": "2.3.4",
-						"tunnel-agent": "0.4.3",
-						"uuid": "3.2.1"
-					}
-				},
-				"strip-indent": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"requires": {
-						"get-stdin": "4.0.1"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				},
-				"tough-cookie": {
-					"version": "2.3.4",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-					"requires": {
-						"punycode": "1.4.1"
-					}
-				},
-				"trim-newlines": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-				},
-				"tunnel-agent": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-					"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-				},
-				"uuid": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-				}
-			}
-		},
-		"nopt": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"requires": {
-				"abbrev": "1.1.1"
+				"growly": "^1.3.0",
+				"semver": "^5.4.1",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
 			}
 		},
 		"normalize-package-data": {
@@ -7525,10 +5779,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "2.6.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.3"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -7536,38 +5790,12 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
 			"integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k="
 		},
-		"normalize-range": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
-		},
-		"normalize-url": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-			"requires": {
-				"object-assign": "4.1.1",
-				"prepend-http": "1.0.4",
-				"query-string": "4.3.4",
-				"sort-keys": "1.1.2"
-			},
-			"dependencies": {
-				"sort-keys": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-					"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-					"requires": {
-						"is-plain-obj": "1.1.0"
-					}
-				}
-			}
-		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"npmlog": {
@@ -7575,16 +5803,11 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"requires": {
-				"are-we-there-yet": "1.1.5",
-				"console-control-strings": "1.1.0",
-				"gauge": "2.7.4",
-				"set-blocking": "2.0.0"
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
 			}
-		},
-		"num2fraction": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
@@ -7611,9 +5834,9 @@
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
 			},
 			"dependencies": {
 				"define-property": {
@@ -7621,7 +5844,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -7636,7 +5859,7 @@
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -7651,8 +5874,8 @@
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.12.0"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.omit": {
@@ -7660,8 +5883,8 @@
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -7669,7 +5892,7 @@
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -7679,20 +5902,12 @@
 				}
 			}
 		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -7700,7 +5915,7 @@
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"optimist": {
@@ -7708,8 +5923,8 @@
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.3"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			}
 		},
 		"optionator": {
@@ -7717,12 +5932,12 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -7742,9 +5957,9 @@
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			},
 			"dependencies": {
 				"execa": {
@@ -7752,13 +5967,13 @@
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				}
 			}
@@ -7767,15 +5982,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
-			}
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -7787,7 +5993,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
@@ -7795,7 +6001,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "1.2.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-try": {
@@ -7808,10 +6014,10 @@
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 			"requires": {
-				"got": "6.7.1",
-				"registry-auth-token": "3.3.2",
-				"registry-url": "3.1.0",
-				"semver": "5.5.0"
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
 			}
 		},
 		"parse-github-repo-url": {
@@ -7824,10 +6030,10 @@
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -7840,7 +6046,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				}
 			}
@@ -7850,19 +6056,14 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"requires": {
-				"error-ex": "1.3.1",
-				"json-parse-better-errors": "1.0.2"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parse5": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
-		},
-		"parseurl": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -7904,7 +6105,7 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"performance-now": {
@@ -7927,15 +6128,7 @@
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
-				"pinkie": "2.0.4"
-			}
-		},
-		"pirates": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
-			"integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
-			"requires": {
-				"node-modules-regexp": "1.0.0"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -7943,7 +6136,7 @@
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
 			}
 		},
 		"pn": {
@@ -7955,1737 +6148,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
-		},
-		"postcss": {
-			"version": "6.0.22",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-			"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-			"requires": {
-				"chalk": "2.4.1",
-				"source-map": "0.6.1",
-				"supports-color": "5.4.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-calc": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-message-helpers": "2.0.0",
-				"reduce-css-calc": "1.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-colormin": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
-			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-			"requires": {
-				"colormin": "1.1.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-convert-values": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
-			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-discard-comments": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
-			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-			"requires": {
-				"postcss": "5.2.18"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-discard-duplicates": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
-			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-			"requires": {
-				"postcss": "5.2.18"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-discard-empty": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
-			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-			"requires": {
-				"postcss": "5.2.18"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-discard-overridden": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
-			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-			"requires": {
-				"postcss": "5.2.18"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-discard-unused": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
-			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-			"requires": {
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-filter-plugins": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
-			"integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
-			"requires": {
-				"postcss": "5.2.18"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-load-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
-			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-			"requires": {
-				"cosmiconfig": "2.2.2",
-				"object-assign": "4.1.1",
-				"postcss-load-options": "1.2.0",
-				"postcss-load-plugins": "2.3.0"
-			}
-		},
-		"postcss-load-options": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
-			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-			"requires": {
-				"cosmiconfig": "2.2.2",
-				"object-assign": "4.1.1"
-			}
-		},
-		"postcss-load-plugins": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
-			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-			"requires": {
-				"cosmiconfig": "2.2.2",
-				"object-assign": "4.1.1"
-			}
-		},
-		"postcss-loader": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.5.tgz",
-			"integrity": "sha512-pV7kB5neJ0/1tZ8L1uGOBNTVBCSCXQoIsZMsrwvO8V2rKGa2tBl/f80GGVxow2jJnRJ2w1ocx693EKhZAb9Isg==",
-			"requires": {
-				"loader-utils": "1.1.0",
-				"postcss": "6.0.22",
-				"postcss-load-config": "1.2.0",
-				"schema-utils": "0.4.5"
-			}
-		},
-		"postcss-merge-idents": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
-			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-			"requires": {
-				"has": "1.0.3",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-merge-longhand": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
-			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-			"requires": {
-				"postcss": "5.2.18"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-merge-rules": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
-			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-api": "1.6.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3",
-				"vendors": "1.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"requires": {
-						"caniuse-db": "1.0.30000849",
-						"electron-to-chromium": "1.3.48"
-					}
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-message-helpers": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
-		},
-		"postcss-minify-font-values": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
-			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-			"requires": {
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-minify-gradients": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
-			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-minify-params": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
-			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"uniqs": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-minify-selectors": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
-			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-			"requires": {
-				"alphanum-sort": "1.0.2",
-				"has": "1.0.3",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-modules-extract-imports": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
-			"integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
-			"requires": {
-				"postcss": "6.0.22"
-			}
-		},
-		"postcss-modules-local-by-default": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
-			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
-			"requires": {
-				"css-selector-tokenizer": "0.7.0",
-				"postcss": "6.0.22"
-			}
-		},
-		"postcss-modules-scope": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
-			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
-			"requires": {
-				"css-selector-tokenizer": "0.7.0",
-				"postcss": "6.0.22"
-			}
-		},
-		"postcss-modules-values": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
-			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
-			"requires": {
-				"icss-replace-symbols": "1.1.0",
-				"postcss": "6.0.22"
-			}
-		},
-		"postcss-normalize-charset": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
-			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-			"requires": {
-				"postcss": "5.2.18"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-normalize-url": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
-			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-			"requires": {
-				"is-absolute-url": "2.1.0",
-				"normalize-url": "1.9.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-ordered-values": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
-			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-reduce-idents": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
-			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-reduce-initial": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
-			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-			"requires": {
-				"postcss": "5.2.18"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-reduce-transforms": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
-			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-			"requires": {
-				"has": "1.0.3",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-			"requires": {
-				"flatten": "1.0.2",
-				"indexes-of": "1.0.1",
-				"uniq": "1.0.1"
-			}
-		},
-		"postcss-svgo": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
-			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-			"requires": {
-				"is-svg": "2.1.0",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"svgo": "0.7.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-unique-selectors": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-value-parser": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
-		},
-		"postcss-zindex": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
-			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-			"requires": {
-				"has": "1.0.3",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.5",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
-			}
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -9717,8 +6179,8 @@
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
 			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
 			"requires": {
-				"ansi-regex": "3.0.0",
-				"ansi-styles": "3.2.1"
+				"ansi-regex": "^3.0.0",
+				"ansi-styles": "^3.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -9733,11 +6195,11 @@
 			"resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-1.6.0.tgz",
 			"integrity": "sha512-bnCmsPy98ERD7VWBO+0y1OGWLfx/DPUjNFN2ZRVyxuGBiic1BXAGgjHsTKgBIbPISdqpP6KBEmRV0Lir4xu/BA==",
 			"requires": {
-				"chalk": "2.4.1",
-				"execa": "0.8.0",
-				"find-up": "2.1.0",
-				"ignore": "3.3.8",
-				"mri": "1.1.1"
+				"chalk": "^2.3.0",
+				"execa": "^0.8.0",
+				"find-up": "^2.1.0",
+				"ignore": "^3.3.7",
+				"mri": "^1.1.0"
 			}
 		},
 		"private": {
@@ -9760,7 +6222,7 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "2.0.6"
+				"asap": "~2.0.3"
 			}
 		},
 		"prop-types": {
@@ -9768,18 +6230,9 @@
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
-			}
-		},
-		"proxy-addr": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
-			"requires": {
-				"forwarded": "0.1.2",
-				"ipaddr.js": "1.6.0"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"pseudomap": {
@@ -9807,15 +6260,6 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
-		"query-string": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"requires": {
-				"object-assign": "4.1.1",
-				"strict-uri-encode": "1.1.0"
-			}
-		},
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
@@ -9826,9 +6270,9 @@
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
 			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"requires": {
-				"is-number": "4.0.0",
-				"kind-of": "6.0.2",
-				"math-random": "1.0.1"
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -9843,59 +6287,15 @@
 				}
 			}
 		},
-		"range-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-		},
-		"raw-body": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-			"requires": {
-				"bytes": "3.0.0",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.19",
-				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-				},
-				"http-errors": {
-					"version": "1.6.2",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-					"requires": {
-						"depd": "1.1.1",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.0.3",
-						"statuses": "1.4.0"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.19",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-				},
-				"setprototypeof": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-				}
-			}
-		},
 		"rc": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"requires": {
-				"deep-extend": "0.6.0",
-				"ini": "1.3.5",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
 			},
 			"dependencies": {
 				"minimist": {
@@ -9910,10 +6310,10 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
 			"integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			}
 		},
 		"react-deep-force-update": {
@@ -9926,10 +6326,10 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.0.tgz",
 			"integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			}
 		},
 		"react-is": {
@@ -9942,19 +6342,8 @@
 			"resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
 			"integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
 			"requires": {
-				"lodash": "4.17.10",
-				"react-deep-force-update": "1.1.1"
-			}
-		},
-		"react-spinkit": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/react-spinkit/-/react-spinkit-3.0.0.tgz",
-			"integrity": "sha1-Mf2vThgXd2bFfRsfMzApD4SSqFo=",
-			"requires": {
-				"classnames": "2.2.5",
-				"loaders.css": "0.1.2",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"lodash": "^4.6.1",
+				"react-deep-force-update": "^1.0.0"
 			}
 		},
 		"react-test-renderer": {
@@ -9962,10 +6351,10 @@
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.0.tgz",
 			"integrity": "sha512-Seh1t9xFY6TKiV/hRlPzUkqX1xHOiKIMsctfU0cggo1ajsLjoIJFL520LlrxV+4/VIj+clrCeH6s/aVv/vTStg==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1",
-				"react-is": "16.4.0"
+				"fbjs": "^0.8.16",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0",
+				"react-is": "^16.4.0"
 			}
 		},
 		"react-transform-hmr": {
@@ -9973,18 +6362,8 @@
 			"resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
 			"integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
 			"requires": {
-				"global": "4.3.2",
-				"react-proxy": "1.1.8"
-			}
-		},
-		"react-transition-group": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
-			"integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
-			"requires": {
-				"dom-helpers": "3.3.1",
-				"loose-envify": "1.3.1",
-				"prop-types": "15.6.1"
+				"global": "^4.3.0",
+				"react-proxy": "^1.1.7"
 			}
 		},
 		"read-cmd-shim": {
@@ -9992,7 +6371,7 @@
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.2"
 			}
 		},
 		"read-pkg": {
@@ -10000,9 +6379,9 @@
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"requires": {
-				"load-json-file": "4.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "3.0.0"
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -10010,8 +6389,8 @@
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -10019,8 +6398,8 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -10028,11 +6407,11 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"parse-json": {
@@ -10040,7 +6419,7 @@
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"path-exists": {
@@ -10048,7 +6427,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
@@ -10056,9 +6435,9 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -10071,9 +6450,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"strip-bom": {
@@ -10081,7 +6460,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -10091,13 +6470,13 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -10105,7 +6484,7 @@
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
 			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
 			"requires": {
-				"util.promisify": "1.0.0"
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"redent": {
@@ -10113,40 +6492,8 @@
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 			"requires": {
-				"indent-string": "3.2.0",
-				"strip-indent": "2.0.0"
-			}
-		},
-		"reduce-css-calc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"requires": {
-				"balanced-match": "0.4.2",
-				"math-expression-evaluator": "1.2.17",
-				"reduce-function-call": "1.0.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				}
-			}
-		},
-		"reduce-function-call": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
-			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"requires": {
-				"balanced-match": "0.4.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				}
+				"indent-string": "^3.0.0",
+				"strip-indent": "^2.0.0"
 			}
 		},
 		"regenerate": {
@@ -10159,7 +6506,7 @@
 			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-6.0.0.tgz",
 			"integrity": "sha512-BvXxRS7RfVWxtm7vrq+0I0j7sqZ1zeSC+yzf5HS0qLnKcZPX541gFEGB39LvGuKHrkyKXrzXug+oC7xkM1Zovw==",
 			"requires": {
-				"regenerate": "1.4.0"
+				"regenerate": "^1.3.3"
 			}
 		},
 		"regenerator-runtime": {
@@ -10172,9 +6519,9 @@
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"private": "0.1.8"
+				"babel-runtime": "^6.18.0",
+				"babel-types": "^6.19.0",
+				"private": "^0.1.6"
 			}
 		},
 		"regex-cache": {
@@ -10182,7 +6529,7 @@
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
@@ -10190,8 +6537,8 @@
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -10199,12 +6546,12 @@
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.5.tgz",
 			"integrity": "sha512-3xo5pFze1F8oR4F9x3aFbdtdxAxQ9WBX6gXfLgeBt7KpDI0+oDF7WVntnhsPKqobU/GAYc2pmx+y3z0JI1+z3w==",
 			"requires": {
-				"regenerate": "1.4.0",
-				"regenerate-unicode-properties": "6.0.0",
-				"regjsgen": "0.4.0",
-				"regjsparser": "0.3.0",
-				"unicode-match-property-ecmascript": "1.0.3",
-				"unicode-match-property-value-ecmascript": "1.0.1"
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^6.0.0",
+				"regjsgen": "^0.4.0",
+				"regjsparser": "^0.3.0",
+				"unicode-match-property-ecmascript": "^1.0.3",
+				"unicode-match-property-value-ecmascript": "^1.0.1"
 			}
 		},
 		"registry-auth-token": {
@@ -10212,8 +6559,8 @@
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 			"requires": {
-				"rc": "1.2.8",
-				"safe-buffer": "5.1.2"
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"registry-url": {
@@ -10221,7 +6568,7 @@
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 			"requires": {
-				"rc": "1.2.8"
+				"rc": "^1.0.1"
 			}
 		},
 		"regjsgen": {
@@ -10234,7 +6581,7 @@
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
 			"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -10264,7 +6611,7 @@
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"request": {
@@ -10272,26 +6619,26 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
 			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.7.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.0.3",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.18",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.3.4",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.2.1"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			},
 			"dependencies": {
 				"punycode": {
@@ -10304,7 +6651,7 @@
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 					"requires": {
-						"punycode": "1.4.1"
+						"punycode": "^1.4.1"
 					}
 				},
 				"uuid": {
@@ -10319,7 +6666,7 @@
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.13.1"
 			}
 		},
 		"request-promise-native": {
@@ -10328,19 +6675,14 @@
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.4.2"
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-		},
-		"require-from-string": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-			"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
@@ -10352,7 +6694,7 @@
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
 			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -10360,7 +6702,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"resolve-from": {
@@ -10378,8 +6720,8 @@
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ret": {
@@ -10393,7 +6735,7 @@
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"optional": true,
 			"requires": {
-				"align-text": "0.1.4"
+				"align-text": "^0.1.1"
 			}
 		},
 		"rimraf": {
@@ -10401,7 +6743,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"rollup": {
@@ -10410,7 +6752,7 @@
 			"integrity": "sha512-RZVvCWm9BHOYloaE6LLiE/ibpjv1CmI8F8k0B0Cp+q1eezo3cswszJH1DN0djgzSlo0hjuuCmyeI+1XOYLl4wg==",
 			"requires": {
 				"@types/estree": "0.0.38",
-				"@types/node": "8.10.18"
+				"@types/node": "*"
 			}
 		},
 		"rollup-plugin-babel": {
@@ -10419,7 +6761,7 @@
 			"integrity": "sha512-zr6iZ1yrd/0I36Lok+HFrTKSaolb4sKLQsJy/j27+dnFFjnavRlEgzec1zJXQr8owG22topvJ5rq3jfXIpvfnw==",
 			"requires": {
 				"@babel/helper-module-imports": "7.0.0-beta.44",
-				"rollup-pluginutils": "2.3.0"
+				"rollup-pluginutils": "^2.0.1"
 			},
 			"dependencies": {
 				"@babel/helper-module-imports": {
@@ -10428,7 +6770,7 @@
 					"integrity": "sha512-V95wi6rCffcLM46XdaUJHRc3D/XSvfsQshedaX1riHQCbs0uVopdswXrykwB6E/QEPfUGxXfs7l5GubupOi+Cw==",
 					"requires": {
 						"@babel/types": "7.0.0-beta.44",
-						"lodash": "4.17.10"
+						"lodash": "^4.2.0"
 					}
 				},
 				"@babel/types": {
@@ -10436,9 +6778,9 @@
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
 					"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
 					"requires": {
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "2.0.0"
+						"esutils": "^2.0.2",
+						"lodash": "^4.2.0",
+						"to-fast-properties": "^2.0.0"
 					}
 				}
 			}
@@ -10448,10 +6790,10 @@
 			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.3.tgz",
 			"integrity": "sha512-g91ZZKZwTW7F7vL6jMee38I8coj/Q9GBdTmXXeFL7ldgC1Ky5WJvHgbKlAiXXTh762qvohhExwUgeQGFh9suGg==",
 			"requires": {
-				"estree-walker": "0.5.2",
-				"magic-string": "0.22.5",
-				"resolve": "1.7.1",
-				"rollup-pluginutils": "2.3.0"
+				"estree-walker": "^0.5.1",
+				"magic-string": "^0.22.4",
+				"resolve": "^1.5.0",
+				"rollup-pluginutils": "^2.0.1"
 			}
 		},
 		"rollup-plugin-node-resolve": {
@@ -10459,9 +6801,9 @@
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz",
 			"integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
 			"requires": {
-				"builtin-modules": "2.0.0",
-				"is-module": "1.0.0",
-				"resolve": "1.7.1"
+				"builtin-modules": "^2.0.0",
+				"is-module": "^1.0.0",
+				"resolve": "^1.1.6"
 			},
 			"dependencies": {
 				"builtin-modules": {
@@ -10476,9 +6818,9 @@
 			"resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz",
 			"integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
 			"requires": {
-				"magic-string": "0.22.5",
-				"minimatch": "3.0.4",
-				"rollup-pluginutils": "2.3.0"
+				"magic-string": "^0.22.4",
+				"minimatch": "^3.0.2",
+				"rollup-pluginutils": "^2.0.1"
 			}
 		},
 		"rollup-plugin-typescript2": {
@@ -10486,10 +6828,10 @@
 			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.14.0.tgz",
 			"integrity": "sha512-+MQDb0K+1KwlQvnIZ57DkmQQ/scP12eEgwi5ORytZ8BLMRmFDktUl30ehgog09D5OrS5izlE0zIgnFJ8T0mFyw==",
 			"requires": {
-				"fs-extra": "5.0.0",
-				"resolve": "1.7.1",
-				"rollup-pluginutils": "2.3.0",
-				"tslib": "1.9.2"
+				"fs-extra": "^5.0.0",
+				"resolve": "^1.7.1",
+				"rollup-pluginutils": "^2.0.1",
+				"tslib": "^1.9.0"
 			},
 			"dependencies": {
 				"fs-extra": {
@@ -10497,9 +6839,9 @@
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
 					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.1"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				}
 			}
@@ -10509,7 +6851,7 @@
 			"resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz",
 			"integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
 			"requires": {
-				"uglify-js": "3.4.0"
+				"uglify-js": "^3.0.9"
 			},
 			"dependencies": {
 				"source-map": {
@@ -10522,8 +6864,8 @@
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.0.tgz",
 					"integrity": "sha512-Jcf5naPkX3rVPSQpRn9Vm6Rr572I1gTtR9LnqKgXjmOgfYQ/QS0V2WRStFR53Bdj520M66aCZqt9uzYXgtGrJQ==",
 					"requires": {
-						"commander": "2.15.1",
-						"source-map": "0.6.1"
+						"commander": "~2.15.0",
+						"source-map": "~0.6.1"
 					}
 				}
 			}
@@ -10533,8 +6875,8 @@
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.0.tgz",
 			"integrity": "sha512-xB6hsRsjdJdIYWEyYUJy/3ki5g69wrf0luHPGNK3ZSocV6HLNfio59l3dZ3TL4xUwEKgROhFi9jOCt6c5gfUWw==",
 			"requires": {
-				"estree-walker": "0.5.2",
-				"micromatch": "2.3.11"
+				"estree-walker": "^0.5.2",
+				"micromatch": "^2.3.11"
 			}
 		},
 		"rsvp": {
@@ -10547,7 +6889,7 @@
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			}
 		},
 		"rx-lite": {
@@ -10560,7 +6902,7 @@
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"requires": {
-				"rx-lite": "4.0.8"
+				"rx-lite": "*"
 			}
 		},
 		"safe-buffer": {
@@ -10573,7 +6915,7 @@
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"safer-buffer": {
@@ -10586,15 +6928,15 @@
 			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
 			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"requires": {
-				"anymatch": "2.0.0",
-				"capture-exit": "1.2.0",
-				"exec-sh": "0.2.1",
-				"fb-watchman": "2.0.0",
-				"fsevents": "1.2.4",
-				"micromatch": "3.1.10",
-				"minimist": "1.2.0",
-				"walker": "1.0.7",
-				"watch": "0.18.0"
+				"anymatch": "^2.0.0",
+				"capture-exit": "^1.2.0",
+				"exec-sh": "^0.2.0",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^1.2.3",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5",
+				"watch": "~0.18.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -10612,16 +6954,16 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -10629,7 +6971,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -10647,13 +6989,13 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -10661,7 +7003,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -10669,7 +7011,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -10677,7 +7019,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -10685,7 +7027,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -10695,7 +7037,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -10703,7 +7045,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -10713,9 +7055,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -10730,14 +7072,14 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -10745,7 +7087,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -10753,7 +7095,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -10763,10 +7105,10 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -10774,7 +7116,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -10784,7 +7126,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -10792,7 +7134,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -10800,9 +7142,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-number": {
@@ -10810,7 +7152,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -10818,7 +7160,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -10838,19 +7180,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"minimist": {
@@ -10860,191 +7202,15 @@
 				}
 			}
 		},
-		"sass-graph": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-			"requires": {
-				"glob": "7.1.2",
-				"lodash": "4.17.10",
-				"scss-tokenizer": "0.2.3",
-				"yargs": "7.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"yargs": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "5.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-					"requires": {
-						"camelcase": "3.0.0"
-					}
-				}
-			}
-		},
-		"sass-loader": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.0.3.tgz",
-			"integrity": "sha512-iaSFtQcGo4SSgDw5Aes5p4VTrA5jCGSA7sGmhPIcOloBlgI1VktM2MUrk2IHHjbNagckXlPz+HWq1vAAPrcYxA==",
-			"requires": {
-				"clone-deep": "2.0.2",
-				"loader-utils": "1.1.0",
-				"lodash.tail": "4.1.1",
-				"neo-async": "2.5.1",
-				"pify": "3.0.0"
-			}
-		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
-		"schema-utils": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
-			"integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
-			"requires": {
-				"ajv": "6.5.0",
-				"ajv-keywords": "3.2.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
-					"integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
-					"requires": {
-						"fast-deep-equal": "2.0.1",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1",
-						"uri-js": "4.2.2"
-					}
-				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				}
-			}
-		},
-		"scss-tokenizer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-			"requires": {
-				"js-base64": "2.4.5",
-				"source-map": "0.4.4"
-			}
-		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
 			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-		},
-		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"destroy": "1.0.4",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"etag": "1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "1.6.3",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
-				"on-finished": "2.3.0",
-				"range-parser": "1.2.0",
-				"statuses": "1.4.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
-		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-			"requires": {
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"parseurl": "1.3.2",
-				"send": "0.16.2"
-			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -11056,10 +7222,10 @@
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -11067,7 +7233,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -11077,34 +7243,12 @@
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
-		"setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-		},
-		"shallow-clone": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
-			"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
-			"requires": {
-				"is-extendable": "0.1.1",
-				"kind-of": "5.1.0",
-				"mixin-object": "2.0.1"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-				}
-			}
-		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -11137,14 +7281,14 @@
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.7",
-				"source-map-resolve": "0.5.2",
-				"use": "3.1.0"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -11160,7 +7304,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
@@ -11168,7 +7312,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"source-map": {
@@ -11183,9 +7327,9 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -11193,7 +7337,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -11201,7 +7345,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -11209,7 +7353,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -11217,9 +7361,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"isobject": {
@@ -11239,15 +7383,7 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"requires": {
-				"kind-of": "3.2.2"
-			}
-		},
-		"sntp": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"requires": {
-				"hoek": "2.16.3"
+				"kind-of": "^3.2.0"
 			}
 		},
 		"sort-keys": {
@@ -11255,56 +7391,15 @@
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
-		},
-		"source-list-map": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
 		},
 		"source-map": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 			"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 			"requires": {
-				"amdefine": "1.0.1"
-			}
-		},
-		"source-map-loader": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
-			"integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
-			"requires": {
-				"async": "2.6.1",
-				"loader-utils": "0.2.17",
-				"source-map": "0.6.1"
-			},
-			"dependencies": {
-				"async": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-					"requires": {
-						"lodash": "4.17.10"
-					}
-				},
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
+				"amdefine": ">=0.0.4"
 			}
 		},
 		"source-map-resolve": {
@@ -11312,11 +7407,11 @@
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"requires": {
-				"atob": "2.1.1",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -11324,7 +7419,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"requires": {
-				"source-map": "0.5.7"
+				"source-map": "^0.5.6"
 			},
 			"dependencies": {
 				"source-map": {
@@ -11344,8 +7439,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -11358,8 +7453,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"requires": {
-				"spdx-exceptions": "2.1.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -11372,7 +7467,7 @@
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 			"requires": {
-				"through": "2.3.8"
+				"through": "2"
 			}
 		},
 		"split-string": {
@@ -11380,7 +7475,7 @@
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"requires": {
-				"extend-shallow": "3.0.2"
+				"extend-shallow": "^3.0.0"
 			}
 		},
 		"split2": {
@@ -11388,7 +7483,7 @@
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 			"requires": {
-				"through2": "2.0.3"
+				"through2": "^2.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -11401,14 +7496,14 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
@@ -11421,8 +7516,8 @@
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -11430,22 +7525,9 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
-			}
-		},
-		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-		},
-		"stdout-stream": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
-			"integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
-			"requires": {
-				"readable-stream": "2.3.6"
 			}
 		},
 		"stealthy-require": {
@@ -11453,18 +7535,13 @@
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"requires": {
-				"astral-regex": "1.0.0",
-				"strip-ansi": "4.0.0"
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11477,7 +7554,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -11487,8 +7564,8 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11501,7 +7578,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -11511,20 +7588,15 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
-		},
-		"stringstream": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -11552,11 +7624,11 @@
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
 			"requires": {
-				"byline": "5.0.0",
-				"duplexer": "0.1.1",
-				"minimist": "0.1.0",
-				"moment": "2.22.2",
-				"through": "2.3.8"
+				"byline": "^5.0.0",
+				"duplexer": "^0.1.1",
+				"minimist": "^0.1.0",
+				"moment": "^2.6.0",
+				"through": "^2.3.4"
 			},
 			"dependencies": {
 				"minimist": {
@@ -11566,81 +7638,18 @@
 				}
 			}
 		},
-		"style-loader": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.21.0.tgz",
-			"integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
-			"requires": {
-				"loader-utils": "1.1.0",
-				"schema-utils": "0.4.5"
-			}
-		},
 		"supports-color": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 			"requires": {
-				"has-flag": "3.0.0"
-			}
-		},
-		"svelte-dev-helper": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/svelte-dev-helper/-/svelte-dev-helper-1.1.7.tgz",
-			"integrity": "sha1-t9iHx75av34kNvlGdWAGGx4qk18="
-		},
-		"svelte-loader": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/svelte-loader/-/svelte-loader-2.9.1.tgz",
-			"integrity": "sha512-6rC/E4+efIfbM3MS+WjDV7BM7LY7yvcPMasojbn+zqiGYQ3GjNu3UN32OfvySHm/aQ9NwXIeiuIRjHQXMXCBGQ==",
-			"requires": {
-				"loader-utils": "1.1.0",
-				"svelte-dev-helper": "1.1.7"
-			}
-		},
-		"svgo": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
-			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-			"requires": {
-				"coa": "1.0.4",
-				"colors": "1.1.2",
-				"csso": "2.3.2",
-				"js-yaml": "3.7.0",
-				"mkdirp": "0.5.1",
-				"sax": "1.2.4",
-				"whet.extend": "0.9.9"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-				},
-				"js-yaml": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-					"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-					"requires": {
-						"argparse": "1.0.10",
-						"esprima": "2.7.3"
-					}
-				}
+				"has-flag": "^3.0.0"
 			}
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
-		},
-		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-			"requires": {
-				"block-stream": "0.0.9",
-				"fstream": "1.0.11",
-				"inherits": "2.0.3"
-			}
 		},
 		"temp-dir": {
 			"version": "1.0.0",
@@ -11652,12 +7661,12 @@
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"is-stream": "1.1.0",
-				"make-dir": "1.3.0",
-				"pify": "3.0.0",
-				"temp-dir": "1.0.0",
-				"uuid": "3.2.1"
+				"graceful-fs": "^4.1.2",
+				"is-stream": "^1.1.0",
+				"make-dir": "^1.0.0",
+				"pify": "^3.0.0",
+				"temp-dir": "^1.0.0",
+				"uuid": "^3.0.1"
 			},
 			"dependencies": {
 				"uuid": {
@@ -11672,8 +7681,8 @@
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
 			"requires": {
-				"os-tmpdir": "1.0.2",
-				"uuid": "2.0.3"
+				"os-tmpdir": "^1.0.0",
+				"uuid": "^2.0.1"
 			}
 		},
 		"test-exclude": {
@@ -11681,11 +7690,11 @@
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
 			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
 			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "3.1.10",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
+				"arrify": "^1.0.1",
+				"micromatch": "^3.1.8",
+				"object-assign": "^4.1.0",
+				"read-pkg-up": "^1.0.1",
+				"require-main-filename": "^1.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -11703,16 +7712,16 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -11720,7 +7729,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -11738,13 +7747,13 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -11752,7 +7761,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -11760,7 +7769,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -11768,7 +7777,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -11776,7 +7785,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -11786,7 +7795,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -11794,7 +7803,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -11804,9 +7813,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -11821,14 +7830,14 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -11836,7 +7845,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -11844,7 +7853,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -11854,10 +7863,10 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -11865,7 +7874,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -11875,7 +7884,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -11883,7 +7892,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -11891,9 +7900,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-number": {
@@ -11901,7 +7910,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11909,7 +7918,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -11929,19 +7938,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				}
 			}
@@ -11966,8 +7975,8 @@
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"requires": {
-				"readable-stream": "2.3.6",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"timed-out": {
@@ -11980,7 +7989,7 @@
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.2"
 			}
 		},
 		"tmpl": {
@@ -11998,7 +8007,7 @@
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"to-regex": {
@@ -12006,10 +8015,10 @@
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -12017,8 +8026,8 @@
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -12026,7 +8035,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				}
 			}
@@ -12036,8 +8045,8 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
 			"integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
 			"requires": {
-				"psl": "1.1.27",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -12052,7 +8061,7 @@
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"requires": {
-				"punycode": "2.1.1"
+				"punycode": "^2.1.0"
 			}
 		},
 		"trim-newlines": {
@@ -12070,28 +8079,6 @@
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
-		"true-case-path": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
-			"integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
-			"requires": {
-				"glob": "6.0.4"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "6.0.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				}
-			}
-		},
 		"tslib": {
 			"version": "1.9.2",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
@@ -12102,7 +8089,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -12116,16 +8103,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"requires": {
-				"prelude-ls": "1.1.2"
-			}
-		},
-		"type-is": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "2.1.18"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"typedarray": {
@@ -12149,9 +8127,9 @@
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
 			"optional": true,
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12166,9 +8144,9 @@
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 					"optional": true,
 					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
+						"camelcase": "^1.0.2",
+						"cliui": "^2.1.0",
+						"decamelize": "^1.0.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -12190,8 +8168,8 @@
 			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
 			"integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA==",
 			"requires": {
-				"unicode-canonical-property-names-ecmascript": "1.0.3",
-				"unicode-property-aliases-ecmascript": "1.0.3"
+				"unicode-canonical-property-names-ecmascript": "^1.0.2",
+				"unicode-property-aliases-ecmascript": "^1.0.3"
 			}
 		},
 		"unicode-match-property-value-ecmascript": {
@@ -12209,10 +8187,10 @@
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -12220,7 +8198,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
@@ -12228,41 +8206,26 @@
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
 			}
-		},
-		"uniq": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
-		},
-		"uniqs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
 		},
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
 			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
 		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"has-value": {
@@ -12270,9 +8233,9 @@
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -12302,14 +8265,6 @@
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
 			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
 		},
-		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"requires": {
-				"punycode": "2.1.1"
-			}
-		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -12320,7 +8275,7 @@
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"requires": {
-				"prepend-http": "1.0.4"
+				"prepend-http": "^1.0.1"
 			}
 		},
 		"use": {
@@ -12328,7 +8283,7 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -12348,14 +8303,9 @@
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"requires": {
-				"define-properties": "1.1.2",
-				"object.getownpropertydescriptors": "2.0.3"
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
 			}
-		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
 			"version": "2.0.3",
@@ -12367,28 +8317,18 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"requires": {
-				"spdx-correct": "3.0.0",
-				"spdx-expression-parse": "3.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-		},
-		"vendors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
-			"integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ=="
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vlq": {
@@ -12396,77 +8336,21 @@
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
 			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
 		},
-		"vue": {
-			"version": "2.5.16",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-2.5.16.tgz",
-			"integrity": "sha512-/ffmsiVuPC8PsWcFkZngdpas19ABm5mh2wA7iDqcltyCTwlgZjHGeJYOXkBMo422iPwIcviOtrTCUpSfXmToLQ=="
-		},
-		"vue-hot-reload-api": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.0.tgz",
-			"integrity": "sha512-2j/t+wIbyVMP5NvctQoSUvLkYKoWAAk2QlQiilrM2a6/ulzFgdcLUJfTvs4XQ/3eZhHiBmmEojbjmM4AzZj8JA=="
-		},
-		"vue-loader": {
-			"version": "13.7.2",
-			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-13.7.2.tgz",
-			"integrity": "sha512-pgFWFsUjYO1v+J+3r7K0Q4lCp0eOyI24/q9j+cCudWyCTjgpjpcAa1MdwjlDUUettt9xkkUBbQ9fkAN1NC8t9w==",
-			"requires": {
-				"consolidate": "0.14.5",
-				"hash-sum": "1.0.2",
-				"loader-utils": "1.1.0",
-				"lru-cache": "4.1.3",
-				"postcss": "6.0.22",
-				"postcss-load-config": "1.2.0",
-				"postcss-selector-parser": "2.2.3",
-				"prettier": "1.13.4",
-				"resolve": "1.7.1",
-				"source-map": "0.6.1",
-				"vue-hot-reload-api": "2.3.0",
-				"vue-style-loader": "3.1.2",
-				"vue-template-es2015-compiler": "1.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"vue-style-loader": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-3.1.2.tgz",
-			"integrity": "sha512-ICtVdK/p+qXWpdSs2alWtsXt9YnDoYjQe0w5616j9+/EhjoxZkbun34uWgsMFnC1MhrMMwaWiImz3K2jK1Yp2Q==",
-			"requires": {
-				"hash-sum": "1.0.2",
-				"loader-utils": "1.1.0"
-			}
-		},
 		"vue-template-compiler": {
 			"version": "2.5.16",
 			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.16.tgz",
 			"integrity": "sha512-ZbuhCcF/hTYmldoUOVcu2fcbeSAZnfzwDskGduOrnjBiIWHgELAd+R8nAtX80aZkceWDKGQ6N9/0/EUpt+l22A==",
 			"requires": {
-				"de-indent": "1.0.2",
-				"he": "1.1.1"
+				"de-indent": "^1.0.2",
+				"he": "^1.1.0"
 			}
-		},
-		"vue-template-es2015-compiler": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
-			"integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg=="
-		},
-		"vuex": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/vuex/-/vuex-3.0.1.tgz",
-			"integrity": "sha512-wLoqz0B7DSZtgbWL1ShIBBCjv22GV5U+vcBFox658g6V0s4wZV9P4YjCNyoHSyIBpj1f29JBoNQIqD82cR4O3w=="
 		},
 		"w3c-hr-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"requires": {
-				"browser-process-hrtime": "0.1.2"
+				"browser-process-hrtime": "^0.1.2"
 			}
 		},
 		"walker": {
@@ -12474,7 +8358,7 @@
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"requires": {
-				"makeerror": "1.0.11"
+				"makeerror": "1.0.x"
 			}
 		},
 		"watch": {
@@ -12482,8 +8366,8 @@
 			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"requires": {
-				"exec-sh": "0.2.1",
-				"minimist": "1.2.0"
+				"exec-sh": "^0.2.0",
+				"minimist": "^1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -12498,7 +8382,7 @@
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"requires": {
-				"defaults": "1.0.3"
+				"defaults": "^1.0.3"
 			}
 		},
 		"webidl-conversions": {
@@ -12536,22 +8420,17 @@
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
 			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
 			"requires": {
-				"lodash.sortby": "4.7.0",
-				"tr46": "1.0.1",
-				"webidl-conversions": "4.0.2"
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
 			}
-		},
-		"whet.extend": {
-			"version": "0.9.9",
-			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
 		},
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -12564,7 +8443,7 @@
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"requires": {
-				"string-width": "2.1.1"
+				"string-width": "^1.0.2 || 2"
 			}
 		},
 		"window-size": {
@@ -12583,8 +8462,8 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -12592,7 +8471,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -12600,9 +8479,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -12617,9 +8496,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"write-json-file": {
@@ -12627,12 +8506,12 @@
 			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
 			"requires": {
-				"detect-indent": "5.0.0",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.3.0",
-				"pify": "3.0.0",
-				"sort-keys": "2.0.0",
-				"write-file-atomic": "2.3.0"
+				"detect-indent": "^5.0.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"pify": "^3.0.0",
+				"sort-keys": "^2.0.0",
+				"write-file-atomic": "^2.0.0"
 			}
 		},
 		"write-pkg": {
@@ -12640,8 +8519,8 @@
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
 			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
 			"requires": {
-				"sort-keys": "2.0.0",
-				"write-json-file": "2.3.0"
+				"sort-keys": "^2.0.0",
+				"write-json-file": "^2.2.0"
 			}
 		},
 		"ws": {
@@ -12649,8 +8528,8 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
 			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
 			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.2"
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"xml-name-validator": {
@@ -12678,19 +8557,19 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
 			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
 			"requires": {
-				"camelcase": "4.1.0",
-				"cliui": "3.2.0",
-				"decamelize": "1.2.0",
-				"get-caller-file": "1.0.2",
-				"os-locale": "2.1.0",
-				"read-pkg-up": "2.0.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "7.0.0"
+				"camelcase": "^4.1.0",
+				"cliui": "^3.2.0",
+				"decamelize": "^1.1.1",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"read-pkg-up": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^7.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -12703,9 +8582,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					},
 					"dependencies": {
 						"string-width": {
@@ -12713,9 +8592,9 @@
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -12725,7 +8604,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -12733,10 +8612,10 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"parse-json": {
@@ -12744,7 +8623,7 @@
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"path-type": {
@@ -12752,7 +8631,7 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"requires": {
-						"pify": "2.3.0"
+						"pify": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -12765,9 +8644,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"requires": {
-						"load-json-file": "2.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "2.0.0"
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -12775,8 +8654,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "2.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
 					}
 				}
 			}
@@ -12786,7 +8665,7 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			},
 			"dependencies": {
 				"camelcase": {

--- a/packages/sitemap/.gitignore
+++ b/packages/sitemap/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+*.log
+.rpt2_cache
+
+dist
+
+coverage

--- a/packages/sitemap/LICENSE
+++ b/packages/sitemap/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Paul Sherman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sitemap/README.md
+++ b/packages/sitemap/README.md
@@ -1,0 +1,16 @@
+# @curi/sitemap
+
+[![npm][badge]][npm-link]
+
+[badge]: https://img.shields.io/npm/v/@curi/sitemap.svg
+[npm-link]: https://npmjs.com/package/@curi/sitemap
+
+`@curi/sitemap` generates a sitemap.
+
+## Installation
+
+```
+npm install --save @curi/sitemap
+```
+
+For more information, please check out the [`@curi/sitemap`](https://curi.js.org/packages/@curi/sitemap) page on the documentation website.

--- a/packages/sitemap/jest.config.js
+++ b/packages/sitemap/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  moduleFileExtensions: ["ts", "js"],
+  testMatch: ["**/tests/**/*.spec.ts"],
+  transform: {
+    "\\.ts$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+  },
+  globals: {
+    "ts-jest": {
+      module: "es6"
+    }
+  }
+};

--- a/packages/sitemap/package-lock.json
+++ b/packages/sitemap/package-lock.json
@@ -1,0 +1,4107 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"ts-jest": {
+			"version": "21.2.4",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-21.2.4.tgz",
+			"integrity": "sha512-Plk49Us+DcncpQcC8fhYwDUdhW96QB0Dv02etOLhzq+2HAvXfrEUys3teZ/BeyQ+r1rHxfGdNj4dB0Q5msZR3g==",
+			"requires": {
+				"babel-core": "^6.24.1",
+				"babel-plugin-istanbul": "^4.1.4",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-preset-jest": "^21.2.0",
+				"cpx": "^1.5.0",
+				"fs-extra": "^4.0.2",
+				"jest-config": "^21.2.1",
+				"pkg-dir": "^2.0.0",
+				"source-map-support": "^0.5.0",
+				"yargs": "^10.0.3"
+			},
+			"dependencies": {
+				"abab": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+					"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+				},
+				"acorn": {
+					"version": "4.0.13",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+				},
+				"acorn-globals": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+					"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+					"requires": {
+						"acorn": "^4.0.4"
+					}
+				},
+				"ajv": {
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"requires": {
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"anymatch": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+					"requires": {
+						"micromatch": "^2.1.5",
+						"normalize-path": "^2.0.0"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+							"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+							"requires": {
+								"arr-flatten": "^1.0.1"
+							}
+						},
+						"array-unique": {
+							"version": "0.2.1",
+							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+							"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+						},
+						"braces": {
+							"version": "1.8.5",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+							"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+							"requires": {
+								"expand-range": "^1.8.1",
+								"preserve": "^0.2.0",
+								"repeat-element": "^1.1.2"
+							}
+						},
+						"expand-brackets": {
+							"version": "0.1.5",
+							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+							"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+							"requires": {
+								"is-posix-bracket": "^0.1.0"
+							}
+						},
+						"extglob": {
+							"version": "0.3.2",
+							"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+							"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+							"requires": {
+								"is-extglob": "^1.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						},
+						"micromatch": {
+							"version": "2.3.11",
+							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+							"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+							"requires": {
+								"arr-diff": "^2.0.0",
+								"array-unique": "^0.2.1",
+								"braces": "^1.8.2",
+								"expand-brackets": "^0.1.4",
+								"extglob": "^0.3.1",
+								"filename-regex": "^2.0.0",
+								"is-extglob": "^1.0.0",
+								"is-glob": "^2.0.1",
+								"kind-of": "^3.0.2",
+								"normalize-path": "^2.0.1",
+								"object.omit": "^2.0.0",
+								"parse-glob": "^3.0.4",
+								"regex-cache": "^0.4.2"
+							}
+						}
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+					"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+					"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+				},
+				"array-equal": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+					"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+				},
+				"array-filter": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+					"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+				},
+				"array-map": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+					"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+				},
+				"array-reduce": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+					"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+				},
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+					"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+				},
+				"async-each": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+					"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+				},
+				"atob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+					"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+				},
+				"aws-sign2": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+				},
+				"aws4": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+					"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+					"requires": {
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
+					}
+				},
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					}
+				},
+				"babel-generator": {
+					"version": "6.26.1",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+					"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+					"requires": {
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"babel-helpers": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+					"requires": {
+						"babel-runtime": "^6.22.0",
+						"babel-template": "^6.24.1"
+					}
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+					"requires": {
+						"babel-runtime": "^6.22.0"
+					}
+				},
+				"babel-plugin-istanbul": {
+					"version": "4.1.6",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+					"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+					"requires": {
+						"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+						"find-up": "^2.1.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"test-exclude": "^4.2.1"
+					}
+				},
+				"babel-plugin-jest-hoist": {
+					"version": "21.2.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
+					"integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ=="
+				},
+				"babel-plugin-syntax-object-rest-spread": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+					"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+				},
+				"babel-plugin-transform-es2015-modules-commonjs": {
+					"version": "6.26.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+					"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+					"requires": {
+						"babel-plugin-transform-strict-mode": "^6.24.1",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-types": "^6.26.0"
+					}
+				},
+				"babel-plugin-transform-strict-mode": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+					"requires": {
+						"babel-runtime": "^6.22.0",
+						"babel-types": "^6.24.1"
+					}
+				},
+				"babel-preset-jest": {
+					"version": "21.2.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
+					"integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
+					"requires": {
+						"babel-plugin-jest-hoist": "^21.2.0",
+						"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+					}
+				},
+				"babel-register": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+					"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+					"requires": {
+						"babel-core": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"core-js": "^2.5.0",
+						"home-or-tmp": "^2.0.0",
+						"lodash": "^4.17.4",
+						"mkdirp": "^0.5.1",
+						"source-map-support": "^0.4.15"
+					},
+					"dependencies": {
+						"source-map-support": {
+							"version": "0.4.18",
+							"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+							"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+							"requires": {
+								"source-map": "^0.5.6"
+							}
+						}
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"requires": {
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
+					}
+				},
+				"babel-template": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+					"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+					"requires": {
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
+					}
+				},
+				"babel-traverse": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+					"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
+					}
+				},
+				"babel-types": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+					"requires": {
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
+					}
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+				},
+				"base": {
+					"version": "0.11.2",
+					"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+					"requires": {
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+					"optional": true,
+					"requires": {
+						"tweetnacl": "^0.14.3"
+					}
+				},
+				"binary-extensions": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+					"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"browser-resolve": {
+					"version": "1.11.2",
+					"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+					"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+					"requires": {
+						"resolve": "1.1.7"
+					},
+					"dependencies": {
+						"resolve": {
+							"version": "1.1.7",
+							"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+							"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+						}
+					}
+				},
+				"buffer-from": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+					"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+					"requires": {
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
+					}
+				},
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"chokidar": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+					"requires": {
+						"anymatch": "^1.3.0",
+						"async-each": "^1.0.0",
+						"fsevents": "^1.0.0",
+						"glob-parent": "^2.0.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^2.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0"
+					}
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+					"requires": {
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+					"requires": {
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+					"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+					"requires": {
+						"color-name": "^1.1.1"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"combined-stream": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+					"requires": {
+						"delayed-stream": "~1.0.0"
+					}
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+				},
+				"content-type-parser": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+					"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+					"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+				},
+				"core-js": {
+					"version": "2.5.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+				},
+				"cpx": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
+					"integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
+					"requires": {
+						"babel-runtime": "^6.9.2",
+						"chokidar": "^1.6.0",
+						"duplexer": "^0.1.1",
+						"glob": "^7.0.5",
+						"glob2base": "^0.0.12",
+						"minimatch": "^3.0.2",
+						"mkdirp": "^0.5.1",
+						"resolve": "^1.1.7",
+						"safe-buffer": "^5.0.1",
+						"shell-quote": "^1.6.1",
+						"subarg": "^1.0.0"
+					}
+				},
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"cssom": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+					"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+				},
+				"cssstyle": {
+					"version": "0.2.37",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+					"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+					"requires": {
+						"cssom": "0.3.x"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+				},
+				"deep-is": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+					"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+				},
+				"detect-indent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+					"requires": {
+						"repeating": "^2.0.0"
+					}
+				},
+				"diff": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+				},
+				"duplexer": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+					"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+					"optional": true,
+					"requires": {
+						"jsbn": "~0.1.0"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+				},
+				"escodegen": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
+					"integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"optional": true
+						}
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+				},
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+					"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+					"requires": {
+						"fill-range": "^2.1.0"
+					},
+					"dependencies": {
+						"fill-range": {
+							"version": "2.2.4",
+							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+							"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+							"requires": {
+								"is-number": "^2.1.0",
+								"isobject": "^2.0.0",
+								"randomatic": "^3.0.0",
+								"repeat-element": "^1.1.2",
+								"repeat-string": "^1.5.2"
+							}
+						},
+						"is-number": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+							"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							}
+						},
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"expect": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
+					"integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"jest-diff": "^21.2.1",
+						"jest-get-type": "^21.2.0",
+						"jest-matcher-utils": "^21.2.1",
+						"jest-message-util": "^21.2.1",
+						"jest-regex-util": "^21.2.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						}
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+					"requires": {
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"extsprintf": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+					"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+				},
+				"fast-deep-equal": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+				},
+				"fast-json-stable-stringify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+				},
+				"fast-levenshtein": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+					"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+					"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"find-index": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+					"integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+					"requires": {
+						"for-in": "^1.0.1"
+					}
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+				},
+				"form-data": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+					"requires": {
+						"map-cache": "^0.2.2"
+					}
+				},
+				"fs-extra": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+				},
+				"fsevents": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+					"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+					"optional": true,
+					"requires": {
+						"nan": "^2.9.2",
+						"node-pre-gyp": "^0.10.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"deep-extend": {
+							"version": "0.5.1",
+							"bundled": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.21",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": "^2.1.0"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						},
+						"minipass": {
+							"version": "2.2.4",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.2.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"debug": "^2.1.2",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.10.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.0",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.1.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.1.10",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.7",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.5.1",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.0.5"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"bundled": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.5.0",
+							"bundled": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.0.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.2.4",
+								"minizlib": "^1.1.0",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"yallist": {
+							"version": "3.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+					"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+					"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+					"requires": {
+						"glob-parent": "^2.0.0",
+						"is-glob": "^2.0.0"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
+				"glob2base": {
+					"version": "0.0.12",
+					"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+					"integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+					"requires": {
+						"find-index": "^0.1.1"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+				},
+				"har-schema": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+				},
+				"har-validator": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+					"requires": {
+						"ajv": "^5.1.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+					"requires": {
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+					"requires": {
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"home-or-tmp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+					"requires": {
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.1"
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+					"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+				},
+				"html-encoding-sniffer": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+					"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+					"requires": {
+						"whatwg-encoding": "^1.0.1"
+					}
+				},
+				"http-signature": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"invariant": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+					"requires": {
+						"loose-envify": "^1.0.0"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+				},
+				"is-binary-path": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+					"requires": {
+						"binary-extensions": "^1.0.0"
+					}
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+					"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+					"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+					"requires": {
+						"is-primitive": "^2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+					"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+					"requires": {
+						"is-number": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+					"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+					"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+					"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+					"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+					"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+					"requires": {
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
+					}
+				},
+				"jest-config": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
+					"integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^21.2.1",
+						"jest-environment-node": "^21.2.1",
+						"jest-get-type": "^21.2.0",
+						"jest-jasmine2": "^21.2.1",
+						"jest-regex-util": "^21.2.0",
+						"jest-resolve": "^21.2.0",
+						"jest-util": "^21.2.1",
+						"jest-validate": "^21.2.1",
+						"pretty-format": "^21.2.1"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-diff": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
+					"integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^21.2.0",
+						"pretty-format": "^21.2.1"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz",
+					"integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
+					"requires": {
+						"jest-mock": "^21.2.0",
+						"jest-util": "^21.2.1",
+						"jsdom": "^9.12.0"
+					}
+				},
+				"jest-environment-node": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz",
+					"integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
+					"requires": {
+						"jest-mock": "^21.2.0",
+						"jest-util": "^21.2.1"
+					}
+				},
+				"jest-get-type": {
+					"version": "21.2.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+					"integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q=="
+				},
+				"jest-jasmine2": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
+					"integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"expect": "^21.2.1",
+						"graceful-fs": "^4.1.11",
+						"jest-diff": "^21.2.1",
+						"jest-matcher-utils": "^21.2.1",
+						"jest-message-util": "^21.2.1",
+						"jest-snapshot": "^21.2.1",
+						"p-cancelable": "^0.3.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
+					"integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^21.2.0",
+						"pretty-format": "^21.2.1"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-message-util": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
+					"integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"micromatch": "^2.3.11",
+						"slash": "^1.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"arr-diff": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+							"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+							"requires": {
+								"arr-flatten": "^1.0.1"
+							}
+						},
+						"array-unique": {
+							"version": "0.2.1",
+							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+							"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+						},
+						"braces": {
+							"version": "1.8.5",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+							"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+							"requires": {
+								"expand-range": "^1.8.1",
+								"preserve": "^0.2.0",
+								"repeat-element": "^1.1.2"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"expand-brackets": {
+							"version": "0.1.5",
+							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+							"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+							"requires": {
+								"is-posix-bracket": "^0.1.0"
+							}
+						},
+						"extglob": {
+							"version": "0.3.2",
+							"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+							"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+							"requires": {
+								"is-extglob": "^1.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						},
+						"micromatch": {
+							"version": "2.3.11",
+							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+							"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+							"requires": {
+								"arr-diff": "^2.0.0",
+								"array-unique": "^0.2.1",
+								"braces": "^1.8.2",
+								"expand-brackets": "^0.1.4",
+								"extglob": "^0.3.1",
+								"filename-regex": "^2.0.0",
+								"is-extglob": "^1.0.0",
+								"is-glob": "^2.0.1",
+								"kind-of": "^3.0.2",
+								"normalize-path": "^2.0.1",
+								"object.omit": "^2.0.0",
+								"parse-glob": "^3.0.4",
+								"regex-cache": "^0.4.2"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-mock": {
+					"version": "21.2.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz",
+					"integrity": "sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw=="
+				},
+				"jest-regex-util": {
+					"version": "21.2.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz",
+					"integrity": "sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ=="
+				},
+				"jest-resolve": {
+					"version": "21.2.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz",
+					"integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
+					"requires": {
+						"browser-resolve": "^1.11.2",
+						"chalk": "^2.0.1",
+						"is-builtin-module": "^1.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-snapshot": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
+					"integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-diff": "^21.2.1",
+						"jest-matcher-utils": "^21.2.1",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^21.2.1"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-util": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
+					"integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
+					"requires": {
+						"callsites": "^2.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.11",
+						"jest-message-util": "^21.2.1",
+						"jest-mock": "^21.2.0",
+						"jest-validate": "^21.2.1",
+						"mkdirp": "^0.5.1"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-validate": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+					"integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^21.2.0",
+						"leven": "^2.1.0",
+						"pretty-format": "^21.2.1"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+					"optional": true
+				},
+				"jsdom": {
+					"version": "9.12.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+					"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+					"requires": {
+						"abab": "^1.0.3",
+						"acorn": "^4.0.4",
+						"acorn-globals": "^3.1.0",
+						"array-equal": "^1.0.0",
+						"content-type-parser": "^1.0.1",
+						"cssom": ">= 0.3.2 < 0.4.0",
+						"cssstyle": ">= 0.2.37 < 0.3.0",
+						"escodegen": "^1.6.1",
+						"html-encoding-sniffer": "^1.0.1",
+						"nwmatcher": ">= 1.3.9 < 2.0.0",
+						"parse5": "^1.5.1",
+						"request": "^2.79.0",
+						"sax": "^1.2.1",
+						"symbol-tree": "^3.2.1",
+						"tough-cookie": "^2.3.2",
+						"webidl-conversions": "^4.0.0",
+						"whatwg-encoding": "^1.0.1",
+						"whatwg-url": "^4.3.0",
+						"xml-name-validator": "^2.0.1"
+					}
+				},
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+				},
+				"json-schema-traverse": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+				},
+				"json5": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+				},
+				"jsonfile": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+				},
+				"jsprim": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+					"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.3.0",
+						"json-schema": "0.2.3",
+						"verror": "1.10.0"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
+				"leven": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+				},
+				"levn": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+					"requires": {
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.10",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+					"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+					"requires": {
+						"object-visit": "^1.0.0"
+					}
+				},
+				"math-random": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+					"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+				},
+				"mem": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"mime-db": {
+					"version": "1.33.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+				},
+				"mime-types": {
+					"version": "2.1.18",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+					"requires": {
+						"mime-db": "~1.33.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+					"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+					"requires": {
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"nan": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+					"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+					"optional": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+					"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					}
+				},
+				"natural-compare": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+					"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+				},
+				"nwmatcher": {
+					"version": "1.4.4",
+					"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+					"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+					"requires": {
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+					"requires": {
+						"isobject": "^3.0.0"
+					}
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+					"requires": {
+						"for-own": "^0.1.4",
+						"is-extendable": "^0.1.1"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"optionator": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+					"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+					"requires": {
+						"deep-is": "~0.1.3",
+						"fast-levenshtein": "~2.0.4",
+						"levn": "~0.3.0",
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2",
+						"wordwrap": "~1.0.0"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+				},
+				"p-cancelable": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+					"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+					"requires": {
+						"glob-base": "^0.3.0",
+						"is-dotfile": "^1.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"parse5": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+					"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+					"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"performance-now": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+					"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+				},
+				"prelude-ls": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+					"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+				},
+				"pretty-format": {
+					"version": "21.2.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						}
+					}
+				},
+				"private": {
+					"version": "0.1.8",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+					"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+				},
+				"psl": {
+					"version": "1.1.27",
+					"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.27.tgz",
+					"integrity": "sha512-J8tJX5tAeEp9tQTI2w2aMZ6V1INuU4JmNaNPRuHAqjjVq3ZJ+jV3+tcT3ncgTnBxvwJy740IB/WZrxFus2VdMA=="
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				},
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+				},
+				"randomatic": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+					"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+					"requires": {
+						"is-number": "^4.0.0",
+						"kind-of": "^6.0.0",
+						"math-random": "^1.0.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+						}
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						},
+						"path-exists": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+							"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+							"requires": {
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"readdirp": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+					"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"minimatch": "^3.0.2",
+						"readable-stream": "^2.0.2",
+						"set-immediate-shim": "^1.0.1"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+					"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+					"requires": {
+						"is-equal-shallow": "^0.1.3"
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+					"requires": {
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+					"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+					"requires": {
+						"is-finite": "^1.0.0"
+					}
+				},
+				"request": {
+					"version": "2.87.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+					"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.6.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.1",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.1",
+						"har-validator": "~5.0.3",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.17",
+						"oauth-sign": "~0.8.2",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.1",
+						"safe-buffer": "^5.1.1",
+						"tough-cookie": "~2.3.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.1.0"
+					},
+					"dependencies": {
+						"tough-cookie": {
+							"version": "2.3.4",
+							"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+							"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+							"requires": {
+								"punycode": "^1.4.1"
+							}
+						}
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+				},
+				"resolve": {
+					"version": "1.7.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+					"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+				},
+				"ret": {
+					"version": "0.1.15",
+					"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+					"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+					"requires": {
+						"ret": "~0.1.10"
+					}
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+				},
+				"sax": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+				},
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+				},
+				"set-immediate-shim": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+					"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+					"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+				},
+				"shell-quote": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+					"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+					"requires": {
+						"array-filter": "~0.0.0",
+						"array-map": "~0.0.0",
+						"array-reduce": "~0.0.0",
+						"jsonify": "~0.0.0"
+					}
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+					"requires": {
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+					"requires": {
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+					"requires": {
+						"kind-of": "^3.2.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				},
+				"source-map-resolve": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+					"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+					"requires": {
+						"atob": "^2.1.1",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
+					}
+				},
+				"source-map-support": {
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+						}
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+					"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+					"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+					"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					}
+				},
+				"sshpk": {
+					"version": "1.14.2",
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+					"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+					"requires": {
+						"asn1": "~0.2.3",
+						"assert-plus": "^1.0.0",
+						"bcrypt-pbkdf": "^1.0.0",
+						"dashdash": "^1.12.0",
+						"ecc-jsbn": "~0.1.1",
+						"getpass": "^0.1.1",
+						"jsbn": "~0.1.0",
+						"safer-buffer": "^2.0.2",
+						"tweetnacl": "~0.14.0"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+					"requires": {
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+				},
+				"subarg": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+					"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+					"requires": {
+						"minimist": "^1.1.0"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+						}
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				},
+				"symbol-tree": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+					"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+				},
+				"test-exclude": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+					"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+					"requires": {
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
+					}
+				},
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
+					"integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				},
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"requires": {
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+					"optional": true
+				},
+				"type-check": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+					"requires": {
+						"prelude-ls": "~1.1.2"
+					}
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+					"requires": {
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
+							}
+						}
+					}
+				},
+				"universalify": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+					"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+					"requires": {
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+							"requires": {
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+									"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+							"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+					"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+				},
+				"use": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+					"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+					"requires": {
+						"kind-of": "^6.0.2"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+				},
+				"uuid": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+					"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"verror": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+					"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"core-util-is": "1.0.2",
+						"extsprintf": "^1.2.0"
+					}
+				},
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+				},
+				"whatwg-encoding": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+					"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+					"requires": {
+						"iconv-lite": "0.4.19"
+					}
+				},
+				"whatwg-url": {
+					"version": "4.8.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+					"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					},
+					"dependencies": {
+						"webidl-conversions": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+							"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+						}
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+				},
+				"xml-name-validator": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+					"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+				},
+				"yargs": {
+					"version": "10.1.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^8.1.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/sitemap/package.json
+++ b/packages/sitemap/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@curi/sitemap",
+  "version": "1.0.0-alpha.0",
+  "description": "Create a sitemap file for an application that uses the Curi router",
+  "main": "dist/curi-sitemap.common.js",
+  "module": "dist/curi-sitemap.es.js",
+  "types": "types/index.d.ts",
+  "files": [
+    "dist",
+    "types",
+    "LICENSE",
+    "*.md"
+  ],
+  "scripts": {
+    "prebuild": "rimraf dist types",
+    "build": "node ./scripts/build",
+    "coverage": "jest --coverage",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test",
+    "prettier": "prettier --single-quote --write \"{src,tests}/**/*.ts\"",
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pshrmn/curi/tree/master/packages/sitemap"
+  },
+  "keywords": [
+    "URL",
+    "URI",
+    "routing",
+    "navigation"
+  ],
+  "author": "Paul Sherman",
+  "license": "MIT",
+  "dependencies": {
+    "@curi/router": "^1.0.0-beta.36",
+    "@hickory/in-memory": "^1.0.0-beta.5"
+  },
+  "devDependencies": {
+    "@types/jest": "^22.0.1",
+    "@types/node": "^8.0.53",
+    "jest": "^22.1.1",
+    "prettier": "^1.10.2",
+    "rimraf": "^2.6.2",
+    "rollup": "^0.58.1",
+    "rollup-plugin-typescript2": "^0.14.0",
+    "ts-jest": "^21.2.3",
+    "typescript": "^2.6.1"
+  }
+}

--- a/packages/sitemap/scripts/build.js
+++ b/packages/sitemap/scripts/build.js
@@ -1,0 +1,42 @@
+const rollupBuild = require("../../../scripts/build");
+const typescript = require("rollup-plugin-typescript2");
+
+// don't bundle dependencies for es/cjs builds
+const pkg = require("../package.json");
+const deps = Object.keys(pkg.dependencies).map(key => key);
+
+const base = {
+  name: "CuriSitemap",
+  input: "src/sitemap.ts",
+  plugins: [
+    typescript({
+      useTsconfigDeclarationDir: true
+    })
+  ]
+};
+
+rollupBuild([
+  [
+    "ES",
+    {
+      ...base,
+      format: "es",
+      file: "dist/curi-sitemap.es.js",
+      external: deps,
+      safeModules: false
+    },
+    { NODE_ENV: "development", BABEL_ENV: "build" }
+  ],
+
+  [
+    "CommonJS",
+    {
+      ...base,
+      format: "cjs",
+      file: "dist/curi-sitemap.common.js",
+      external: deps,
+      safeModules: false
+    },
+    { NODE_ENV: "development", BABEL_ENV: "build" }
+  ]
+]);

--- a/packages/sitemap/src/sitemap.ts
+++ b/packages/sitemap/src/sitemap.ts
@@ -1,0 +1,45 @@
+import curi from "@curi/router";
+import InMemory from "@hickory/in-memory";
+
+import { Params, RouteDescriptor } from "@curi/router";
+
+export interface ParamRoute {
+  name: string;
+  params: Array<Params>;
+}
+export type RouteToMap = string | ParamRoute;
+
+export default function(
+  routes: Array<RouteDescriptor>,
+  absolute: string,
+  map: Array<RouteToMap>
+) {
+  const history = InMemory();
+  const router = curi(history, routes);
+
+  let sitemap: Array<string> = [];
+
+  map.forEach(item => {
+    if (typeof item === "string") {
+      const path = router.route.pathname(item);
+      sitemap.push(router.route.pathname(item));
+    } else {
+      const { name, params } = item;
+      sitemap = sitemap.concat(
+        params.map(key => router.route.pathname(name, key))
+      );
+    }
+  });
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${sitemap
+    .map(
+      page =>
+        `  <url>
+    <loc>${absolute}${page}</loc>
+  </url>`
+    )
+    .join("\n")}
+</urlset>`;
+}

--- a/packages/sitemap/tests/sitemap.spec.ts
+++ b/packages/sitemap/tests/sitemap.spec.ts
@@ -1,0 +1,59 @@
+import "jest";
+import sitemap from "../src/sitemap";
+
+describe("sitemap", () => {
+  it("returns a sitemap string", () => {
+    const routes = [
+      { name: "Home", path: "" },
+      { name: "About", path: "about" }
+    ];
+    const output = sitemap(routes, "https://www.example.com", [
+      "Home",
+      "About"
+    ]);
+    expect(output).toContain("https://www.example.com/");
+    expect(output).toContain("https://www.example.com/about");
+  });
+
+  it("uses route params", () => {
+    const routes = [
+      { name: "Home", path: "" },
+      { name: "Product", path: "p/:id" }
+    ];
+    const output = sitemap(routes, "https://www.example.com", [
+      "Home",
+      {
+        name: "Product",
+        params: [{ id: 1 }, { id: 2 }, { id: 3 }]
+      }
+    ]);
+    expect(output).toContain("https://www.example.com/");
+    expect(output).toContain("https://www.example.com/p/1");
+    expect(output).toContain("https://www.example.com/p/2");
+    expect(output).toContain("https://www.example.com/p/3");
+  });
+
+  it("works with nested routes", () => {
+    const routes = [
+      { name: "Home", path: "" },
+      {
+        name: "Products",
+        path: "p",
+        children: [{ name: "Product", path: ":id" }]
+      }
+    ];
+    const output = sitemap(routes, "https://www.example.com", [
+      "Home",
+      "Products",
+      {
+        name: "Product",
+        params: [{ id: 1 }, { id: 2 }, { id: 3 }]
+      }
+    ]);
+    expect(output).toContain("https://www.example.com/");
+    expect(output).toContain("https://www.example.com/p");
+    expect(output).toContain("https://www.example.com/p/1");
+    expect(output).toContain("https://www.example.com/p/2");
+    expect(output).toContain("https://www.example.com/p/3");
+  });
+});

--- a/packages/sitemap/tsconfig.json
+++ b/packages/sitemap/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "lib": ["es5", "es6"],
+    "target": "es5",
+    "module": "es6",
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "Node",
+    "declaration": true,
+    "declarationDir": "types",
+    "outDir": ".build"
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
A simple sitemap generator

```js
import sitemap from "@curi/sitemap";

import routes from "./routes";

const output = sitemap(
  routes,
  "https://www.example.com",
  ["Home", "About"]
);
```
This isn't ready to be merged yet. Right now there is a bit of configuration required to specify which routes should be included in the pathname. It would be preferable to automatically generate this, but there might be issues with "private" routes. No matter what, the user will have to provide the params for any routes that require those.

Is this necessary? In some cases, it might be "easier" to use a utility that crawls a site to generate a sitemap. That has the advantage of not needing user input (besides the initial location).