### PR TITLE
Fix for optional initial path segment

### DIFF
--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Fix for optional initial path segments.
+
 ## 1.0.0-beta.38
 
 * Switch script builds from IIFE to UMD

--- a/packages/router/src/interactions/pathname.ts
+++ b/packages/router/src/interactions/pathname.ts
@@ -30,7 +30,7 @@ function generatePathname(options?: PathFunctionOptions): Interaction {
       if (parent && knownPaths[parent]) {
         base = knownPaths[parent];
       }
-      knownPaths[name] = base ? join(base, path) : path;
+      knownPaths[name] = withLeadingSlash(base ? join(base, path) : path);
       return name;
     },
     get: (name: string, params: Params): string | void => {
@@ -43,7 +43,7 @@ function generatePathname(options?: PathFunctionOptions): Interaction {
       const compile = cache[name]
         ? cache[name]
         : (cache[name] = PathToRegexp.compile(knownPaths[name]));
-      return withLeadingSlash(compile(params, options));
+      return compile(params, options);
     },
     reset: () => {
       knownPaths = {};

--- a/packages/router/src/matchLocation.ts
+++ b/packages/router/src/matchLocation.ts
@@ -10,7 +10,7 @@ function matchRoute(
   route: InternalRoute,
   pathname: string
 ): Array<MatchingRoute> {
-  const testPath: string = stripLeadingSlash(pathname);
+  const testPath: string = pathname;
   const regExpMatch: RegExpMatchArray | null = route.pathMatching.re.exec(
     testPath
   );

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -1,5 +1,7 @@
 import PathToRegexp from "path-to-regexp";
 
+import { withLeadingSlash } from "./utils/path";
+
 import { RouteDescriptor, InternalRoute } from "./types/route";
 import { Key } from "path-to-regexp";
 
@@ -30,7 +32,9 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
 
   // keys is populated by PathToRegexp
   const keys: Array<Key> = [];
-  const re = PathToRegexp(path, keys, pathOptions);
+  // path is compiled with a leading slash
+  // for optional initial params
+  const re = PathToRegexp(withLeadingSlash(path), keys, pathOptions);
 
   const match = options.match || {};
 

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -163,6 +163,46 @@ describe("route matching/response generation", () => {
         done();
       });
     });
+
+    describe("optional path parameters", () => {
+      it("works when optional param is included", () => {
+        const history = InMemory({ locations: ["/NY/about"] });
+        const routes = [
+          {
+            name: "State",
+            path: ":state?/about",
+            pathOptions: { end: false }
+          },
+          {
+            name: "Not Found",
+            path: "(.*)"
+          }
+        ];
+        const router = curi(history, routes);
+        router.respond(({ response }) => {
+          expect(response.name).toBe("State");
+        });
+      });
+
+      it("works when optional param is NOT included", () => {
+        const history = InMemory({ locations: ["/about"] });
+        const routes = [
+          {
+            name: "State",
+            path: ":state?/about",
+            pathOptions: { end: false }
+          },
+          {
+            name: "Not Found",
+            path: "(.*)"
+          }
+        ];
+        const router = curi(history, routes);
+        router.respond(({ response }) => {
+          expect(response.name).toBe("State");
+        });
+      });
+    });
   });
 
   describe("response", () => {


### PR DESCRIPTION
Previously, a path whose initial segment is optional (`:lang?/about`) would fail when the initial segment wasn't provided. This switches the internals to compile the path (via `path-to-regexp`) with a leading slash.