### PR TITLE
Use dual-mode packages (.js & .mjs)

### DIFF
--- a/packages/interactions/route-active/CHANGELOG.md
+++ b/packages/interactions/route-active/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.8
 
 - Include package name in warning when attempting to overwrite a registered route.

--- a/packages/interactions/route-active/package.json
+++ b/packages/interactions/route-active/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/route-active",
   "version": "1.0.0-beta.9",
   "description": "A Curi router interaction to determine if a route is \"active\"",
-  "main": "dist/curi-route-active.common.js",
-  "module": "dist/curi-route-active.es.js",
+  "main": "dist/curi-route-active",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/interactions/route-active/scripts/build.js
+++ b/packages/interactions/route-active/scripts/build.js
@@ -17,11 +17,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-route-active.es.js",
+      format: "esm",
+      file: "dist/curi-route-active.mjs",
       external: deps,
       safeModules: false
     },
@@ -33,7 +33,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-route-active.common.js",
+      file: "dist/curi-route-active.js",
       external: deps,
       safeModules: false
     },
@@ -45,7 +45,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-route-active.js"
+      file: "dist/curi-route-active.umd.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],

--- a/packages/interactions/route-ancestors/CHANGELOG.md
+++ b/packages/interactions/route-ancestors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.8
 
 - Include package name in warning when attempting to overwrite a registered route.

--- a/packages/interactions/route-ancestors/package.json
+++ b/packages/interactions/route-ancestors/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/route-ancestors",
   "version": "1.0.0-beta.8",
   "description": "Get a Curi route's ancestor routes",
-  "main": "dist/curi-route-ancestors.common.js",
-  "module": "dist/curi-route-ancestors.es.js",
+  "main": "dist/curi-route-ancestors",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/interactions/route-ancestors/scripts/build.js
+++ b/packages/interactions/route-ancestors/scripts/build.js
@@ -17,11 +17,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-route-ancestors.es.js",
+      format: "esm",
+      file: "dist/curi-route-ancestors.mjs",
       external: deps,
       safeModules: false
     },
@@ -33,7 +33,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-route-ancestors.common.js",
+      file: "dist/curi-route-ancestors.js",
       external: deps,
       safeModules: false
     },
@@ -45,7 +45,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-route-ancestors.js"
+      file: "dist/curi-route-ancestors.umd.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],

--- a/packages/interactions/route-prefetch/CHANGELOG.md
+++ b/packages/interactions/route-prefetch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.14
 
 - Switch from `route.match` to `route.resolve`.

--- a/packages/interactions/route-prefetch/package.json
+++ b/packages/interactions/route-prefetch/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/route-prefetch",
   "version": "1.0.0-beta.14",
   "description": "A route interaction to prefetching Curi route data",
-  "main": "dist/curi-route-prefetch.common.js",
-  "module": "dist/curi-route-prefetch.es.js",
+  "main": "dist/curi-route-prefetch",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/interactions/route-prefetch/scripts/build.js
+++ b/packages/interactions/route-prefetch/scripts/build.js
@@ -17,11 +17,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-route-prefetch.es.js",
+      format: "esm",
+      file: "dist/curi-route-prefetch.mjs",
       external: deps,
       safeModules: false
     },
@@ -33,7 +33,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-route-prefetch.common.js",
+      file: "dist/curi-route-prefetch.js",
       external: deps,
       safeModules: false
     },
@@ -45,7 +45,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-route-prefetch.js"
+      file: "dist/curi-route-prefetch.umd.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.2
 
 * Export a `curiProvider()` function to create a routing provider component instead of a `<CuriProvider>`.

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/react-dom",
   "version": "1.0.0-beta.2",
   "description": "React DOM components to use with Curi",
-  "main": "dist/curi-react-dom.common.js",
-  "module": "dist/curi-react-dom.es.js",
+  "main": "dist/curi-react-dom",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/react-dom/scripts/build.js
+++ b/packages/react-dom/scripts/build.js
@@ -20,11 +20,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-react-dom.es.js",
+      format: "esm",
+      file: "dist/curi-react-dom.mjs",
       external: [...deps, "react"],
       safeModules: false
     },
@@ -36,7 +36,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-react-dom.common.js",
+      file: "dist/curi-react-dom.js",
       external: [...deps, "react"],
       safeModules: false
     },
@@ -48,7 +48,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-react-dom.js",
+      file: "dist/curi-react-dom.umd.js",
       external: ["react"]
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.11
 
 * Export a `curiProvider()` function to create a routing provider component instead of a `<CuriProvider>`.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/react-native",
   "version": "1.0.0-beta.11",
   "description": "React Native components to use with Curi",
-  "main": "dist/curi-react-native.common.js",
-  "module": "dist/curi-react-native.es.js",
+  "main": "dist/curi-react-native",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/react-native/scripts/build.js
+++ b/packages/react-native/scripts/build.js
@@ -24,11 +24,11 @@ const plugins = [
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-react-native.es.js",
+      format: "esm",
+      file: "dist/curi-react-native.mjs",
       safeModules: false
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
@@ -39,7 +39,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-react-native.common.js",
+      file: "dist/curi-react-native.js",
       safeModules: false
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }

