### PR TITLE
<Focus preventScroll={true}>

### DIFF
--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `preventScroll` prop to `<Focus>`. When `false` (default), the page will scroll to the element that it focuses. When `true`, the page will not scroll.
+
 ## 1.0.0-beta.0
 
 * Added `@curi/react-dom`. This package has its own `<Link>` and `<Focus>` components, which rely on DOM APIs. This package re-exports all of `@curi/react`'s exports.

--- a/packages/react-dom/src/Focus.tsx
+++ b/packages/react-dom/src/Focus.tsx
@@ -6,6 +6,7 @@ import { Response } from "@curi/router";
 
 export interface FocusProps {
   children(ref: Ref<any>): ReactNode;
+  preventScroll: boolean;
 }
 
 interface FocusPropsWithResponse extends FocusProps {
@@ -19,6 +20,10 @@ class FocusWithResponse extends React.Component<FocusPropsWithResponse> {
     super(props);
     this.eleToFocus = null;
   }
+
+  static defaultProps = {
+    preventScroll: false
+  };
 
   setRef = (element: any) => {
     this.eleToFocus = element;
@@ -55,7 +60,8 @@ class FocusWithResponse extends React.Component<FocusPropsWithResponse> {
         }
       }
       setTimeout(() => {
-        this.eleToFocus.focus();
+        // @ts-ignore
+        this.eleToFocus.focus({ preventScroll: this.props.preventScroll });
       });
     }
   }

--- a/packages/react-dom/tests/Focus.spec.tsx
+++ b/packages/react-dom/tests/Focus.spec.tsx
@@ -134,6 +134,81 @@ describe("<Focus>", () => {
     expect(wrapper).toBe(postNavFocus);
   });
 
+  describe("preventScroll", () => {
+    const realFocus = HTMLElement.prototype.focus;
+    let fakeFocus;
+
+    beforeEach(() => {
+      fakeFocus = HTMLElement.prototype.focus = jest.fn();
+    });
+
+    afterEach(() => {
+      fakeFocus.mockReset();
+      HTMLElement.prototype.focus = realFocus;
+    });
+
+    it("calls focus({ preventScroll: false }} when not provided", () => {
+      ReactDOM.render(
+        <CuriProvider router={router}>
+          {() => (
+            <Focus>
+              {ref => (
+                <div id="test" tabIndex={-1} ref={ref}>
+                  <input type="text" />
+                </div>
+              )}
+            </Focus>
+          )}
+        </CuriProvider>,
+        node
+      );
+      jest.runAllTimers();
+      expect(fakeFocus.mock.calls[0][0]).toMatchObject({
+        preventScroll: false
+      });
+    });
+
+    it("calls focus({ preventScroll: true }} when preventScroll = true", () => {
+      ReactDOM.render(
+        <CuriProvider router={router}>
+          {() => (
+            <Focus preventScroll={true}>
+              {ref => (
+                <div id="test" tabIndex={-1} ref={ref}>
+                  <input type="text" />
+                </div>
+              )}
+            </Focus>
+          )}
+        </CuriProvider>,
+        node
+      );
+      jest.runAllTimers();
+      expect(fakeFocus.mock.calls[0][0]).toMatchObject({ preventScroll: true });
+    });
+
+    it("calls focus({ preventScroll: false }} when preventScroll = false", () => {
+      ReactDOM.render(
+        <CuriProvider router={router}>
+          {() => (
+            <Focus preventScroll={false}>
+              {ref => (
+                <div id="test" tabIndex={-1} ref={ref}>
+                  <input type="text" />
+                </div>
+              )}
+            </Focus>
+          )}
+        </CuriProvider>,
+        node
+      );
+      jest.runAllTimers();
+      expect(fakeFocus.mock.calls[0][0]).toMatchObject({
+        preventScroll: false
+      });
+    });
+  });
+
   describe("tabIndex", () => {
     it("warns when ref element does not have a tabIndex attribute", () => {
       const realWarn = console.warn;

--- a/packages/react-dom/types/Focus.d.ts
+++ b/packages/react-dom/types/Focus.d.ts
@@ -1,6 +1,7 @@
 import { ReactNode, Ref } from "react";
 export interface FocusProps {
     children(ref: Ref<any>): ReactNode;
+    preventScroll: boolean;
 }
 declare const Focus: (props: FocusProps) => JSX.Element;
 export default Focus;


### PR DESCRIPTION
Enables the [experimental `preventScroll` option](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#Parameters) for the focused element.