### PR TITLE
Emit new response after updating routes

### DIFF
--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Emit a new response after calling `replaceRoutes()`.
+
 ## 1.0.0-beta.37
 
 * Default export is moved to the `curi` named export.

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -53,6 +53,10 @@ export default function createRouter(
         routeInteractions[interaction.name] = interaction.get;
         registerRoutes(routes, interaction);
       });
+
+    // assign navigation response handler
+    // this will be re-called if router.replaceRoutes() is called
+    history.respondWith(navigationHandler);
   }
 
   let observers: Array<Observer> = [];
@@ -207,7 +211,6 @@ export default function createRouter(
 
   // now that everything is defined, actually do the setup
   setupRoutesAndInteractions(routeArray);
-  history.respondWith(navigationHandler);
 
   return router;
 }

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -464,6 +464,32 @@ describe("curi", () => {
         expect(router.route.pathname(n)).toBeDefined();
       });
     });
+
+    it("re-calls response handler for new routes", () => {
+      const history = InMemory({
+        locations: ["/admin"]
+      });
+
+      const nonAuthRoutes = [
+        { name: "Home", path: "" },
+        { name: "Not Found", path: "(.*)" }
+      ];
+      const authRoutes = [
+        { name: "Home", path: "" },
+        { name: "Admin", path: "admin" },
+        { name: "Not Found", path: "(.*)" }
+      ];
+
+      const router = curi(history, nonAuthRoutes);
+
+      const { response: initialResponse } = router.current();
+      expect(initialResponse.name).toBe("Not Found");
+
+      router.replaceRoutes(authRoutes);
+
+      const { response: replacedResponse, navigation } = router.current();
+      expect(replacedResponse.name).toBe("Admin");
+    });
   });
 
   describe("respond", () => {


### PR DESCRIPTION
Previously, a new response would not be emitted after calling `replaceRoutes()` until a new navigation occurs. Now, a new response is emitted immediately so that the application re-renders using a response generated from the new routes.