### PR TITLE
Rename replaceRoutes() to refresh()

### DIFF
--- a/examples/misc/updating-routes/src/components/App.js
+++ b/examples/misc/updating-routes/src/components/App.js
@@ -14,13 +14,13 @@ class App extends React.Component {
   }
 
   login() {
-    this.props.router.replaceRoutes(adminRoutes);
+    this.props.router.refresh(adminRoutes);
     this.setState({ admin: true });
   }
 
   logout() {
     const { router } = this.props;
-    router.replaceRoutes(baseRoutes);
+    router.refresh(baseRoutes);
     this.setState({ admin: false });
     const pathname = router.route.pathname("Home");
     router.history.push(pathname);

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Rename `router.replaceRoutes()` to `router.refresh()`. If called with no arguments, just re-emits a response.
+
 ## 1.0.0-beta.40
 
 * Switch from `route.match` to `route.resolve`.

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -54,24 +54,26 @@ export default function createRouter(
   const oneTimers: Array<Observer> = [];
 
   function setupRoutesAndInteractions(
-    routeArray: Array<RouteDescriptor>
+    routeArray?: Array<RouteDescriptor>
   ): void {
-    routes = routeArray.map(createRoute);
-    for (let key in routeInteractions) {
-      delete routeInteractions[key];
+    if (routeArray) {
+      routes = routeArray.map(createRoute);
+      for (let key in routeInteractions) {
+        delete routeInteractions[key];
+      }
+
+      // add the pathname interaction to the provided interactions
+      userInteractions
+        .concat(pathnameInteraction(options.pathnameOptions))
+        .forEach(interaction => {
+          interaction.reset();
+          routeInteractions[interaction.name] = interaction.get;
+          registerRoutes(routes, interaction);
+        });
     }
 
-    // add the pathname interaction to the provided interactions
-    userInteractions
-      .concat(pathnameInteraction(options.pathnameOptions))
-      .forEach(interaction => {
-        interaction.reset();
-        routeInteractions[interaction.name] = interaction.get;
-        registerRoutes(routes, interaction);
-      });
-
     // assign navigation response handler
-    // this will be re-called if router.replaceRoutes() is called
+    // this will be re-called if router.refresh() is called
     history.respondWith(navigationHandler);
   }
 
@@ -196,7 +198,7 @@ export default function createRouter(
         }
       }
     },
-    replaceRoutes: setupRoutesAndInteractions,
+    refresh: setupRoutesAndInteractions,
     current() {
       return mostRecent;
     },

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -48,7 +48,7 @@ export interface NavigationDetails {
 }
 
 export interface CuriRouter {
-  replaceRoutes: (routeArray: Array<RouteDescriptor>) => void;
+  refresh: (routeArray?: Array<RouteDescriptor>) => void;
   respond: (fn: Observer, options?: RespondOptions) => RemoveObserver | void;
   route: Interactions;
   history: History;

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -429,7 +429,7 @@ describe("curi", () => {
     });
   });
 
-  describe("replaceRoutes", () => {
+  describe("refresh", () => {
     const err = console.error;
 
     beforeEach(() => {
@@ -454,7 +454,7 @@ describe("curi", () => {
 
       const router = curi(history, englishRoutes);
 
-      router.replaceRoutes(spanishRoutes);
+      router.refresh(spanishRoutes);
 
       const englishNames = ["Home", "About", "Contact"];
       englishNames.forEach(n => {
@@ -467,7 +467,7 @@ describe("curi", () => {
       });
     });
 
-    it("re-calls response handler for new routes", () => {
+    it("emits a new response handler for new routes", () => {
       const history = InMemory({
         locations: ["/admin"]
       });
@@ -487,10 +487,36 @@ describe("curi", () => {
       const { response: initialResponse } = router.current();
       expect(initialResponse.name).toBe("Not Found");
 
-      router.replaceRoutes(authRoutes);
+      router.refresh(authRoutes);
 
       const { response: replacedResponse, navigation } = router.current();
       expect(replacedResponse.name).toBe("Admin");
+    });
+
+    it("emits a response when called with no argument", done => {
+      const englishRoutes = [
+        { name: "Home", path: "" },
+        { name: "About", path: "about" },
+        { name: "Contact", path: "contact" }
+      ];
+      const history = InMemory({ locations: ["/about"] });
+      const router = curi(history, englishRoutes);
+
+      const { response: initialResponse } = router.current();
+      expect(initialResponse.name).toBe("About");
+
+      // setup a response handler, but ensure it doesn't get called
+      // with existing response.
+      router.respond(
+        ({ response }) => {
+          expect(response.name).toBe("About");
+          done();
+        },
+        { observe: false, initial: false }
+      );
+      // then refresh the router. the response handler should be called
+      // with a response for the current location.
+      router.refresh();
     });
   });
 

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -39,7 +39,7 @@ export interface NavigationDetails {
     finished?: () => void;
 }
 export interface CuriRouter {
-    replaceRoutes: (routeArray: Array<RouteDescriptor>) => void;
+    refresh: (routeArray?: Array<RouteDescriptor>) => void;
     respond: (fn: Observer, options?: RespondOptions) => RemoveObserver | void;
     route: Interactions;
     history: History;


### PR DESCRIPTION
In addition to the name change, `refresh()` can be called with no arguments. When this is done, a new response will be emitted based on the current location. This may allow you to regenerate a new route based on some internal state (if that is read in any `route.resolve` functions or in `route.response()`).