--- a/packages/react-universal/CHANGELOG.md
+++ b/packages/react-universal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.1
 
 * Export a `curiProvider()` function to create a routing provider component instead of a `<CuriProvider>`.

--- a/packages/react-universal/package.json
+++ b/packages/react-universal/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/react-universal",
   "version": "1.0.0-beta.1",
   "description": "React components to use with Curi",
-  "main": "dist/curi-react-universal.common.js",
-  "module": "dist/curi-react-universal.es.js",
+  "main": "dist/curi-react-universal",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/react-universal/scripts/build.js
+++ b/packages/react-universal/scripts/build.js
@@ -20,11 +20,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-react-universal.es.js",
+      format: "esm",
+      file: "dist/curi-react-universal.mjs",
       external: [...deps, "react"],
       safeModules: false
     },
@@ -36,7 +36,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-react-universal.common.js",
+      file: "dist/curi-react-universal.js",
       external: [...deps, "react"],
       safeModules: false
     },
@@ -48,7 +48,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-react-universal.js",
+      file: "dist/curi-react-universal.umd.js",
       external: ["react"]
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }

--- a/packages/react-universal/src/curiProvider.tsx
+++ b/packages/react-universal/src/curiProvider.tsx
@@ -18,7 +18,7 @@ export interface RouterState {
   emitted: CurrentResponse;
 }
 
-export default function curiRoot(router: CuriRouter) {
+export default function curiProvider(router: CuriRouter) {
   return class Router extends React.Component<RouterProps, RouterState> {
     stopResponding: () => void;
     removed: boolean;

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.41
 
 * Rename `router.replaceRoutes()` to `router.refresh()`. If called with no arguments, just re-emits a response. The emitted `navigation.previous` will re-use the last emitted `navigation.previous`.

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/router",
   "version": "1.0.0-beta.41",
   "description": "A JavaScript router that doesn't care how you render",
-  "main": "dist/curi-router.common.js",
-  "module": "dist/curi-router.es.js",
+  "main": "dist/curi-router",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/router/scripts/build.js
+++ b/packages/router/scripts/build.js
@@ -17,11 +17,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-router.es.js",
+      format: "esm",
+      file: "dist/curi-router.mjs",
       external: deps,
       safeModules: false
     },
@@ -33,7 +33,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-router.common.js",
+      file: "dist/curi-router.js",
       external: deps,
       safeModules: false
     },
@@ -45,7 +45,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-router.js"
+      file: "dist/curi-router.umd.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],

--- a/packages/router/src/interactions/pathname.ts
+++ b/packages/router/src/interactions/pathname.ts
@@ -1,9 +1,7 @@
-import PathToRegexp, {
-  PathFunction,
-  PathFunctionOptions
-} from "path-to-regexp";
+import PathToRegexp from "path-to-regexp";
 import { withLeadingSlash, join } from "../utils/path";
 
+import { PathFunction, PathFunctionOptions } from "path-to-regexp";
 import { Interaction } from "../types/interaction";
 import { Route } from "../types/route";
 import { Params } from "../types/response";

--- a/packages/side-effects/side-effect-aria-live/CHANGELOG.md
+++ b/packages/side-effects/side-effect-aria-live/CHANGELOG.md
@@ -1,6 +1,10 @@
+## Next
+
+* Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.1
 
-- Switch script builds from IIFE to UMD
+* Switch script builds from IIFE to UMD
 
 ## 1.0.0-beta.0
 

--- a/packages/side-effects/side-effect-aria-live/package.json
+++ b/packages/side-effects/side-effect-aria-live/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/side-effect-aria-live",
   "version": "1.0.0-beta.1",
   "description": "Curi side effect to announce location changes using aria-live",
-  "main": "dist/curi-side-effect-aria-live.common.js",
-  "module": "dist/curi-side-effect-aria-live.es.js",
+  "main": "dist/curi-side-effect-aria-live",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/side-effects/side-effect-aria-live/scripts/build.js
+++ b/packages/side-effects/side-effect-aria-live/scripts/build.js
@@ -17,11 +17,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-side-effect-aria-live.es.js",
+      format: "esm",
+      file: "dist/curi-side-effect-aria-live.mjs",
       external: deps,
       safeModules: false
     },
@@ -33,7 +33,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-side-effect-aria-live.common.js",
+      file: "dist/curi-side-effect-aria-live.js",
       external: deps,
       safeModules: false
     },
@@ -45,7 +45,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-side-effect-aria-live.js"
+      file: "dist/curi-side-effect-aria-live.umd.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],

--- a/packages/side-effects/side-effect-scroll/CHANGELOG.md
+++ b/packages/side-effects/side-effect-scroll/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.10
 
 - Switch script builds from IIFE to UMD

--- a/packages/side-effects/side-effect-scroll/package.json
+++ b/packages/side-effects/side-effect-scroll/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/side-effect-scroll",
   "version": "1.0.0-beta.10",
   "description": "Curi side effect to scroll when navigating to new locations",
