### PR TITLE
Prep <CuriProvider> for suspense

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Prepare `<CuriProvider>` for Suspense support by using `getDerivedStateFromProps()` to store subscription source (the router).
 * Remove `<Prefetch>`.
 * `<CuriProvider>` can accept a new `router` prop.
 

--- a/packages/react/types/CuriProvider.d.ts
+++ b/packages/react/types/CuriProvider.d.ts
@@ -1,14 +1,22 @@
 import React from "react";
-import { CuriRouter, Emitted } from "@curi/router";
+import { CuriRouter, CurrentResponse, Emitted } from "@curi/router";
 export declare type CuriRenderFn = (props: Emitted) => React.ReactNode;
 export interface CuriProviderProps {
     children: CuriRenderFn;
     router: CuriRouter;
 }
-declare class CuriProvider extends React.Component<CuriProviderProps> {
+export interface CuriProviderState {
+    router: CuriRouter;
+    emitted: CurrentResponse;
+}
+declare class CuriProvider extends React.Component<CuriProviderProps, CuriProviderState> {
     stopResponding: () => void;
     removed: boolean;
     constructor(props: CuriProviderProps);
+    static getDerivedStateFromProps(nextProps: CuriProviderProps, prevState: CuriProviderState): {
+        router: CuriRouter;
+        emitted: CurrentResponse;
+    };
     componentDidMount(): void;
     componentDidUpdate(prevProps: CuriProviderProps): void;
     setupRespond(router: CuriRouter): void;

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Updates exported types.
 * Emit a new response after calling `replaceRoutes()`.
 
 ## 1.0.0-beta.37

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -28,5 +28,6 @@ export {
   Observer,
   Emitted,
   RemoveObserver,
-  Navigation
+  Navigation,
+  CurrentResponse
 } from "./curi";

--- a/packages/router/types/types/index.d.ts
+++ b/packages/router/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
 export { Route, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, AsyncGroup, Resolved, ResolveResults } from "./route";
 export { Response, RawParams, Params, MatchResponseProperties, SettableResponseProperties } from "./response";
-export { CuriRouter, RouterOptions, Observer, Emitted, RemoveObserver, Navigation } from "./curi";
+export { CuriRouter, RouterOptions, Observer, Emitted, RemoveObserver, Navigation, CurrentResponse } from "./curi";


### PR DESCRIPTION
With Suspense, the `<CuriProvider>` will need to store the `response` (and `navigation`) in state instead of reading from the router.