### PR TITLE
Re-use navigation.previous when refreshing

### DIFF
--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Rename `router.replaceRoutes()` to `router.refresh()`. If called with no arguments, just re-emits a response.
+* Rename `router.replaceRoutes()` to `router.refresh()`. If called with no arguments, just re-emits a response. The emitted `navigation.previous` will re-use the last emitted `navigation.previous`.
 
 ## 1.0.0-beta.40
 

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -45,6 +45,9 @@ export default function createRouter(
     response: null,
     navigation: null
   };
+  // when true, navigation.previous will re-use the previous
+  // navigation.previous instead of using mostRecent.response
+  let refreshing = false;
 
   // router.navigate() hooks
   let cancelCallback: (() => void) | undefined;
@@ -86,8 +89,13 @@ export default function createRouter(
 
     const navigation: Navigation = {
       action: pendingNav.action,
-      previous: mostRecent.response
+      previous: refreshing
+        ? mostRecent.navigation
+          ? mostRecent.navigation.previous
+          : null
+        : mostRecent.response
     };
+    refreshing = false;
 
     const match = matchLocation(pendingNav.location, routes);
     // if no routes match, do nothing
@@ -198,7 +206,10 @@ export default function createRouter(
         }
       }
     },
-    refresh: setupRoutesAndInteractions,
+    refresh(routes?: Array<RouteDescriptor>) {
+      refreshing = true;
+      setupRoutesAndInteractions(routes);
+    },
     current() {
       return mostRecent;
     },

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -502,13 +502,39 @@ describe("curi", () => {
       const router = curi(history, englishRoutes);
 
       const { response: initialResponse } = router.current();
+
       expect(initialResponse.name).toBe("About");
 
       // setup a response handler, but ensure it doesn't get called
       // with existing response.
       router.respond(
-        ({ response }) => {
+        ({ response, navigation }) => {
           expect(response.name).toBe("About");
+          done();
+        },
+        { observe: false, initial: false }
+      );
+      // then refresh the router. the response handler should be called
+      // with a response for the current location.
+      router.refresh();
+    });
+
+    it("re-uses previously emitted navigation.previous", done => {
+      const englishRoutes = [
+        { name: "Home", path: "" },
+        { name: "About", path: "about" },
+        { name: "Contact", path: "contact" }
+      ];
+      const history = InMemory({ locations: ["/about"] });
+      const router = curi(history, englishRoutes);
+
+      const { navigation: initialNavigation } = router.current();
+
+      // setup a response handler, but ensure it doesn't get called
+      // with existing response.
+      router.respond(
+        ({ response, navigation }) => {
+          expect(navigation).toMatchObject(initialNavigation);
           done();
         },
         { observe: false, initial: false }


### PR DESCRIPTION
Previously, refreshing would emit a `navigation.previous` that was the most recent `response`. Now, refreshing will emit a `navigation.previous` that was the most recent `navigation.previous`.