### PR TITLE
Switch route.match object to route.resolve

### DIFF
--- a/examples/misc/code-splitting/src/routes.js
+++ b/examples/misc/code-splitting/src/routes.js
@@ -4,7 +4,7 @@ export default [
   {
     name: "Home",
     path: "",
-    match: {
+    resolve: {
       body: () => import("./components/Home.js").then(module => module.default)
     },
     response: ({ resolved }) => {
@@ -16,7 +16,7 @@ export default [
   {
     name: "Contact",
     path: "contact",
-    match: {
+    resolve: {
       body: () =>
         import("./components/Contact.js").then(module => module.default)
     },

--- a/examples/misc/server-rendering/src/routes.js
+++ b/examples/misc/server-rendering/src/routes.js
@@ -2,7 +2,7 @@ export default [
   {
     name: "Home",
     path: "",
-    match: {
+    resolve: {
       body: () => import("./components/Home.js").then(module => module.default)
     },
     response: ({ resolved }) => {
@@ -14,7 +14,7 @@ export default [
   {
     name: "Contact",
     path: "contact",
-    match: {
+    resolve: {
       body: () =>
         import("./components/Contact.js").then(module => module.default)
     },
@@ -27,7 +27,7 @@ export default [
       {
         name: "Contact Method",
         path: ":method",
-        match: {
+        resolve: {
           body: () =>
             import("./components/Method.js").then(module => module.default)
         },
@@ -42,7 +42,7 @@ export default [
   {
     name: "Not Found",
     path: "(.*)",
-    match: {
+    resolve: {
       body: () =>
         import("./components/NotFound.js").then(module => module.default)
     },

--- a/examples/react/async-nav/src/routes.js
+++ b/examples/react/async-nav/src/routes.js
@@ -4,7 +4,7 @@ export default [
   {
     name: "Home",
     path: "",
-    match: {
+    resolve: {
       body: () =>
         import(/* webpackChunkName: "Home" */ "./pages/Home").then(
           module => module.default
@@ -21,7 +21,7 @@ export default [
   {
     name: "Movie",
     path: "movie/:id",
-    match: {
+    resolve: {
       body: () =>
         import(/* webpackChunkName: "Movie" */ "./pages/Movie").then(
           module => module.default
@@ -43,7 +43,7 @@ export default [
   {
     name: "Not Found",
     path: "(.*)",
-    match: {
+    resolve: {
       body: () =>
         import(/* webpackChunkName: "NotFound" */ "./pages/NotFound").then(
           module => module.default

--- a/examples/react/data-loading/src/routes.js
+++ b/examples/react/data-loading/src/routes.js
@@ -17,7 +17,7 @@ export default [
   {
     name: "Album",
     path: "a/:id",
-    match: {
+    resolve: {
       // the fakeAPI caches results based on id
       data: ({ params }) => fakeAPI(params.id)
     },

--- a/examples/vue/async-nav/src/routes.js
+++ b/examples/vue/async-nav/src/routes.js
@@ -4,7 +4,7 @@ export default [
   {
     name: "Home",
     path: "",
-    match: {
+    resolve: {
       body: () =>
         import("./pages/Home").then(
           module => (module.default ? module.default : module)
@@ -21,7 +21,7 @@ export default [
   {
     name: "Movie",
     path: "movie/:id",
-    match: {
+    resolve: {
       body: () =>
         import("./pages/Movie").then(
           module => (module.default ? module.default : module)
@@ -43,7 +43,7 @@ export default [
   {
     name: "Not Found",
     path: "(.*)",
-    match: {
+    resolve: {
       body: () =>
         import("./pages/NotFound").then(
           module => (module.default ? module.default : module)

--- a/packages/interactions/route-prefetch/CHANGELOG.md
+++ b/packages/interactions/route-prefetch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Switch from `route.match` to `route.resolve`.
+
 ## 1.0.0-beta.13
 
 - Include package name in warning when attempting to overwrite a registered route.

--- a/packages/interactions/route-prefetch/src/index.ts
+++ b/packages/interactions/route-prefetch/src/index.ts
@@ -15,7 +15,7 @@ export default function prefetchRoute(): Interaction {
   return {
     name: "prefetch",
     register: (route: Route) => {
-      const { name, match } = route;
+      const { name, resolve } = route;
       if (loaders[name] !== undefined) {
         console.warn(
           '[@curi/route-prefetch] A route with the name "' +
@@ -25,8 +25,8 @@ export default function prefetchRoute(): Interaction {
             "you are overwriting the existing one. This may break your application."
         );
       }
-      if (match && Object.keys(match).length) {
-        loaders[name] = match;
+      if (resolve && Object.keys(resolve).length) {
+        loaders[name] = resolve;
       }
     },
     get: (

--- a/packages/interactions/route-prefetch/tests/prefetch.spec.ts
+++ b/packages/interactions/route-prefetch/tests/prefetch.spec.ts
@@ -20,12 +20,12 @@ describe("prefetch route interaction", () => {
   });
 
   describe("register", () => {
-    it("adds routes with match function(s)", () => {
+    it("adds routes with async function(s)", () => {
       const route = {
         name: "Player",
         path: "player",
         keys: [],
-        match: {
+        resolve: {
           test: () => Promise.resolve()
         }
       };
@@ -34,7 +34,7 @@ describe("prefetch route interaction", () => {
       expect(prefetch.get("Player")).toBeDefined();
     });
 
-    it("does not register if there are no match functions", () => {
+    it("does not register if there are no async functions", () => {
       const route = { name: "None", path: "player" };
       prefetch.register(route as Route);
       // This is a bit roundabout, but we verify that the paths did not register
@@ -56,7 +56,7 @@ describe("prefetch route interaction", () => {
         name: "Test",
         path: "first",
         keys: [],
-        match: {
+        resolve: {
           test: () => Promise.resolve()
         }
       };
@@ -64,7 +64,7 @@ describe("prefetch route interaction", () => {
         name: "Test",
         path: "second",
         keys: [],
-        match: {
+        resolve: {
           test: () => Promise.resolve()
         }
       };
@@ -85,7 +85,7 @@ describe("prefetch route interaction", () => {
         name: "Player",
         path: "player/:id",
         keys: ["id"],
-        match: {
+        resolve: {
           test: () => Promise.resolve()
         }
       };
@@ -112,7 +112,7 @@ describe("prefetch route interaction", () => {
         name,
         path: "throws",
         keys: [],
-        match: {
+        resolve: {
           test: () =>
             new Promise((resolve, reject) => {
               reject(errorMessage);
@@ -134,7 +134,7 @@ describe("prefetch route interaction", () => {
           name: "Player",
           path: "player/:id",
           keys: ["id"],
-          match: {
+          resolve: {
             test: function(props) {
               expect(props).toMatchObject({
                 name: "Player",
@@ -161,7 +161,7 @@ describe("prefetch route interaction", () => {
         name: "Home",
         path: "",
         keys: [],
-        match: {
+        resolve: {
           one: jest.fn(),
           two: jest.fn()
         }
@@ -170,21 +170,21 @@ describe("prefetch route interaction", () => {
       prefetch.register(route as Route);
 
       afterEach(() => {
-        route.match.one.mockReset();
-        route.match.two.mockReset();
+        route.resolve.one.mockReset();
+        route.resolve.two.mockReset();
       });
 
       it("calls all available async functions when not provided", () => {
         return prefetch.get("Home").then(resolved => {
-          expect(route.match.one.mock.calls.length).toBe(1);
-          expect(route.match.two.mock.calls.length).toBe(1);
+          expect(route.resolve.one.mock.calls.length).toBe(1);
+          expect(route.resolve.two.mock.calls.length).toBe(1);
         });
       });
 
-      it("only calls match.one() when which = ['one']", () => {
+      it("only calls async.one() when which = ['one']", () => {
         return prefetch.get("Home", null, ["one"]).then(resolved => {
-          expect(route.match.one.mock.calls.length).toBe(1);
-          expect(route.match.two.mock.calls.length).toBe(0);
+          expect(route.resolve.one.mock.calls.length).toBe(1);
+          expect(route.resolve.two.mock.calls.length).toBe(0);
         });
       });
     });
@@ -196,7 +196,7 @@ describe("prefetch route interaction", () => {
         name: "Player",
         path: "player/:id",
         keys: ["id"],
-        match: {
+        resolve: {
           test: () => Promise.resolve()
         }
       };

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -271,7 +271,7 @@ describe("<Link>", () => {
           {
             name: "Test",
             path: "test",
-            match: {
+            resolve: {
               test: () => {
                 return new Promise(resolve => {
                   setTimeout(() => {
@@ -319,7 +319,7 @@ describe("<Link>", () => {
           {
             name: "Slow",
             path: "slow",
-            match: {
+            resolve: {
               test: () => {
                 // takes 500ms to resolve
                 return new Promise(resolve => {
@@ -382,7 +382,7 @@ describe("<Link>", () => {
           {
             name: "Loader",
             path: "load",
-            match: {
+            resolve: {
               test: () => Promise.resolve("done")
             }
           },

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -323,7 +323,7 @@ describe("<Link>", () => {
           {
             name: "Test",
             path: "test",
-            match: {
+            resolve: {
               test: () => {
                 return new Promise(resolve => {
                   setTimeout(() => {
@@ -363,7 +363,7 @@ describe("<Link>", () => {
           {
             name: "Slow",
             path: "slow",
-            match: {
+            resolve: {
               test: () => {
                 // takes 500ms to resolve
                 return new Promise(resolve => {
@@ -420,7 +420,7 @@ describe("<Link>", () => {
           {
             name: "Loader",
             path: "load",
-            match: {
+            resolve: {
               test: () => Promise.resolve("done")
             }
           },

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+* Switch from `route.match` to `route.resolve`.
+
+## 1.0.0-beta.39
+
 * Fix for optional initial path segments.
 
 ## 1.0.0-beta.38

--- a/packages/router/src/resolveMatchedRoute.ts
+++ b/packages/router/src/resolveMatchedRoute.ts
@@ -9,12 +9,12 @@ export interface KeyPromiseGroup {
  * This will call any initial/every match functions for the matching route
  */
 export default function resolveRoute(match: Match): Promise<ResolveResults> {
-  const { match: asyncFns } = match.route.public;
+  const { resolve } = match.route.public;
 
-  const { keys, promises } = Object.keys(asyncFns).reduce(
+  const { keys, promises } = Object.keys(resolve).reduce(
     (acc, key) => {
       acc.keys.push(key);
-      acc.promises.push(asyncFns[key](match.match));
+      acc.promises.push(resolve[key](match.match));
       return acc;
     },
     { keys: [], promises: [] } as KeyPromiseGroup

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -19,7 +19,7 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
 
   const pathOptions = options.pathOptions || {};
   // end defaults to true, so end has to be hardcoded for it to be false
-  // set this before setting pathOptions.end for children
+  // set this resolve setting pathOptions.end for children
   const mustBeExact = pathOptions.end == null || pathOptions.end;
 
   let children: Array<InternalRoute> = [];
@@ -36,14 +36,14 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
   // for optional initial params
   const re = PathToRegexp(withLeadingSlash(path), keys, pathOptions);
 
-  const match = options.match || {};
+  const resolve = options.resolve || {};
 
   return {
     public: {
       name: options.name,
       path: path,
       keys: keys.map(key => key.name),
-      match,
+      resolve,
       extra: options.extra
     },
     pathMatching: {
@@ -51,7 +51,7 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
       keys,
       mustBeExact
     },
-    sync: !Object.keys(match).length,
+    sync: !Object.keys(resolve).length,
     response: options.response,
     children,
     paramParsers: options.params

--- a/packages/router/src/types/route.ts
+++ b/packages/router/src/types/route.ts
@@ -38,7 +38,7 @@ export interface RouteDescriptor {
   params?: ParamParsers;
   children?: Array<RouteDescriptor>;
   response?: ResponseFn;
-  match?: AsyncGroup;
+  resolve?: AsyncGroup;
   extra?: { [key: string]: any };
 }
 
@@ -50,7 +50,7 @@ export interface Route {
   name: string;
   path: string;
   keys: Array<string | number>;
-  match: AsyncGroup;
+  resolve: AsyncGroup;
   extra?: { [key: string]: any };
 }
 

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -311,12 +311,12 @@ describe("curi", () => {
         after();
       });
 
-      it("does asynchronous matching when route.match isn't empty", () => {
+      it("does asynchronous matching when route.resolve isn't empty", () => {
         const routes = [
           {
             name: "Home",
             path: "",
-            match: {
+            resolve: {
               test: () => Promise.resolve()
             }
           }
@@ -338,7 +338,7 @@ describe("curi", () => {
               {
                 name: "Child",
                 path: "child",
-                match: {
+                resolve: {
                   test: () => Promise.resolve()
                 }
               }
@@ -383,7 +383,7 @@ describe("curi", () => {
           {
             name: "Catch All",
             path: "(.*)",
-            match: {
+            resolve: {
               test: () => Promise.resolve()
             }
           }
@@ -582,7 +582,7 @@ describe("curi", () => {
             {
               name: "How",
               path: ":method",
-              match: {
+              resolve: {
                 test: () => {
                   promiseResolved = true;
                   return Promise.resolve(promiseResolved);
@@ -613,7 +613,7 @@ describe("curi", () => {
             {
               name: "How",
               path: ":method",
-              match: {
+              resolve: {
                 test: () => Promise.resolve()
               }
             }
@@ -653,7 +653,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              match: {
+              resolve: {
                 test: () => Promise.resolve()
               }
             }
@@ -672,7 +672,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              match: {
+              resolve: {
                 test: () => Promise.resolve()
               }
             }
@@ -727,7 +727,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              match: {
+              resolve: {
                 test: () => Promise.resolve()
               }
             },
@@ -787,7 +787,7 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              match: {
+              resolve: {
                 test: () => Promise.resolve()
               }
             },
@@ -950,7 +950,7 @@ describe("curi", () => {
           {
             name: "Slow",
             path: "slow",
-            match: {
+            resolve: {
               test: () => {
                 // takes 500ms to resolve
                 return new Promise(resolve => {
@@ -964,7 +964,7 @@ describe("curi", () => {
           {
             name: "Fast",
             path: "fast",
-            match: {
+            resolve: {
               test: () => Promise.resolve("complete")
             }
           },
@@ -988,7 +988,7 @@ describe("curi", () => {
           {
             name: "Loader",
             path: "loader/:id",
-            match: {
+            resolve: {
               test: () => Promise.resolve("complete")
             }
           },
@@ -1027,7 +1027,7 @@ describe("curi", () => {
           {
             name: "Slow",
             path: "slow",
-            match: {
+            resolve: {
               test: () => {
                 // takes 500ms to resolve
                 return new Promise(resolve => {
@@ -1041,7 +1041,7 @@ describe("curi", () => {
           {
             name: "Fast",
             path: "fast",
-            match: {
+            resolve: {
               test: () => Promise.resolve("complete")
             }
           },
@@ -1064,7 +1064,7 @@ describe("curi", () => {
           {
             name: "Loader",
             path: "loader/:id",
-            match: {
+            resolve: {
               test: () => Promise.resolve("complete")
             }
           },

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -627,7 +627,7 @@ describe("route matching/response generation", () => {
     });
   });
 
-  describe("the match functions", () => {
+  describe("resolve functions", () => {
     describe("calling functions", () => {
       it("is called with location, matched route name, and params", done => {
         const spy = jest.fn(route => {
@@ -645,20 +645,20 @@ describe("route matching/response generation", () => {
         const CatchAll = {
           name: "Catch All",
           path: ":anything",
-          match: { spy }
+          resolve: { spy }
         };
 
         const history = InMemory({ locations: ["/hello?one=two"] });
         curi(history, [CatchAll]);
       });
 
-      it("calls all match functions", done => {
+      it("calls all resolve functions", done => {
         const one = jest.fn();
         const two = jest.fn();
         const CatchAll = {
           name: "Catch All",
           path: ":anything",
-          match: {
+          resolve: {
             one,
             two
           }
@@ -691,7 +691,7 @@ describe("route matching/response generation", () => {
           {
             name: "First",
             path: "first",
-            match: {
+            resolve: {
               spy
             },
             response: responseSpy
@@ -706,7 +706,7 @@ describe("route matching/response generation", () => {
               done();
               return {};
             },
-            match: {
+            resolve: {
               // re-use the spy so that this route's response
               // fn isn't call until after the first route's spy
               // fn has resolved
@@ -721,7 +721,7 @@ describe("route matching/response generation", () => {
       });
 
       describe("resolved", () => {
-        it("is null when route has no match functions", () => {
+        it("is null when route has no resolve functions", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
@@ -735,11 +735,11 @@ describe("route matching/response generation", () => {
           const router = curi(history, [CatchAll]);
         });
 
-        it("is null when route a match function throws", () => {
+        it("is null when a resolve function throws", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
-            match: {
+            resolve: {
               fails: () => Promise.reject("woops!")
             },
             response: ({ resolved }) => {
@@ -752,7 +752,7 @@ describe("route matching/response generation", () => {
           const router = curi(history, [CatchAll]);
         });
 
-        it("is an object named match function properties when router is asynchronous", () => {
+        it("is an object with named resolve function properties for async routes", () => {
           const CatchAll = {
             name: "Catch All",
             path: ":anything",
@@ -761,7 +761,7 @@ describe("route matching/response generation", () => {
               expect(resolved.yo).toBe("yo!");
               return {};
             },
-            match: {
+            resolve: {
               test: () => Promise.resolve(1),
               yo: () => Promise.resolve("yo!")
             }
@@ -773,7 +773,7 @@ describe("route matching/response generation", () => {
       });
 
       describe("error", () => {
-        it("receives the error rejected by a match function", done => {
+        it("receives the error rejected by a resolve function", done => {
           const spy = jest.fn(({ error }) => {
             expect(error).toBe("rejected");
             done();
@@ -783,7 +783,7 @@ describe("route matching/response generation", () => {
             name: "Catch All",
             path: ":anything",
             response: spy,
-            match: {
+            resolve: {
               fails: () => Promise.reject("rejected")
             }
           };
@@ -792,7 +792,7 @@ describe("route matching/response generation", () => {
           const router = curi(history, [CatchAll]);
         });
 
-        it("is null when all match functions succeed", done => {
+        it("is null when all resolve functions succeed", done => {
           const spy = jest.fn(({ error }) => {
             expect(error).toBe(null);
             done();
@@ -802,7 +802,7 @@ describe("route matching/response generation", () => {
             name: "Catch All",
             path: ":anything",
             response: spy,
-            match: {
+            resolve: {
               succeed: () => Promise.resolve("hurray!")
             }
           };

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -95,14 +95,14 @@ describe("public route properties", () => {
     });
   });
 
-  describe("match", () => {
-    it("is the match functions", done => {
+  describe("resolve", () => {
+    it("is the resolve functions", done => {
       const history = InMemory({ locations: ["/test"] });
       const routes = [
         {
           name: "Test",
           path: "test",
-          match: {
+          resolve: {
             iTest: () => Promise.resolve("iTest"),
             eTest: () => Promise.resolve("eTest")
           }
@@ -112,7 +112,7 @@ describe("public route properties", () => {
         route: [PropertyReporter()]
       });
       const routeProperties = router.route.properties("Test");
-      const { iTest, eTest } = routeProperties.match;
+      const { iTest, eTest } = routeProperties.resolve;
       Promise.all([iTest(), eTest()]).then(([iResult, eResult]) => {
         expect(iResult).toBe("iTest");
         expect(eResult).toBe("eTest");
@@ -120,7 +120,7 @@ describe("public route properties", () => {
       });
     });
 
-    it("is an empty object when route.match isn't provided", done => {
+    it("is an empty object when route.resolve isn't provided", done => {
       const history = InMemory({ locations: ["/test"] });
       const routes = [
         {
@@ -132,24 +132,24 @@ describe("public route properties", () => {
         route: [PropertyReporter()]
       });
       const routeProperties = router.route.properties("Test");
-      expect(routeProperties.match).toEqual({});
+      expect(routeProperties.resolve).toEqual({});
       done();
     });
 
-    it("is an empty object when route.match is an empty object", done => {
+    it("is an empty object when route.resolve is an empty object", done => {
       const history = InMemory({ locations: ["/test"] });
       const routes = [
         {
           name: "Test",
           path: "test",
-          match: {}
+          resolve: {}
         }
       ];
       const router = curi(history, routes, {
         route: [PropertyReporter()]
       });
       const routeProperties = router.route.properties("Test");
-      expect(routeProperties.match).toEqual({});
+      expect(routeProperties.resolve).toEqual({});
       done();
     });
   });

--- a/packages/router/types/types/route.d.ts
+++ b/packages/router/types/types/route.d.ts
@@ -28,7 +28,7 @@ export interface RouteDescriptor {
     params?: ParamParsers;
     children?: Array<RouteDescriptor>;
     response?: ResponseFn;
-    match?: AsyncGroup;
+    resolve?: AsyncGroup;
     extra?: {
         [key: string]: any;
     };
@@ -37,7 +37,7 @@ export interface Route {
     name: string;
     path: string;
     keys: Array<string | number>;
-    match: AsyncGroup;
+    resolve: AsyncGroup;
     extra?: {
         [key: string]: any;
     };

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -150,7 +150,7 @@ describe("<curi-link>", () => {
         {
           name: "Test",
           path: "test",
-          match: {
+          resolve: {
             test: () => {
               return new Promise(resolve => {
                 setTimeout(() => {
@@ -253,7 +253,7 @@ describe("<curi-link>", () => {
           {
             name: "Slow",
             path: "slow",
-            match: {
+            resolve: {
               test: () => {
                 return new Promise(resolve => {
                   setTimeout(() => {
@@ -266,7 +266,7 @@ describe("<curi-link>", () => {
           {
             name: "Fast",
             path: "fast",
-            match: {
+            resolve: {
               test: () => Promise.resolve("fast")
             }
           },

--- a/website/src/client/pages/Examples/misc/CodeSplitting.js
+++ b/website/src/client/pages/Examples/misc/CodeSplitting.js
@@ -9,7 +9,7 @@ export default ({ name }) => (
     <h1>{name}</h1>
     <Section title="Explanation" id="explanation">
       <p>
-        Code splitting with Curi routes is done using a <IJS>match</IJS>{" "}
+        Code splitting with Curi routes is done using a <IJS>resolve</IJS>{" "}
         function. The{" "}
         <Link to="Guide" params={{ slug: "code-splitting" }}>
           code splitting

--- a/website/src/client/pages/Examples/misc/SideEffect.js
+++ b/website/src/client/pages/Examples/misc/SideEffect.js
@@ -9,7 +9,7 @@ export default ({ name }) => (
     <h1>{name}</h1>
     <Section title="Explanation" id="explanation">
       <p>
-        Once a response has completed (the route's <IJS>match</IJS> functions
+        Once a response has completed (the route's <IJS>resolve</IJS> functions
         have resolved), the response's properties are used to create a
         JavaScript object. Then, any response handler functions are called and
         passed that JavaScript object . Side effects are permanent observers

--- a/website/src/client/pages/Examples/react/Authentication.js
+++ b/website/src/client/pages/Examples/react/Authentication.js
@@ -14,7 +14,7 @@ export default ({ name }) => (
     <Section title="Explanation" id="explanation">
       <p>
         Sometimes you will want to redirect based on the results of your{" "}
-        <IJS>match</IJS> functions. For instance, you might see that a user is
+        <IJS>resolve</IJS> functions. For instance, you might see that a user is
         not authenticated and shouldn't be able to view a page.
       </p>
 

--- a/website/src/client/pages/Examples/vue/Authentication.js
+++ b/website/src/client/pages/Examples/vue/Authentication.js
@@ -14,7 +14,7 @@ export default ({ name }) => (
     <Section title="Explanation" id="explanation">
       <p>
         Sometimes you will want to redirect based on the results of your{" "}
-        <IJS>match</IJS> functions. For instance, you might see that a user is
+        <IJS>resolve</IJS> functions. For instance, you might see that a user is
         not authenticated and shouldn't be able to view a page.
       </p>
 

--- a/website/src/client/pages/Guides/Apollo.js
+++ b/website/src/client/pages/Guides/Apollo.js
@@ -190,12 +190,13 @@ const Noun = ({ response }) => (
         <Explanation>
           <p>
             You can use your Apollo client instance to call queries in a route's{" "}
-            <IJS>match</IJS> functions. <IJS>match</IJS> functions are expected
-            to return a Promise, which is exactly what <IJS>client.query()</IJS>{" "}
-            returns, so tightly pairing Curi and Apollo is mostly center around
-            using a <IJS>match</IJS> functoin to return a{" "}
-            <IJS>client.query()</IJS> call. This will delay navigation until
-            after a route's GraphQL data has been loaded by Apollo.
+            <IJS>resolve</IJS> functions. <IJS>resolve</IJS> functions are
+            expected to return a Promise, which is exactly what{" "}
+            <IJS>client.query()</IJS> returns, so tightly pairing Curi and
+            Apollo is mostly center around using a <IJS>resolve</IJS> function
+            to return a <IJS>client.query()</IJS> call. This will delay
+            navigation until after a route's GraphQL data has been loaded by
+            Apollo.
           </p>
         </Explanation>
         <CodeBlock>
@@ -206,7 +207,7 @@ const routes = [
   {
     name: "Example",
     path: "example/:id",
-    match: {
+    resolve: {
       data({ params }) {
         return client.query({
           query: EXAMPLE_QUERY,
@@ -268,7 +269,7 @@ export default [
   {
     name: "Verb",
     path: "verb/:word",
-    match: {
+    resolve: {
       verb({ params }) {
         return client.query({
           query: GET_VERB,
@@ -312,7 +313,7 @@ const Verb = ({ response }) => (
       <SideBySide>
         <Explanation>
           <p>
-            The second approach is to use a <IJS>match</IJS> function as a way
+            The second approach is to use a <IJS>resolve</IJS> function as a way
             to cache the data, but also use <Cmp>Query</Cmp>. With this
             approach, we do not have to attach the query data to the response;
             we are just relying on the fact that Apollo will execute and cache
@@ -328,7 +329,7 @@ export default [
   {
     name: "Verb",
     path: "verb/:word",
-    match: {
+    resolve: {
       data({ params }) {
         // load the data so it is cached by
         // your Apollo client
@@ -380,7 +381,7 @@ const Verb = ({ response }) => (
           <Explanation>
             <p>
               One additional benefit of adding queries to routes using{" "}
-              <IJS>match</IJS> functions is that you can prefetch data for a
+              <IJS>resolve</IJS> functions is that you can prefetch data for a
               route.
             </p>
             <p>
@@ -400,7 +401,7 @@ const routes = [
   {
     name: "Example",
     path: "example/:id",
-    match {
+    resolve: {
       examples({ params }) {
         client.query({
           query: GET_EXAMPLES,

--- a/website/src/client/pages/Guides/CodeSplitting.js
+++ b/website/src/client/pages/Guides/CodeSplitting.js
@@ -81,33 +81,33 @@ const routes = [
       </SideBySide>
     </Section>
 
-    <Section title="import() in match" id="import">
+    <Section title="import() in resolve" id="import">
       <SideBySide>
         <Explanation>
           <p>
             Instead of having static imports, we will use the{" "}
             <IJS>import()</IJS> function to import our modules. We will import
-            our components by adding a property to a route's <IJS>match</IJS>{" "}
+            our components by adding a property to a route's <IJS>resolve</IJS>{" "}
             object. The property name for the function is how we will access the
             resolved data in the route's <IJS>response()</IJS> function.
           </p>
           <p>
-            <IJS>match</IJS> functions are called every time a route matches.
+            <IJS>resolve</IJS> functions are called every time a route matches.
             However, <IJS>import()</IJS> calls automatically re-use the results
             of a previous call, so we do not have to worry about extra network
             requests.
           </p>
           <p>
-            Here we will name the <IJS>match</IJS> function for importing a
+            Here we will name the <IJS>resolve</IJS> function for importing a
             component <IJS>body</IJS>, since it will be set as the response's{" "}
             <IJS>body</IJS> property.
           </p>
           <p>
-            <IJS>match.body()</IJS> should return a Promise; <IJS>import()</IJS>,
-            conveniently, returns a Promise. In our <IJS>response()</IJS>{" "}
-            function, instead of referencing values imported at the top of the
-            file, we can reference the result of the <IJS>match.body()</IJS>{" "}
-            function using <IJS>resolved.body</IJS>.
+            <IJS>resolve.body()</IJS> should return a Promise;{" "}
+            <IJS>import()</IJS>, conveniently, returns a Promise. In our{" "}
+            <IJS>response()</IJS> function, instead of referencing values
+            imported at the top of the file, we can reference the result of the{" "}
+            <IJS>resolve.body()</IJS> function using <IJS>resolved.body</IJS>.
           </p>
           <p>
             <IJS>import()</IJS> resolves with a module object. If the component
@@ -121,7 +121,7 @@ const routes = [
   {
     name: 'Home',
     path: '',
-    match: {
+    resolve: {
       body: () => (
         import('./components/Home')
           .then(module => module.default)
@@ -136,7 +136,7 @@ const routes = [
   {
     name: 'Contact',
     path: 'contact',
-    match: {
+    resolve: {
       body: () => (
         import('./components/Contact')
           .then(module => module.default)
@@ -151,7 +151,7 @@ const routes = [
       {
         name: 'Contact Method',
         path: ':method',
-        match: {
+        resolve: {
           body: () => (
             import('./components/ContactMethod')
               .then(module => module.default)
@@ -173,7 +173,7 @@ const routes = [
     <Section title="Other Approaches" id="other">
       <p>
         The approaches taken here are not the only way to do code splitting.
-        Another approach is to skip the <IJS>match</IJS> method and do code
+        Another approach is to skip the <IJS>resolve</IJS> method and do code
         splitting at other points in your application (e.g.{" "}
         <a href="https://github.com/jamiebuilds/react-loadable">
           <IJS>react-loadable</IJS>
@@ -181,9 +181,9 @@ const routes = [
       </p>
       <p>
         Whatever path you decide to go, hopefully this has shown you that
-        setting up code splitting with a <IJS>match</IJS> function is fairly
+        setting up code splitting with a <IJS>resolve</IJS> function is fairly
         simple to do. If you are using Webpack and want to reduce your initial
-        bundle size, <IJS>match</IJS> functions are a good way to accomplish
+        bundle size, <IJS>resolve</IJS> functions are a good way to accomplish
         this.
       </p>
     </Section>

--- a/website/src/client/pages/Guides/CreatingARouter.js
+++ b/website/src/client/pages/Guides/CreatingARouter.js
@@ -310,7 +310,7 @@ stop();
       <SideBySide>
         <Explanation>
           <p>
-            If you have any asynchronous routes (routes with <IJS>match</IJS>{" "}
+            If you have any asynchronous routes (routes with <IJS>resolve</IJS>{" "}
             functions), <IJS>router.respond()</IJS> should be used to delay the
             initial render. If you don't pass the{" "}
             <IJS>{`{ observe: true }`}</IJS> option, the observer function will

--- a/website/src/client/pages/Guides/Loading.js
+++ b/website/src/client/pages/Guides/Loading.js
@@ -22,18 +22,18 @@ export default ({ name }) => (
       <Explanation>
         <p>
           In the code splitting guide, we added a function that calls{" "}
-          <IJS>import()</IJS> to a route's <IJS>match</IJS> object in order to
+          <IJS>import()</IJS> to a route's <IJS>resolve</IJS> object in order to
           dynamically load modules. We can do the same thing for other data.
         </p>
       </Explanation>
     </SideBySide>
 
-    <Section title="match" id="match">
+    <Section title="resolve" id="resolve">
       <SideBySide>
         <Explanation>
           <p>
             An async function (with any name you want it to have) can be added
-            to the <IJS>match</IJS> object and the value it resolves will be
+            to the <IJS>resolve</IJS> object and the value it resolves will be
             available in the route's <IJS>response()</IJS> function (as a
             property of the <IJS>resolved</IJS> object).
           </p>
@@ -55,29 +55,29 @@ export default ({ name }) => (
       <SideBySide>
         <Explanation>
           <p>
-            Here, we will name the match function for fetching data{" "}
+            Here, we will name the <IJS>resolve</IJS> function for fetching data{" "}
             <IJS>"data"</IJS>.
           </p>
           <p>
-            The <IJS>match.data()</IJS> function will be passed an object that
+            The <IJS>resolve.data()</IJS> function will be passed an object that
             contains the matched route response properties, including the route{" "}
             <IJS>params</IJS>.
           </p>
           <p>
-            All <IJS>match</IJS> functions are expected to return a Promise.
+            All <IJS>resolve</IJS> functions are expected to return a Promise.
           </p>
           <p>
             Now, when we navigate to <IJS>/recipe/chocolate-chip-cookies</IJS>,
-            the <IJS>match.data()</IJS> function will call the fake API function
-            to load the <IJS>"chocolate-chip-cookies"</IJS> recipe. The function
-            will resolve with the loaded data.
+            the <IJS>resolve.data()</IJS> function will call the fake API
+            function to load the <IJS>"chocolate-chip-cookies"</IJS> recipe. The
+            function will resolve with the loaded data.
           </p>
         </Explanation>
         <CodeBlock>
           {`{
   name: 'Recipe',
   path: 'recipe/:id',
-  match: {
+  resolve: {
     data: ({ params }) => fakeAPI.getRecipe(params.id)
   }
 }`}
@@ -89,16 +89,16 @@ export default ({ name }) => (
       <SideBySide>
         <Explanation>
           <p>
-            While <IJS>match.data()</IJS> starts our data loading, it doesn't
+            While <IJS>resolve.data()</IJS> starts our data loading, it doesn't
             actually do anything. Instead, we should handle any loaded data with
             the <IJS>response()</IJS> function.
           </p>
 
           <p>
-            The <IJS>response()</IJS> and <IJS>match.data()</IJS> are separate
+            The <IJS>response()</IJS> and <IJS>resolve.data()</IJS> are separate
             because while a route is resolving, the user may navigate again,
             which overrides the current navigation. We cannot cancel the{" "}
-            <IJS>match.data()</IJS> function for the current navigation, so if
+            <IJS>resolve.data()</IJS> function for the current navigation, so if
             it performs any side effects, our application is stuck with them. To
             avoid this, the <IJS>response()</IJS> function is not called until
             we know that the current navigation will complete.
@@ -122,7 +122,7 @@ export default ({ name }) => (
           {`{
   name: 'Recipe',
   path: 'recipe/:id',
-  match: {
+  resolve: {
     data: ({ params }) => fakeAPI.getRecipe(params.id),
   },
   response({ resolved }) {
@@ -175,11 +175,11 @@ export default ({ name }) => (
       </SideBySide>
     </Section>
     <p>
-      A route's <IJS>match</IJS> and <IJS>response()</IJS> functions offer a
-      convenient way to do data loading prior to actually rendering the route,
-      but please remember that your application will not be re-rendering until{" "}
-      <em>after</em> the fetching has resolved. If you have a long running load
-      function, you may wish to implement some sort of loading display. The{" "}
+      A route's <IJS>resolve</IJS> object and <IJS>response()</IJS> functions
+      offer a convenient way to do data loading prior to actually rendering the
+      route, but please remember that your application will not be re-rendering
+      until <em>after</em> the fetching has resolved. If you have a long running
+      load function, you may wish to implement some sort of loading display. The{" "}
       <Link to="Example" params={{ category: "react", slug: "data-loading" }}>
         data loading example
       </Link>{" "}

--- a/website/src/client/pages/Guides/MigrateReactRouterv3.js
+++ b/website/src/client/pages/Guides/MigrateReactRouterv3.js
@@ -226,8 +226,8 @@ const routes = [
               </IJS>{" "}
               route. With Curi, routes can have functions that are called when
               they match the new location. These are grouped under the route's{" "}
-              <IJS>match</IJS> object. The <IJS>match</IJS> functions are called
-              every time that a route matches a location.
+              <IJS>resolve</IJS> object. The <IJS>resolve</IJS> functions are
+              called every time that a route matches a location.
             </p>
             <p>
               With React Router, <IJS>onEnter</IJS> is called when the route
@@ -237,7 +237,7 @@ const routes = [
               the big difference between the two is that <IJS>onChange</IJS>{" "}
               will receive the previous props, which could be used to determine
               which props changed. The functionality for both <IJS>onEnter</IJS>{" "}
-              and <IJS>onChange</IJS> can be covered using a <IJS>match</IJS>{" "}
+              and <IJS>onChange</IJS> can be covered using a <IJS>resolve</IJS>{" "}
               function.
             </p>
             <p>
@@ -287,7 +287,7 @@ const routes = [
             body: Message
           };
         },
-        match: {
+        resolve: {
           data: (route) => { return ... },
         }
       }

--- a/website/src/client/pages/Guides/MigrateReactRouterv4.js
+++ b/website/src/client/pages/Guides/MigrateReactRouterv4.js
@@ -169,8 +169,8 @@ const routes = [
               loading data, code splitting, and other non-rendering tasks. With
               Curi, routes can have functions that are called when they match
               the new location. These are grouped under the route's{" "}
-              <IJS>match</IJS> object. The <IJS>match</IJS> functions are called
-              every time that a route matches a location.
+              <IJS>resolve</IJS> object. The <IJS>resolve</IJS> functions are
+              called every time that a route matches a location.
             </p>
             <p>
               The{" "}
@@ -209,7 +209,7 @@ const routes = [
             body: Message
           };
         },
-        match: {
+        resolve: {
           body: (route) => { return ... },
         }
       }

--- a/website/src/client/pages/Guides/NavigatingAndObserving.js
+++ b/website/src/client/pages/Guides/NavigatingAndObserving.js
@@ -365,7 +365,7 @@ const stop = router.respond(fn, { observe: true });`}
           <SideBySide>
             <Explanation>
               <p>
-                If any of the routes in an application have <IJS>match</IJS>{" "}
+                If any of the routes in an application have <IJS>resolve</IJS>{" "}
                 functions, responses for them are creating asynchronously. When
                 the application first renders, if the router matches an async
                 route, the response isn't immediately ready to use. To deal with

--- a/website/src/client/pages/Guides/RoutesAndResponses.js
+++ b/website/src/client/pages/Guides/RoutesAndResponses.js
@@ -99,7 +99,7 @@ export default ({ name }) => (
                   <td>data</td>
                   <td>
                     A place to attach any data you want to the response, such as
-                    data loaded in the route's <IJS>match</IJS> functions.
+                    data loaded in the route's <IJS>resolve</IJS> functions.
                   </td>
                 </tr>
                 <tr>
@@ -286,7 +286,7 @@ const routes = [
 ];`}
         </CodeBlock>
       </SideBySide>
-      <Subsection title="Match" id="match">
+      <Subsection title="Resolve" id="resolve">
         <SideBySide>
           <Explanation>
             <p>
@@ -296,13 +296,13 @@ const routes = [
               based on the path parameters parsed from the location.
             </p>
             <p>
-              A route's <IJS>match</IJS> property is an optional object for
+              A route's <IJS>resolve</IJS> property is an optional object for
               attaching functions to a route. A response will not be emitted
-              until after all of a route's <IJS>match</IJS> functions have
+              until after all of a route's <IJS>resolve</IJS> functions have
               finished.
             </p>
             <p>
-              A route with <IJS>match</IJS> properties is asynchronous, which
+              A route with <IJS>resolve</IJS> properties is asynchronous, which
               has effects to be aware of. You can read about these in the{" "}
               <Link to="Guide" params={{ slug: "sync-or-async" }}>
                 Sync or Async
@@ -310,17 +310,17 @@ const routes = [
               guide.
             </p>
             <p>
-              Curi uses Promises to manage a route's <IJS>match</IJS> functions.
-              Each function should return a Promise. This makes it easy to wait
-              for all of the <IJS>match</IJS> functions to complete before
-              emitting the response for a matched route.
+              Curi uses Promises to manage a route's <IJS>resolve</IJS>{" "}
+              functions. Each function should return a Promise. This makes it
+              easy to wait for all of the <IJS>resolve</IJS> functions to
+              complete before emitting the response for a matched route.
             </p>
             <Note>
               <IJS>Promise.resolve()</IJS> can be used to return a Promise.
             </Note>
             <p>
-              When <IJS>match</IJS> functions are called, they will be passed an
-              object with the "match" properties of a response. These are the
+              When <IJS>resolve</IJS> functions are called, they will be passed
+              an object with the "match" properties of a response. These are the
               matched route's <IJS>name</IJS>, the <IJS>location</IJS>, an
               object of parsed <IJS>params</IJS>, and an array of the names of{" "}
               <IJS>partial</IJS> route matches.
@@ -330,7 +330,7 @@ const routes = [
             {`{
   name: "User",
   path: "u/:id",
-  match: {
+  resolve: {
     authorized: () => {
       // run code to verify the user can view the page
       return Promise.resolve(true);
@@ -369,16 +369,16 @@ const routes = [
               might find useful.
             </p>
             <p>
-              The first is an object of <IJS>match</IJS> properties (the base
+              The first is an object of <IJS>resolve</IJS> properties (the base
               response properties).
             </p>
             <p>
               The second is a <IJS>resolved</IJS> object, which contains the
-              resolved values from the route's <IJS>match</IJS> functions.
+              resolved values from the route's <IJS>resolve</IJS> functions.
             </p>
             <p>
               The third property is an <IJS>error</IJS>, which is only defined
-              if one of the <IJS>match</IJS> functions throws an error and you
+              if one of the <IJS>resolve</IJS> functions throws an error and you
               don't catch it.
             </p>
           </Explanation>
@@ -389,7 +389,7 @@ const routes = [
   {
     name: "User",
     path: "u/:id",
-    match: {
+    resolve: {
       data: ({ params }) => UserAPI.get(params.id)
     },
     response({ match, resolved, error }) {

--- a/website/src/client/pages/Guides/SyncAsync.js
+++ b/website/src/client/pages/Guides/SyncAsync.js
@@ -30,7 +30,7 @@ export default ({ name }) => (
 
         <p>
           By default, routes are synchronous. If a route has any functions in
-          its <IJS>match</IJS> object, it becomes async.
+          its <IJS>resolve</IJS> object, it becomes async.
         </p>
       </Explanation>
       <CodeBlock>
@@ -42,7 +42,7 @@ export default ({ name }) => (
   name: "User",
   path: "user/:id,
   // any functions in here makes the route async
-  match: {
+  resolve: {
     body: () => import("./components/User"),
   }
 }`}

--- a/website/src/client/pages/Packages/RoutePrefetch.js
+++ b/website/src/client/pages/Packages/RoutePrefetch.js
@@ -21,7 +21,7 @@ export default ({ name, version, globalName }) => (
         <p>
           The prefetch route interaction can be used fetch data for a route
           prior to navigating. The interaction will call a route's{" "}
-          <IJS>match</IJS> functions (if they exist on the route).
+          <IJS>resolve</IJS> functions (if they exist on the route).
         </p>
         <p>
           Prefetching data means results in faster renders after navigation
@@ -33,10 +33,11 @@ export default ({ name, version, globalName }) => (
     <SideBySide>
       <Explanation>
         <Note>
-          Prefetching <IJS>match</IJS> functions calls is only beneficial if you
-          cache the results because the function will be re-called when the user
-          navigates to that route. Functions wrapped by Curi's <IJS>once()</IJS>{" "}
-          wrapper will automatically re-use the results from their first call.
+          Prefetching <IJS>resolve</IJS> functions calls is only beneficial if
+          you cache the results because the function will be re-called when the
+          user navigates to that route. Functions wrapped by Curi's{" "}
+          <IJS>once()</IJS> wrapper will automatically re-use the results from
+          their first call.
         </Note>
       </Explanation>
     </SideBySide>
@@ -80,18 +81,19 @@ router.route.prefetch("Some Route");`}
                     <td>The name of the route to prefetch.</td>
                   </tr>
                   <tr>
-                    <td>match</td>
+                    <td>resolve</td>
                     <td>
-                      Route props that are used by the <IJS>on</IJS> functions.
+                      Route props that are used by the <IJS>resolve</IJS>{" "}
+                      functions.
                     </td>
                   </tr>
                   <tr>
                     <td>which</td>
                     <td>
                       An array whose values are the names of the{" "}
-                      <IJS>match</IJS> functions that should be called. If this
-                      array is not provided, all available functions will be
-                      called.
+                      <IJS>resolve</IJS> functions that should be called. If
+                      this array is not provided, all available functions will
+                      be called.
                     </td>
                   </tr>
                 </tbody>
@@ -99,7 +101,7 @@ router.route.prefetch("Some Route");`}
               <Note>
                 <p>
                   This route interaction will only register routes that have{" "}
-                  <IJS>match</IJS> functions. If you try calling this for any
+                  <IJS>resolve</IJS> functions. If you try calling this for any
                   routes with neither of those, <IJS>prefetch()</IJS> will
                   resolve an object with an <IJS>error</IJS> property.
                 </p>
@@ -110,19 +112,19 @@ router.route.prefetch("Some Route");`}
 {
   name: "User",
   path: "u/:id",
-  match: {
+  resolve: {
     one: () => {...},
     two: () => {...}
   }
 }
 
-// call a route's match.one() and match.two() functions
+// call a route's resolve.one() and resolve.two() functions
 router.route.prefetch(
   'User',
   { params: { id: 2 }}
 )
 
-// only call the route's match.one() function
+// only call the route's resolve.one() function
 router.route.prefetch(
   'User',
   { params: { id: 3 }},

--- a/website/src/client/pages/Packages/Router.js
+++ b/website/src/client/pages/Packages/Router.js
@@ -391,7 +391,7 @@ router.navigate({
                 </table>
 
                 <p>
-                  When a matched route is async (it has <IJS>match</IJS>{" "}
+                  When a matched route is async (it has <IJS>resolve</IJS>{" "}
                   functions), the router will not call the observer functions
                   until the async function(s) have resolved.
                 </p>
@@ -553,7 +553,7 @@ const userPathname = router.route.pathname(
             </p>
             <p>
               The <IJS>once()</IJS> function is useful for any async route{" "}
-              <IJS>match</IJS> functions that only need to be called once.
+              <IJS>resolve</IJS> functions that only need to be called once.
             </p>
             <Note>
               This will not work for functions whose result depends on variables
@@ -568,7 +568,7 @@ const routes = [
   {
     name: "Menu",
     path: "menu",
-    match: {
+    resolve: {
       // this function will be called every time the user
       // navigates to the "Menu" route
       nonCached: () => api.getItems(),
@@ -666,44 +666,44 @@ const path = pathnameGenerator.get("Yo", { name: "joey" })
           </SideBySide>
         </Subsection>
 
-        <Subsection title="route.match" id="match">
+        <Subsection title="route.resolve" id="resolve">
           <SideBySide>
             <Explanation>
               <p>
-                The <IJS>match</IJS> object groups async functions that will be
-                called when the route matches.
+                The <IJS>resolve</IJS> object groups async functions that will
+                be called when the route matches.
               </p>
               <p>
-                A route with any <IJS>match</IJS> functions is asynchronous,
-                while one with no <IJS>match</IJS> functions is synchronous. You
-                can read more about this is the{" "}
+                A route with any <IJS>resolve</IJS> functions is asynchronous,
+                while one with no <IJS>resolve</IJS> functions is synchronous.
+                You can read more about this is the{" "}
                 <Link to="Guide" params={{ slug: "sync-or-async" }}>
                   sync or async
                 </Link>{" "}
                 guide.
               </p>
               <p>
-                <IJS>match</IJS> functions are called every time that a route
+                <IJS>resolve</IJS> functions are called every time that a route
                 matches the current location.
               </p>
               <p>
-                <IJS>match</IJS> functions will be passed an object with the
+                <IJS>resolve</IJS> functions will be passed an object with the
                 matched route properties: <IJS>name</IJS>, <IJS>params</IJS>,{" "}
                 <IJS>partials</IJS>, and <IJS>location</IJS>.
               </p>
               <Note>
                 You should not perform side effects (e.g. passing the loaded
-                data to a Redux store) in <IJS>match</IJS> functions because it
-                is possible that navigating to the route might be cancelled. If
-                you must perform side effects for a route, you should do so in{" "}
-                <IJS>response()</IJS>.
+                data to a Redux store) in <IJS>resolve</IJS> functions because
+                it is possible that navigating to the route might be cancelled.
+                If you must perform side effects for a route, you should do so
+                in <IJS>response()</IJS>.
               </Note>
             </Explanation>
             <CodeBlock>
               {`const about = {
   name: 'About',
   path: 'about',
-  match: {
+  resolve: {
     body: () => import('./components/About'),
     data: () => fetch('/api/about')
   }
@@ -777,13 +777,13 @@ const routes = [
                 <Explanation>
                   <p>
                     <IJS>error</IJS> - If an error occurs with the route's{" "}
-                    <IJS>match</IJS> methods, you might want to attach an error
-                    message to the response.
+                    <IJS>resolve</IJS> methods, you might want to attach an
+                    error message to the response.
                   </p>
                 </Explanation>
                 <CodeBlock>
                   {`{
-  match: {
+  resolve: {
     test: () => Promise.reject("woops!")
   },
   response({ error }) {
@@ -934,7 +934,7 @@ const routes = [
                 <Explanation>
                   <p>
                     <IJS>resolved</IJS> is an object with the values resolved by
-                    the <IJS>match</IJS> functions.
+                    the <IJS>resolve</IJS> functions.
                   </p>
                   <p>
                     If a route isn't async, <IJS>resolved</IJS> will be{" "}
@@ -946,7 +946,7 @@ const routes = [
 const user = {
   name: 'User',
   path: ':id',
-  match: {
+  resolve: {
     data: ({ params, location }) => (
       fetch(\`/api/users/$\{params.id\}\`)
         .then(resp => JSON.parse(resp))
@@ -966,15 +966,15 @@ const user = {
                 <Explanation>
                   <p>
                     <IJS>error</IJS> is an error thrown by one of the route's{" "}
-                    <IJS>match</IJS> functions.
+                    <IJS>resolve</IJS> functions.
                   </p>
                 </Explanation>
                 <CodeBlock>
-                  {`// check if any of a route's match functions threw
+                  {`// check if any of a route's resolve functions threw
 const user = {
   name: 'User',
   path: ':id',
-  match: {
+  resolve: {
     data: ({ params, location }) => (
       fetch(\`/api/users/$\{params.id\}\`)
         .then(resp => JSON.parse(resp))

--- a/website/src/client/pages/Tutorials/ReactAdvanced.js
+++ b/website/src/client/pages/Tutorials/ReactAdvanced.js
@@ -91,8 +91,8 @@ npm run start`}
           </Note>
           <p>
             The async functions for a route are grouped under the route's{" "}
-            <IJS>match</IJS> object. The name of each function is the name that
-            the function's result will be available as on the{" "}
+            <IJS>resolve</IJS> object. The name of each function is the name
+            that the function's result will be available as on the{" "}
             <IJS>resolved</IJS> object. If any of the async functions throws an
             error, that error will be available in the <IJS>response()</IJS>{" "}
             function through the <IJS>error</IJS> property.
@@ -112,7 +112,7 @@ npm run start`}
   {
     name: "A Route",
     path: "route/:id",
-    match: {
+    resolve: {
       component: () => import("./components/SomeComponent")
         .then(module => module.default),
       data: ({ params }) => fetch(\`/api/data/$\{params.id\}\`)
@@ -244,7 +244,7 @@ import(/* webpackChunkName: "Test" */ "./components/Test.js")`}
   {
     name: "Test",
     path: "test",
-    match: {
+    resolve: {
       body: () => import(/* webpackChunkName: "Test" */ "./components/Test.js")
     }
   }
@@ -279,7 +279,7 @@ import(/* webpackChunkName: "Test" */ "./components/Test.js")`}
   {
     name: "One",
     path: "one",
-    match: {
+    resolve: {
       body: () => import("./components/One.js")
         .then(module => module.default)
     },
@@ -292,7 +292,7 @@ import(/* webpackChunkName: "Test" */ "./components/Test.js")`}
   {
     name: "Two",
     path: "two",
-    match: {
+    resolve: {
       body: () => import("./components/Two.js")
     },
     response({ resolved }) {
@@ -323,7 +323,7 @@ const routes = [
   {
     name: "One",
     path: "one",
-    match: {
+    resolve: {
       body: () => import("./components/One.js")
         .then(module => module.default)
         .catch(err => displayLoadError(err))
@@ -357,7 +357,7 @@ export default [
   {
     name: "Home",
     path: "",
-    match: {
+    resolve: {
       body: () => import("./components/Home")
         .then(module => module.default)
     },
@@ -370,7 +370,7 @@ export default [
   {
     name: "Book",
     path: "book/:id",
-    match: {
+    resolve: {
       body: () => import("./components/Book")
         .then(module => module.default)
     },
@@ -383,7 +383,7 @@ export default [
   {
     name: "Checkout",
     path: "checkout",
-    match: {
+    resolve: {
       body: () => import("./components/Checkout")
         .then(module => module.default)
     },
@@ -396,7 +396,7 @@ export default [
   {
     name: "Catch All",
     path: "(.*)",
-    match: {
+    resolve: {
       body: () => import("./components/NotFound")
         .then(module => module.default)
     },
@@ -582,7 +582,7 @@ export default [
   {
     name: "Home",
     path: "",
-    match: {
+    resolve: {
       body: () => import("./components/Home")
         .then(module => module.default),
       books: () => BOOKS()
@@ -600,7 +600,7 @@ export default [
     params: {
       id: id => parseInt(id, 10)
     },
-    match: {
+    resolve: {
       body: () => import("./components/Book")
         .then(module => module.default),
       book: ({ params }) => BOOK(params.id)
@@ -615,7 +615,7 @@ export default [
   {
     name: "Checkout",
     path: "checkout",
-    match: {
+    resolve: {
       body: () => import("./components/Checkout")
         .then(module => module.default)
     },
@@ -628,7 +628,7 @@ export default [
   {
     name: "Catch All",
     path: "(.*)",
-    match: {
+    resolve: {
       body: () => import("./components/NotFound")
         .then(module => module.default)
     },

--- a/website/src/client/routes.js
+++ b/website/src/client/routes.js
@@ -36,7 +36,7 @@ export default [
       {
         name: "Tutorial",
         path: ":slug",
-        match: {
+        resolve: {
           body: () =>
             import(/* webpackChunkName: 'tutorial' */ "./route-components/Tutorial").then(
               module => module.default,
@@ -73,7 +73,7 @@ export default [
       {
         name: "Guide",
         path: ":slug/",
-        match: {
+        resolve: {
           body: () =>
             import(/* webpackChunkName: 'guide' */ "./route-components/Guide").then(
               module => module.default,
@@ -104,7 +104,7 @@ export default [
       {
         name: "Package",
         path: "@curi/:package/",
-        match: {
+        resolve: {
           body: () =>
             import(/* webpackChunkName: 'package' */ "./route-components/Package").then(
               module => module.default,
@@ -135,7 +135,7 @@ export default [
       {
         name: "Example",
         path: ":category/:slug/",
-        match: {
+        resolve: {
           body: () =>
             import(/* webpackChunkName: 'example' */ "./route-components/Example").then(
               module => module.default,


### PR DESCRIPTION
This has been changed a few times, but as I am getting closer to v1, I want to nail down the final API. The main reasoning for switching away from `route.match` is that `route.response()` receives a `match` object, and the name conflict might be confusing. Since the results of the async functions are passed to the `response()` function as `resolved`, the name `resolve` makes sense to use for the object.

Another idea would be to have the property name reference that these are functions to be called before emitting the response. Either `before` or `enter` would make sense for this. However, I like the pairing between `route.resolve` and the `resolved` results object.

```js
// old
{
  name: "User",
  path: "u/:id",
  match: {
    data: () => {...}
  },
  response({ resolved, match }) {
    // ...
  }
}

// new
{
  name: "User",
  path: "u/:id",
  resolve: {
    data: () => {...}
  },
  response({ resolved, match }) {
    // ...
  }
}

```