### PR TITLE
Moving scripts to UMD instead of IIFE

### DIFF
--- a/packages/interactions/route-active/CHANGELOG.md
+++ b/packages/interactions/route-active/CHANGELOG.md
@@ -1,24 +1,28 @@
+## Next
+
+- Switch script builds from IIFE to UMD
+
 ## 1.0.0-beta.6
 
-* Moved to `@curi/route-active`.
-* Removed source maps from `dist`.
+- Moved to `@curi/route-active`.
+- Removed source maps from `dist`.
 
 ## 1.0.0-beta.5
 
-* Add `reset` property.
+- Add `reset` property.
 
 ## 1.0.0-beta.4
 
-* Switch to TypeScript
+- Switch to TypeScript
 
 ## 1.0.0-beta.3
 
-* Switched to scoped package: `@curi/addon-active`.
+- Switched to scoped package: `@curi/addon-active`.
 
 ## 1.0.0-beta.1
 
-* Getting close to where this should be ready for release, so switching to beta version.
+- Getting close to where this should be ready for release, so switching to beta version.
 
 ## 0.2.0
 
-* New build (uses Rollup to output a single file for each build type).
+- New build (uses Rollup to output a single file for each build type).

--- a/packages/interactions/route-active/scripts/build.js
+++ b/packages/interactions/route-active/scripts/build.js
@@ -41,20 +41,20 @@ rollupBuild([
   ],
 
   [
-    "<script> file",
+    "UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-route-active.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],
 
   [
-    "<script> min file",
+    "minimized UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-route-active.min.js",
       uglify: true
     },

--- a/packages/interactions/route-ancestors/CHANGELOG.md
+++ b/packages/interactions/route-ancestors/CHANGELOG.md
@@ -1,29 +1,33 @@
+## Next
+
+- Switch script builds from IIFE to UMD
+
 ## 1.0.0-beta.6
 
-* Moved to `@curi/route-ancestors`.
-* Removed source maps from `dist`.
+- Moved to `@curi/route-ancestors`.
+- Removed source maps from `dist`.
 
 ## 1.0.0-beta.5
 
-* Add `reset` property.
-* Return `undefined` if requested route is not registered.
+- Add `reset` property.
+- Return `undefined` if requested route is not registered.
 
 ## 1.0.0-beta.4
 
-* Switch to TypeScript
+- Switch to TypeScript
 
 ## 1.0.0-beta.3
 
-* Switched to scoped package: `@curi/addon-ancestors`.
+- Switched to scoped package: `@curi/addon-ancestors`.
 
 ## 1.0.0-beta.1
 
-* Getting close to where this should be ready for release, so switching to beta version.
+- Getting close to where this should be ready for release, so switching to beta version.
 
 ## 0.2.1
 
-* When get is called with no arguments, it returns a copy of the array. This prevents bugs from happening when the user manipulates the received array.
+- When get is called with no arguments, it returns a copy of the array. This prevents bugs from happening when the user manipulates the received array.
 
 ## 0.2.0
 
-* New build (uses Rollup to output a single file for each build type).
+- New build (uses Rollup to output a single file for each build type).

--- a/packages/interactions/route-ancestors/scripts/build.js
+++ b/packages/interactions/route-ancestors/scripts/build.js
@@ -41,20 +41,20 @@ rollupBuild([
   ],
 
   [
-    "<script> file",
+    "UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-route-ancestors.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],
 
   [
-    "<script> min file",
+    "minimized UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-route-ancestors.min.js",
       uglify: true
     },

--- a/packages/interactions/route-prefetch/CHANGELOG.md
+++ b/packages/interactions/route-prefetch/CHANGELOG.md
@@ -1,50 +1,54 @@
+## Next
+
+- Switch script builds from IIFE to UMD
+
 ## 1.0.0-beta.11
 
-* `which` takes an array of `match` function names.
+- `which` takes an array of `match` function names.
 
 ## 1.0.0-beta.10
 
-* Add `which` object argument to specify which async functions to call. If not provided, all available functions are called. When `which` is provided, only functions with `true` `which` properties will be called.
+- Add `which` object argument to specify which async functions to call. If not provided, all available functions are called. When `which` is provided, only functions with `true` `which` properties will be called.
 
 ## 1.0.0-beta.9
 
-* If a requested route is not registered, Promise resolves object with `error` property instead
+- If a requested route is not registered, Promise resolves object with `error` property instead
   of throwing.
-* Support prefetching both `on.every()` _and_ `on.initial()`.
+- Support prefetching both `on.every()` _and_ `on.initial()`.
 
 ## 1.0.0-beta.8
 
-* Update type of props passed to `get()`.
+- Update type of props passed to `get()`.
 
 ## 1.0.0-beta.7
 
-* Moved to `@curi/route-prefetch`.
-* Switch to `on.every()`.
-* Removed source maps from `dist`.
+- Moved to `@curi/route-prefetch`.
+- Switch to `on.every()`.
+- Removed source maps from `dist`.
 
 ## 1.0.0-beta.6
 
-* Update to use the new `match.every` API.
+- Update to use the new `match.every` API.
 
 ## 1.0.0-beta.5
 
-* Add `reset` property.
+- Add `reset` property.
 
 ## 1.0.0-beta.4
 
-* Switch to TypeScript
+- Switch to TypeScript
 
 ## 1.0.0-beta.3
 
-* Switched to scoped package: `@curi/addon-prefetch`.
+- Switched to scoped package: `@curi/addon-prefetch`.
 
 ## 1.0.0-beta.1
 
-* Getting close to where this should be ready for release, so switching to beta version.
+- Getting close to where this should be ready for release, so switching to beta version.
 
 ## 0.2.0
 
-* New build (uses Rollup to output a single file for each build type).
+- New build (uses Rollup to output a single file for each build type).
 
 ## 0.1.2
 

--- a/packages/interactions/route-prefetch/scripts/build.js
+++ b/packages/interactions/route-prefetch/scripts/build.js
@@ -41,20 +41,20 @@ rollupBuild([
   ],
 
   [
-    "<script> file",
+    "UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-route-prefetch.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],
 
   [
-    "<script> min file",
+    "minimized UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-route-prefetch.min.js",
       uglify: true
     },

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Switch script builds from IIFE to UMD
 * Prepare `<CuriProvider>` for Suspense support by using `getDerivedStateFromProps()` to store subscription source (the router).
 * Remove `<Prefetch>`.
 * `<CuriProvider>` can accept a new `router` prop.

--- a/packages/react/scripts/build.js
+++ b/packages/react/scripts/build.js
@@ -44,10 +44,10 @@ rollupBuild([
   ],
 
   [
-    "<script> file",
+    "UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-react.js",
       external: ["react"]
     },
@@ -55,10 +55,10 @@ rollupBuild([
   ],
 
   [
-    "<script> min file",
+    "minimized UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-react.min.js",
       external: ["react"],
       uglify: true

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Switch script builds from IIFE to UMD
 * Updates exported types.
 * Emit a new response after calling `replaceRoutes()`.
 

--- a/packages/router/scripts/build.js
+++ b/packages/router/scripts/build.js
@@ -41,20 +41,20 @@ rollupBuild([
   ],
 
   [
-    "<script> file",
+    "UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-router.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],
 
   [
-    "<script> min file",
+    "minimized UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-router.min.js",
       uglify: true
     },

--- a/packages/side-effects/side-effect-aria-live/CHANGELOG.md
+++ b/packages/side-effects/side-effect-aria-live/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Switch script builds from IIFE to UMD
+
 ## 1.0.0-beta.0
 
 * Initial release

--- a/packages/side-effects/side-effect-aria-live/scripts/build.js
+++ b/packages/side-effects/side-effect-aria-live/scripts/build.js
@@ -41,20 +41,20 @@ rollupBuild([
   ],
 
   [
-    "<script> file",
+    "UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-side-effect-aria-live.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],
 
   [
-    "<script> min file",
+    "minimized UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-side-effect-aria-live.min.js",
       uglify: true
     },

--- a/packages/side-effects/side-effect-scroll/CHANGELOG.md
+++ b/packages/side-effects/side-effect-scroll/CHANGELOG.md
@@ -1,32 +1,36 @@
+## Next
+
+- Switch script builds from IIFE to UMD
+
 ## 1.0.0-beta.9
 
-* Side effect function returns an `Observer`.
+- Side effect function returns an `Observer`.
 
 ## 1.0.0-beta.8
 
-* Side effect receives `Emitted`.
+- Side effect receives `Emitted`.
 
 ## 1.0.0-beta.7
 
-* Expect a `Navigation` instead of an `Action`.
-* Removed source maps from `dist`
+- Expect a `Navigation` instead of an `Action`.
+- Removed source maps from `dist`
 
 ## 1.0.0-beta.6
 
-* Return a `ResponseHandler`, not a `Subscriber`.
+- Return a `ResponseHandler`, not a `Subscriber`.
 
 ## 1.0.0-beta.5
 
-* Return a `Subscriber`, not a `SideEffect`.
+- Return a `Subscriber`, not a `SideEffect`.
 
 ## 1.0.0-beta.4
 
-* Switch to TypeScript
+- Switch to TypeScript
 
 ## 1.0.0-beta.3
 
-* Switched to scoped package: `@curi/side-effect-scroll`.
+- Switched to scoped package: `@curi/side-effect-scroll`.
 
 ## 1.0.0-beta.1
 
-* Getting close to where this should be ready for release, so switching to beta version.
+- Getting close to where this should be ready for release, so switching to beta version.

--- a/packages/side-effects/side-effect-scroll/scripts/build.js
+++ b/packages/side-effects/side-effect-scroll/scripts/build.js
@@ -41,20 +41,20 @@ rollupBuild([
   ],
 
   [
-    "<script> file",
+    "UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-side-effect-scroll.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],
 
   [
-    "<script> min file",
+    "minimized UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-side-effect-scroll.min.js",
       uglify: true
     },

--- a/packages/side-effects/side-effect-title/scripts/build.js
+++ b/packages/side-effects/side-effect-title/scripts/build.js
@@ -41,20 +41,20 @@ rollupBuild([
   ],
 
   [
-    "<script> file",
+    "UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-side-effect-title.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],
 
   [
-    "<script> min file",
+    "minimized UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-side-effect-title.min.js",
       uglify: true
     },

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Switch script builds from IIFE to UMD
+
 ## 1.0.0-beta.20
 
 * `curi-focus` uses a 0 second timeout to delay focusing.

--- a/packages/vue/scripts/build.js
+++ b/packages/vue/scripts/build.js
@@ -43,10 +43,10 @@ rollupBuild([
   ],
 
   [
-    "<script> file",
+    "UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-vue.js",
       external: ["vue"]
     },
@@ -54,10 +54,10 @@ rollupBuild([
   ],
 
   [
-    "<script> min file",
+    "minimized UMD",
     {
       ...base,
-      format: "iife",
+      format: "umd",
       file: "dist/curi-vue.min.js",
       external: ["vue"],
       uglify: true


### PR DESCRIPTION
This is primarily being done so that the builds intended for `<script>` tags can be tested.