### PR TITLE
Allow <CuriProvider> to receive a new router prop

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `<CuriProvider>` can accept a new `router` prop.
+
 ## 1.0.0-beta.29
 
 * `<Prefetch when>` accepts array of match function names to call and its render-invoked `children()` function now receives a third argument: `error`.

--- a/packages/react/src/CuriProvider.tsx
+++ b/packages/react/src/CuriProvider.tsx
@@ -41,9 +41,9 @@ class CuriProvider extends React.Component<
     ) as RemoveObserver;
   }
 
-  componentWillReceiveProps(nextProps: CuriProviderProps) {
+  componentDidUpdate(prevProps: CuriProviderProps) {
     if (process.env.NODE_ENV !== "production") {
-      if (nextProps.router !== this.props.router) {
+      if (prevProps.router !== this.props.router) {
         console.warn(
           `The "router" prop passed to <CuriProvider> cannot be changed. If you need to update the router's routes, use router.replaceRoutes().`
         );

--- a/packages/react/tests/CuriProvider.spec.tsx
+++ b/packages/react/tests/CuriProvider.spec.tsx
@@ -7,8 +7,6 @@ import InMemory from "@hickory/in-memory";
 import CuriProvider from "../src/CuriProvider";
 import { Curious } from "../src/Context";
 
-import { Response, Navigation } from "@curi/router";
-
 describe("<CuriProvider>", () => {
   let node;
   const routes = [{ name: "Home", path: "" }, { name: "About", path: "about" }];
@@ -22,31 +20,44 @@ describe("<CuriProvider>", () => {
   });
 
   describe("router prop", () => {
-    it("warns if attempting to pass a new router prop", () => {
+    it("can switch observers when given a new router", () => {
       const history = InMemory();
-      const router = curi(history, [{ name: "Catch All", path: "(.*)" }]);
-      const router2 = curi(history, [{ name: "Catch All", path: "(.*)" }]);
+      const router = curi(history, [
+        {
+          name: "Catch All",
+          path: "(.*)",
+          response() {
+            return { data: "one" };
+          }
+        }
+      ]);
+      const router2 = curi(history, [
+        {
+          name: "Catch All",
+          path: "(.*)",
+          response() {
+            return { data: "two" };
+          }
+        }
+      ]);
+
       ReactDOM.render(
-        <CuriProvider router={router}>{() => null}</CuriProvider>,
+        <CuriProvider router={router}>
+          {({ response }) => <div>{response.data}</div>}
+        </CuriProvider>,
         node
       );
 
-      const realWarn = console.warn;
-      const fakeWarn = (console.warn = jest.fn());
-
-      expect(fakeWarn.mock.calls.length).toBe(0);
+      expect(node.textContent).toBe("one");
 
       ReactDOM.render(
-        <CuriProvider router={router2}>{() => null}</CuriProvider>,
+        <CuriProvider router={router2}>
+          {({ response }) => <div>{response.data}</div>}
+        </CuriProvider>,
         node
       );
 
-      expect(fakeWarn.mock.calls.length).toBe(1);
-      expect(fakeWarn.mock.calls[0][0]).toBe(
-        `The "router" prop passed to <CuriProvider> cannot be changed. If you need to update the router's routes, use router.replaceRoutes().`
-      );
-
-      console.warn = realWarn;
+      expect(node.textContent).toBe("two");
     });
   });
 

--- a/packages/react/types/CuriProvider.d.ts
+++ b/packages/react/types/CuriProvider.d.ts
@@ -1,19 +1,16 @@
 import React from "react";
-import { CuriRouter, Emitted, Response, Navigation } from "@curi/router";
+import { CuriRouter, Emitted } from "@curi/router";
 export declare type CuriRenderFn = (props: Emitted) => React.ReactNode;
 export interface CuriProviderProps {
     children: CuriRenderFn;
-    router?: CuriRouter;
+    router: CuriRouter;
 }
-export interface CuriProviderState {
-    response: Response;
-    navigation: Navigation;
-}
-declare class CuriProvider extends React.Component<CuriProviderProps, CuriProviderState> {
+declare class CuriProvider extends React.Component<CuriProviderProps> {
     stopResponding: () => void;
     constructor(props: CuriProviderProps);
     componentDidMount(): void;
-    componentWillReceiveProps(nextProps: CuriProviderProps): void;
+    componentDidUpdate(prevProps: CuriProviderProps): void;
+    setupRespond(router: CuriRouter): void;
     componentWillUnmount(): void;
     render(): JSX.Element;
 }


### PR DESCRIPTION
While the user should generally always use the same router, they can now pass the `<CuriProvider>` a new router and the component will stop observing the old router and start observing the new router.