### PR TITLE
Simplify @curi/side-effect-title

### DIFF
--- a/packages/side-effects/side-effect-title/CHANGELOG.md
+++ b/packages/side-effects/side-effect-title/CHANGELOG.md
@@ -1,6 +1,10 @@
+## Next
+
+* Pass the side effect creator a callback function that returns a string.
+
 ## 1.0.0-beta.11
 
-- Switch script builds from IIFE to UMD
+* Switch script builds from IIFE to UMD
 
 ## 1.0.0-beta.10
 

--- a/packages/side-effects/side-effect-title/src/index.ts
+++ b/packages/side-effects/side-effect-title/src/index.ts
@@ -1,12 +1,11 @@
-import { Observer, Emitted, Response } from "@curi/router";
+import { Observer, Emitted } from "@curi/router";
 
-export type TitleBuilder = (response: Response) => string;
+export type TitleBuilder = (emitted: Emitted) => string;
 
 export default function createTitleSideEffect(
   callback: TitleBuilder
 ): Observer {
-  return function({ response }: Emitted) {
-    const title = callback(response);
-    document.title = title;
+  return function(emitted: Emitted) {
+    document.title = callback(emitted);
   };
 }

--- a/packages/side-effects/side-effect-title/src/index.ts
+++ b/packages/side-effects/side-effect-title/src/index.ts
@@ -1,25 +1,12 @@
-import { Observer, Emitted } from "@curi/router";
+import { Observer, Emitted, Response } from "@curi/router";
 
-export interface TitleOptions {
-  prefix?: string;
-  suffix?: string;
-  delimiter?: string;
-}
+export type TitleBuilder = (response: Response) => string;
 
 export default function createTitleSideEffect(
-  options?: TitleOptions
+  callback: TitleBuilder
 ): Observer {
-  const { prefix = "", suffix = "", delimiter = "" } = options || {};
-
   return function({ response }: Emitted) {
-    const parts: Array<string> = [];
-    if (prefix !== "") {
-      parts.push(prefix, delimiter);
-    }
-    parts.push(response.title);
-    if (suffix !== "") {
-      parts.push(delimiter, suffix);
-    }
-    document.title = parts.join(" ");
+    const title = callback(response);
+    document.title = title;
   };
 }

--- a/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
+++ b/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
@@ -10,7 +10,7 @@ describe("createTitleSideEffect", () => {
   } as Emitted;
 
   it("sets document.title to value returned by provided callback", () => {
-    const sideEffect = createTitleSideEffect(response => {
+    const sideEffect = createTitleSideEffect(({ response }) => {
       return `My Site | ${response.title}`;
     });
     sideEffect(fakeResponse);

--- a/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
+++ b/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
@@ -9,64 +9,11 @@ describe("createTitleSideEffect", () => {
     response: { title: "Test Title; Please Ignore" }
   } as Emitted;
 
-  it("returned function sets document.title using response.title", () => {
-    const sideEffect = createTitleSideEffect();
-    const queryResponse = sideEffect(fakeResponse);
-    expect(document.title).toBe("Test Title; Please Ignore");
-  });
-
-  it("sets document.title to empty string if response has no title", () => {
-    const sideEffect = createTitleSideEffect();
-    const fakeResponse = { response: {} } as Emitted;
-    const queryResponse = sideEffect(fakeResponse);
-    expect(document.title).toBe("");
-  });
-
-  describe("prefix", () => {
-    it("prepends the prefix before the title", () => {
-      const sideEffect = createTitleSideEffect({ prefix: "My Site" });
-      const queryResponse = sideEffect(fakeResponse);
-      expect(document.title).toBe("My Site Test Title; Please Ignore");
+  it("sets document.title to value returned by provided callback", () => {
+    const sideEffect = createTitleSideEffect(response => {
+      return `My Site | ${response.title}`;
     });
-  });
-
-  describe("suffix", () => {
-    it("appends the suffix after the title", () => {
-      const sideEffect = createTitleSideEffect({ suffix: "My Site" });
-      const queryResponse = sideEffect(fakeResponse);
-      expect(document.title).toBe("Test Title; Please Ignore My Site");
-    });
-  });
-
-  describe("delimiter", () => {
-    it("it adds delimiter between prefix, response.title, and suffix", () => {
-      const sideEffect = createTitleSideEffect({
-        prefix: "Prefix",
-        suffix: "Suffix",
-        delimiter: "|"
-      });
-      const queryResponse = sideEffect(fakeResponse);
-      expect(document.title).toBe(
-        "Prefix | Test Title; Please Ignore | Suffix"
-      );
-    });
-
-    it("does not prepend delimiter when there is no prefix", () => {
-      const sideEffect = createTitleSideEffect({
-        suffix: "Suffix",
-        delimiter: "|"
-      });
-      const queryResponse = sideEffect(fakeResponse);
-      expect(document.title).toBe("Test Title; Please Ignore | Suffix");
-    });
-
-    it("does not append delimiter when there is no suffix", () => {
-      const sideEffect = createTitleSideEffect({
-        prefix: "Prefix",
-        delimiter: "|"
-      });
-      const queryResponse = sideEffect(fakeResponse);
-      expect(document.title).toBe("Prefix | Test Title; Please Ignore");
-    });
+    sideEffect(fakeResponse);
+    expect(document.title).toBe("My Site | Test Title; Please Ignore");
   });
 });

--- a/packages/side-effects/side-effect-title/types/index.d.ts
+++ b/packages/side-effects/side-effect-title/types/index.d.ts
@@ -1,7 +1,3 @@
-import { Observer } from "@curi/router";
-export interface TitleOptions {
-    prefix?: string;
-    suffix?: string;
-    delimiter?: string;
-}
-export default function createTitleSideEffect(options?: TitleOptions): Observer;
+import { Observer, Response } from "@curi/router";
+export declare type TitleBuilder = (response: Response) => string;
+export default function createTitleSideEffect(callback: TitleBuilder): Observer;

--- a/website/src/client/index.js
+++ b/website/src/client/index.js
@@ -12,7 +12,7 @@ import routes from "./routes";
 import renderFunction from "./render";
 
 const setTitle = titleSideEffect(
-  response => `${response.title} | Curi Documentation`
+  ({ response }) => `${response.title} | Curi Documentation`
 );
 const scrollTo = scrollSideEffect();
 const announce = ariaLiveSideEffect(

--- a/website/src/client/index.js
+++ b/website/src/client/index.js
@@ -11,7 +11,9 @@ import prefetch from "@curi/route-prefetch";
 import routes from "./routes";
 import renderFunction from "./render";
 
-const setTitle = titleSideEffect({ suffix: "| Curi Documentation" });
+const setTitle = titleSideEffect(
+  response => `${response.title} | Curi Documentation`
+);
 const scrollTo = scrollSideEffect();
 const announce = ariaLiveSideEffect(
   ({ response }) => `Navigated to ${response.title}`


### PR DESCRIPTION
Instead of specifying prefixes, suffixes, and delimiters, the side effect takes a `callback()` function, which will be passed the emitted object. The results of the `callback()` function will be set as the document's `title`.

```js
import createTitleSideEffect from "@curi/side-effect-title";

const setTitle = createTitleSideEffect(({ response }) => `My Site | ${response.title}`);
```