-  "main": "dist/curi-side-effect-scroll.common.js",
-  "module": "dist/curi-side-effect-scroll.es.js",
+  "main": "dist/curi-side-effect-scroll",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/side-effects/side-effect-scroll/scripts/build.js
+++ b/packages/side-effects/side-effect-scroll/scripts/build.js
@@ -17,11 +17,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-side-effect-scroll.es.js",
+      format: "esm",
+      file: "dist/curi-side-effect-scroll.mjs",
       external: deps,
       safeModules: false
     },
@@ -33,7 +33,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-side-effect-scroll.common.js",
+      file: "dist/curi-side-effect-scroll.js",
       external: deps,
       safeModules: false
     },
@@ -45,7 +45,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-side-effect-scroll.js"
+      file: "dist/curi-side-effect-scroll.umd.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],

--- a/packages/side-effects/side-effect-title/CHANGELOG.md
+++ b/packages/side-effects/side-effect-title/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Support dual-mode package (CJS/ESM) builds.
 * Pass the side effect creator a callback function that returns a string.
 
 ## 1.0.0-beta.11

--- a/packages/side-effects/side-effect-title/package.json
+++ b/packages/side-effects/side-effect-title/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/side-effect-title",
   "version": "1.0.0-beta.11",
   "description": "Curi side effecft to set the page title when loading a route",
-  "main": "dist/curi-side-effect-title.common.js",
-  "module": "dist/curi-side-effect-title.es.js",
+  "main": "dist/curi-side-effect-title",
   "types": "types/index.d.ts",
   "files": [
     "dist",

--- a/packages/side-effects/side-effect-title/scripts/build.js
+++ b/packages/side-effects/side-effect-title/scripts/build.js
@@ -17,11 +17,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-side-effect-title.es.js",
+      format: "esm",
+      file: "dist/curi-side-effect-title.mjs",
       external: deps,
       safeModules: false
     },
@@ -33,7 +33,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-side-effect-title.common.js",
+      file: "dist/curi-side-effect-title.js",
       external: deps,
       safeModules: false
     },
@@ -45,7 +45,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-side-effect-title.js"
+      file: "dist/curi-side-effect-title.umd.js"
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }
   ],

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.6
 
 * Update to Svelte v2 minimum dependency.

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/svelte",
   "version": "1.0.0-beta.6",
   "description": "Curi integration with Svelte",
-  "main": "dist/curi-svelte.common.js",
-  "module": "dist/curi-svelte.es.js",
+  "main": "dist/curi-svelte",
   "files": [
     "dist",
     "LICENSE",

--- a/packages/svelte/scripts/build.js
+++ b/packages/svelte/scripts/build.js
@@ -23,11 +23,11 @@ const base = {
 
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-svelte.es.js",
+      format: "esm",
+      file: "dist/curi-svelte.mjs",
       safeModules: false
     },
     { NODE_ENV: "development" }
@@ -37,7 +37,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-svelte.common.js",
+      file: "dist/curi-svelte.js",
       safeModules: false
     },
     { NODE_ENV: "development" }

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Support dual-mode package (CJS/ESM) builds.
+
 ## 1.0.0-beta.21
 
 * Fix bad `@curi/route-active` dependency.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,8 +2,7 @@
   "name": "@curi/vue",
   "version": "1.0.0-beta.21",
   "description": "Curi plugins and components for Vue.js",
-  "main": "dist/curi-vue.common.js",
-  "module": "dist/curi-vue.es.js",
+  "main": "dist/curi-vue",
   "files": [
     "dist",
     "LICENSE",

--- a/packages/vue/scripts/build.js
+++ b/packages/vue/scripts/build.js
@@ -19,11 +19,11 @@ const base = {
 };
 rollupBuild([
   [
-    "ES",
+    "ESM",
     {
       ...base,
-      format: "es",
-      file: "dist/curi-vue.es.js",
+      format: "esm",
+      file: "dist/curi-vue.mjs",
       external: [...deps, "vue"],
       safeModules: false
     },
@@ -35,7 +35,7 @@ rollupBuild([
     {
       ...base,
       format: "cjs",
-      file: "dist/curi-vue.common.js",
+      file: "dist/curi-vue.js",
       external: [...deps, "vue"],
       safeModules: false
     },
@@ -47,7 +47,7 @@ rollupBuild([
     {
       ...base,
       format: "umd",
-      file: "dist/curi-vue.js",
+      file: "dist/curi-vue.umd.js",
       external: ["vue"]
     },
     { NODE_ENV: "development", BABEL_ENV: "build" }


### PR DESCRIPTION
An ESM build is output with the `.mjs` extension, while a CommonJS build is output with the `.js` extension. In `package.json`, the `"main"` field has no extension, which allows the system to choose which module to resolve with.

UMD builds now have the extension `.umd.js` because the CommonJS builds needed to be just `.js`.

`.mjs` files exist in a bit of an odd place right now. In order to use them with `node`, the `--experimental-modules` flag has to be used. Webpack and Rollup support them, although I am unsure to what extent.