### PR TITLE
Split router.respond() into once() and observe()

### DIFF
--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -419,7 +419,7 @@ describe("<Link>", () => {
         };
         Simulate.click(a, leftClickEvent);
         expect(a.textContent).toBe("true");
-        router.respond(
+        router.once(
           ({ response }) => {
             expect(response.name).toBe("Loader");
             expect(a.textContent).toBe("false");

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -472,7 +472,7 @@ describe("<Link>", () => {
         anchor.props.onPress(fakeEvent());
         expect(text.instance.props.children).toBe("true");
 
-        router.respond(
+        router.once(
           ({ response }) => {
             expect(response.name).toBe("Loader");
             expect(text.instance.props.children).toBe("false");

--- a/packages/react-universal/src/curiProvider.tsx
+++ b/packages/react-universal/src/curiProvider.tsx
@@ -44,7 +44,7 @@ export default function curiProvider(router: CuriRouter) {
           }
         },
         { initial: false }
-      ) as RemoveObserver;
+      );
     }
 
     componentWillUnmount() {

--- a/packages/react-universal/src/curiProvider.tsx
+++ b/packages/react-universal/src/curiProvider.tsx
@@ -35,7 +35,7 @@ export default function curiProvider(router: CuriRouter) {
     }
 
     setupRespond(router: CuriRouter) {
-      this.stopResponding = router.respond(
+      this.stopResponding = router.observe(
         ({ response, navigation }) => {
           if (!this.removed) {
             this.setState({
@@ -43,7 +43,7 @@ export default function curiProvider(router: CuriRouter) {
             });
           }
         },
-        { observe: true, initial: false }
+        { initial: false }
       ) as RemoveObserver;
     }
 

--- a/packages/react-universal/tests/Curious.spec.tsx
+++ b/packages/react-universal/tests/Curious.spec.tsx
@@ -33,7 +33,6 @@ describe("<Curious>", () => {
               expect(value.router).toBe(router);
               expect(value.response).toBe(response);
               expect(value.navigation).toBe(navigation);
-              console.log("*************");
               return null;
             }}
           </Curious>

--- a/packages/react-universal/tests/Curious.spec.tsx
+++ b/packages/react-universal/tests/Curious.spec.tsx
@@ -23,24 +23,23 @@ describe("<Curious>", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
-  it("passes router, response, and navigation to children function", done => {
-    router.respond(({ response, navigation }) => {
-      ReactDOM.render(
-        <Router>
-          {() => (
-            <Curious>
-              {value => {
-                expect(value.router).toBe(router);
-                expect(value.response).toBe(response);
-                expect(value.navigation).toBe(navigation);
-                done();
-                return null;
-              }}
-            </Curious>
-          )}
-        </Router>,
-        node
-      );
-    });
+  it("passes router, response, and navigation to children function", () => {
+    const { response, navigation } = router.current();
+    ReactDOM.render(
+      <Router>
+        {() => (
+          <Curious>
+            {value => {
+              expect(value.router).toBe(router);
+              expect(value.response).toBe(response);
+              expect(value.navigation).toBe(navigation);
+              console.log("*************");
+              return null;
+            }}
+          </Curious>
+        )}
+      </Router>,
+      node
+    );
   });
 });

--- a/packages/react-universal/tests/curiProvider.spec.tsx
+++ b/packages/react-universal/tests/curiProvider.spec.tsx
@@ -76,8 +76,6 @@ describe("curiProvider()", () => {
 
   describe("context", () => {
     it("makes response, navigation, and router available to <Curious>", () => {
-      let emittedResponse;
-      let emittedNavigation;
       const history = InMemory();
       const router = curi(history, routes);
 
@@ -87,7 +85,6 @@ describe("curiProvider()", () => {
             expect(value.response).toBe(emittedResponse);
             expect(value.router).toBe(router);
             expect(value.navigation).toBe(emittedNavigation);
-            console.log("9999999999999999999");
             return null;
           }}
         </Curious>
@@ -95,9 +92,10 @@ describe("curiProvider()", () => {
 
       const Router = curiProvider(router);
 
-      const { response, navigation } = router.current();
-      emittedResponse = response;
-      emittedNavigation = navigation;
+      const {
+        response: emittedResponse,
+        navigation: emittedNavigation
+      } = router.current();
       ReactDOM.render(<Router>{() => <ContextLogger />}</Router>, node);
     });
   });

--- a/packages/react-universal/tests/curiProvider.spec.tsx
+++ b/packages/react-universal/tests/curiProvider.spec.tsx
@@ -75,7 +75,7 @@ describe("curiProvider()", () => {
   });
 
   describe("context", () => {
-    it("makes response, navigation, and router available to <Curious>", done => {
+    it("makes response, navigation, and router available to <Curious>", () => {
       let emittedResponse;
       let emittedNavigation;
       const history = InMemory();
@@ -87,7 +87,7 @@ describe("curiProvider()", () => {
             expect(value.response).toBe(emittedResponse);
             expect(value.router).toBe(router);
             expect(value.navigation).toBe(emittedNavigation);
-            done();
+            console.log("9999999999999999999");
             return null;
           }}
         </Curious>
@@ -95,11 +95,10 @@ describe("curiProvider()", () => {
 
       const Router = curiProvider(router);
 
-      router.respond(({ response, navigation }) => {
-        emittedResponse = response;
-        emittedNavigation = navigation;
-        ReactDOM.render(<Router>{() => <ContextLogger />}</Router>, node);
-      });
+      const { response, navigation } = router.current();
+      emittedResponse = response;
+      emittedNavigation = navigation;
+      ReactDOM.render(<Router>{() => <ContextLogger />}</Router>, node);
     });
   });
 });

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Split `router.respond()` into `router.once()` for one time functions and `router.observe()` for observer functions.
 * Support dual-mode package (CJS/ESM) builds.
 
 ## 1.0.0-beta.41

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -169,7 +169,7 @@ export default function createRouter(
     resetCallbacks();
 
     if (!response.redirectTo || emitRedirects) {
-      // store for current() and observe()
+      // store for current(), observe(), and once()
       mostRecent.response = response;
       mostRecent.navigation = navigation;
 

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -16,7 +16,7 @@ import {
   RouterOptions,
   Observer,
   Emitted,
-  ObserveOptions,
+  ResponseHandlerOptions,
   RemoveObserver,
   CurrentResponse,
   Navigation,
@@ -185,7 +185,7 @@ export default function createRouter(
   const router: CuriRouter = {
     route: routeInteractions,
     history,
-    observe(fn: Observer, options?: ObserveOptions): RemoveObserver {
+    observe(fn: Observer, options?: ResponseHandlerOptions): RemoveObserver {
       const { initial = true } = options || {};
 
       observers.push(fn);
@@ -198,7 +198,7 @@ export default function createRouter(
         });
       };
     },
-    once(fn: Observer, options?: ObserveOptions) {
+    once(fn: Observer, options?: ResponseHandlerOptions) {
       const { initial = true } = options || {};
 
       if (mostRecent.response && initial) {

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -18,8 +18,7 @@ export interface Emitted {
 
 export type Observer = (props?: Emitted) => void;
 
-export interface RespondOptions {
-  observe?: boolean;
+export interface ObserveOptions {
   initial?: boolean;
 }
 export type RemoveObserver = () => void;
@@ -49,7 +48,8 @@ export interface NavigationDetails {
 
 export interface CuriRouter {
   refresh: (routeArray?: Array<RouteDescriptor>) => void;
-  respond: (fn: Observer, options?: RespondOptions) => RemoveObserver | void;
+  observe: (fn: Observer, options?: ObserveOptions) => RemoveObserver;
+  once: (fn: Observer, options?: ObserveOptions) => void;
   route: Interactions;
   history: History;
   current(): CurrentResponse;

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -18,7 +18,7 @@ export interface Emitted {
 
 export type Observer = (props?: Emitted) => void;
 
-export interface ObserveOptions {
+export interface ResponseHandlerOptions {
   initial?: boolean;
 }
 export type RemoveObserver = () => void;
@@ -48,8 +48,8 @@ export interface NavigationDetails {
 
 export interface CuriRouter {
   refresh: (routeArray?: Array<RouteDescriptor>) => void;
-  observe: (fn: Observer, options?: ObserveOptions) => RemoveObserver;
-  once: (fn: Observer, options?: ObserveOptions) => void;
+  observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
+  once: (fn: Observer, options?: ResponseHandlerOptions) => void;
   route: Interactions;
   history: History;
   current(): CurrentResponse;

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -27,6 +27,7 @@ export {
   RouterOptions,
   Observer,
   Emitted,
+  ResponseHandlerOptions,
   RemoveObserver,
   Navigation,
   CurrentResponse

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -70,9 +70,8 @@ describe("curi", () => {
 
       it("removes the leading slash", () => {
         const router = curi(history, routes);
-        router.respond(({ response }) => {
-          expect(response.name).toBe("Home");
-        });
+        const { response } = router.current();
+        expect(response.name).toBe("Home");
       });
 
       it("warns", () => {
@@ -208,7 +207,7 @@ describe("curi", () => {
           const router = curi(history, routes, {
             sideEffects: [sideEffect]
           });
-          router.respond(({ response, navigation }) => {
+          router.once(({ response, navigation }) => {
             expect(sideEffect.mock.calls.length).toBe(1);
             expect(sideEffect.mock.calls[0][0].response).toBe(response);
             expect(sideEffect.mock.calls[0][0].navigation).toBe(navigation);
@@ -219,7 +218,6 @@ describe("curi", () => {
 
         it("passes response, navigation, and router object to side effect", done => {
           const routes = [{ name: "All", path: "(.*)" }];
-          const responseHandler = jest.fn();
           const sideEffect = function({ response, navigation, router }) {
             expect(response).toMatchObject({
               name: "All",
@@ -235,7 +233,6 @@ describe("curi", () => {
           const router = curi(history, routes, {
             sideEffects: [sideEffect]
           });
-          router.respond(responseHandler);
         });
       });
 
@@ -292,7 +289,8 @@ describe("curi", () => {
           const router = curi(history, routes, {
             emitRedirects: false
           });
-          router.respond(({ response }) => {
+          // the first emitted response is the location that was redirected to
+          router.once(({ response }) => {
             expect(response.name).toBe("Other");
             done();
           });
@@ -305,7 +303,7 @@ describe("curi", () => {
         const routes = [{ name: "Home", path: "" }];
         const router = curi(history, routes);
         const after = jest.fn();
-        router.respond(r => {
+        router.once(r => {
           expect(after.mock.calls.length).toBe(0);
         });
         after();
@@ -323,7 +321,7 @@ describe("curi", () => {
         ];
         const router = curi(history, routes);
         const after = jest.fn();
-        router.respond(r => {
+        router.once(r => {
           expect(after.mock.calls.length).toBe(1);
         });
         after();
@@ -348,20 +346,17 @@ describe("curi", () => {
         const history = InMemory({ locations: ["/parent/child"] });
         const router = curi(history, routes);
         const after = jest.fn();
-        let calls = 0;
-        router.respond(
-          r => {
-            if (calls === 0) {
-              calls++;
-              history.navigate({ pathname: "/parent" });
-              after();
-              return;
-            }
-            expect(after.mock.calls.length).toBe(0);
-            done();
-          },
-          { observe: true }
-        );
+        let navigated = false;
+        router.observe(r => {
+          if (!navigated) {
+            navigated = true;
+            history.navigate({ pathname: "/parent" });
+            after();
+            return;
+          }
+          expect(after.mock.calls.length).toBe(0);
+          done();
+        });
       });
     });
   });
@@ -397,7 +392,7 @@ describe("curi", () => {
 
     it("response and navigation are the last resolved response and navigation", () => {
       const router = curi(history, [{ name: "Home", path: "" }]);
-      router.respond(({ response, navigation }) => {
+      router.once(({ response, navigation }) => {
         expect(router.current()).toMatchObject({
           response,
           navigation
@@ -411,21 +406,18 @@ describe("curi", () => {
         { name: "About", path: "about" }
       ]);
       let calls = 0;
-      router.respond(
-        ({ response, navigation }) => {
-          calls++;
-          expect(router.current()).toMatchObject({
-            response,
-            navigation
-          });
-          if (calls === 2) {
-            done();
-          } else {
-            router.navigate({ name: "About" });
-          }
-        },
-        { observe: true }
-      );
+      router.observe(({ response, navigation }) => {
+        calls++;
+        expect(router.current()).toMatchObject({
+          response,
+          navigation
+        });
+        if (calls === 2) {
+          done();
+        } else {
+          router.navigate({ name: "About" });
+        }
+      });
     });
   });
 
@@ -507,12 +499,12 @@ describe("curi", () => {
 
       // setup a response handler, but ensure it doesn't get called
       // with existing response.
-      router.respond(
+      router.once(
         ({ response, navigation }) => {
           expect(response.name).toBe("About");
           done();
         },
-        { observe: false, initial: false }
+        { initial: false }
       );
       // then refresh the router. the response handler should be called
       // with a response for the current location.
@@ -532,12 +524,12 @@ describe("curi", () => {
 
       // setup a response handler, but ensure it doesn't get called
       // with existing response.
-      router.respond(
+      router.once(
         ({ response, navigation }) => {
           expect(navigation).toMatchObject(initialNavigation);
           done();
         },
-        { observe: false, initial: false }
+        { initial: false }
       );
       // then refresh the router. the response handler should be called
       // with a response for the current location.
@@ -545,7 +537,7 @@ describe("curi", () => {
     });
   });
 
-  describe("respond", () => {
+  describe("observe()", () => {
     let history;
     beforeEach(() => {
       history = InMemory({ locations: ["/"] });
@@ -562,11 +554,11 @@ describe("curi", () => {
 
       // wait for the first response to be generated to ensure that both
       // response handler functions are called when subscribing
-      const unsub1 = router.respond(sub1, {
+      const unsub1 = router.observe(sub1, {
         observe: true,
         initial: false
       }) as RemoveObserver;
-      const unsub2 = router.respond(sub2, { observe: true, initial: false });
+      const unsub2 = router.observe(sub2, { observe: true, initial: false });
 
       expect(sub1.mock.calls.length).toBe(0);
       expect(sub2.mock.calls.length).toBe(0);
@@ -592,10 +584,10 @@ describe("curi", () => {
       };
 
       const router = curi(history, routes);
-      router.respond(responseHandler);
+      router.observe(responseHandler);
     });
 
-    it("notifies response handlers of new response and navigation when location changes", () => {
+    it("is called when location changes", () => {
       const How = { name: "How", path: ":method" };
       const routes = [
         { name: "Home", path: "" },
@@ -618,10 +610,10 @@ describe("curi", () => {
 
       const router = curi(history, routes);
       history.navigate("/contact/mail");
-      router.respond(check);
+      router.observe(check);
     });
 
-    it("[async] notifies response handlers AFTER promises have resolved", done => {
+    it("[async] is called AFTER promises have resolved", done => {
       let promiseResolved = false;
       const routes = [
         { name: "Home", path: "" },
@@ -650,7 +642,7 @@ describe("curi", () => {
       };
       const history = InMemory({ locations: ["/contact/phone"] });
       const router = curi(history, routes);
-      router.respond(check);
+      router.observe(check);
     });
 
     it("[async] does not emit responses for cancelled navigation", done => {
@@ -677,9 +669,56 @@ describe("curi", () => {
       };
       const history = InMemory({ locations: ["/contact/fax"] });
       const router = curi(history, routes);
-      router.respond(check);
+      router.observe(check);
       history.navigate("/contact/phone");
       history.navigate("/contact/mail");
+    });
+
+    it("is re-called for new responses", done => {
+      const routes = [
+        { name: "Home", path: "" },
+        { name: "Contact", path: "contact" },
+        { name: "Not Found", path: "(.*)" }
+      ];
+      const everyTime = jest.fn();
+      let called = false;
+      const responseHandler = jest.fn(() => {
+        if (called) {
+          expect(everyTime.mock.calls.length).toBe(2);
+          expect(responseHandler.mock.calls.length).toBe(2);
+          done();
+        } else {
+          called = true;
+          // trigger another navigation to verify that the observer
+          // is called again
+          router.navigate({ name: "Contact" });
+        }
+      });
+      const router = curi(history, routes);
+      router.observe(everyTime);
+      router.observe(responseHandler);
+    });
+
+    it("[async] no initial response, is called before one time response handlers", done => {
+      const routes = [
+        {
+          name: "Home",
+          path: "",
+          resolve: {
+            test: () => Promise.resolve()
+          }
+        },
+        { name: "Catch All", path: "(.*)" }
+      ];
+      const oneTime = jest.fn();
+      let called = false;
+      const responseHandler = jest.fn(() => {
+        expect(oneTime.mock.calls.length).toBe(0);
+        done();
+      });
+      const router = curi(history, routes);
+      router.once(oneTime);
+      router.observe(responseHandler);
     });
 
     describe("response handler options", () => {
@@ -689,7 +728,7 @@ describe("curi", () => {
           const sub = jest.fn();
           const router = curi(history, routes);
           const { response, navigation } = router.current();
-          router.respond(sub, { initial: true });
+          router.observe(sub, { initial: true });
           expect(sub.mock.calls.length).toBe(1);
           const {
             response: mockResponse,
@@ -711,8 +750,8 @@ describe("curi", () => {
           ];
           const sub = jest.fn();
           const router = curi(history, routes);
-          router.respond(() => {
-            router.respond(sub, { initial: true });
+          router.once(() => {
+            router.observe(sub, { initial: true });
             expect(sub.mock.calls.length).toBe(1);
             done();
           });
@@ -730,50 +769,144 @@ describe("curi", () => {
           ];
           const sub = jest.fn();
           const router = curi(history, routes);
-          router.respond(sub, { initial: true });
+          router.observe(sub, { initial: true });
           expect(sub.mock.calls.length).toBe(0);
         });
       });
 
-      describe("{ observe: false } (default)", () => {
-        it("is called once", () => {
+      describe("{ initial: false }", () => {
+        it("has response, is not immediately called", done => {
           const routes = [{ name: "Home", path: "" }];
-          const oneTime = jest.fn();
-          const responseHandler = jest.fn(() => {
-            expect(oneTime.mock.calls.length).toBe(1);
-            expect(responseHandler.mock.calls.length).toBe(1);
-          });
+          const everyTime = jest.fn();
           const router = curi(history, routes);
-          router.respond(oneTime);
-          router.respond(responseHandler, { observe: true });
+          router.once(() => {
+            router.observe(everyTime, { initial: false });
+            expect(everyTime.mock.calls.length).toBe(0);
+            done();
+          });
         });
 
-        it("isn't re-called for new responses", done => {
+        it("is called AFTER next navigation", done => {
           const routes = [
             { name: "Home", path: "" },
-            { name: "Contact", path: "contact" },
-            { name: "Not Found", path: "(.*)" }
+            { name: "Catch All", path: "(.*)" }
           ];
-          const oneTime = jest.fn();
-          let called = false;
-          const responseHandler = jest.fn(() => {
-            if (called) {
-              expect(oneTime.mock.calls.length).toBe(1);
-              expect(responseHandler.mock.calls.length).toBe(2);
-              done();
-            } else {
-              called = true;
-              // trigger another navigation to verify that the once sub
-              // is not called again
-              router.navigate({ name: "Contact" });
-            }
+          const everyTime = jest.fn(({ response }) => {
+            expect(response.name).toBe("Catch All");
+            done();
           });
           const router = curi(history, routes);
-          router.respond(oneTime);
-          router.respond(responseHandler, { observe: true });
+          router.once(() => {
+            router.observe(everyTime, { initial: false });
+            expect(everyTime.mock.calls.length).toBe(0);
+            history.navigate("/somewhere-else");
+          });
+        });
+      });
+    });
+  });
+
+  describe("once()", () => {
+    let history;
+    beforeEach(() => {
+      history = InMemory({ locations: ["/"] });
+    });
+
+    it("passes response, navigation, and router object to response handler", done => {
+      const routes = [{ name: "All", path: "(.*)" }];
+      const responseHandler = function({ response, navigation, router }) {
+        expect(response).toMatchObject({
+          name: "All",
+          location: { pathname: "/" }
+        });
+        expect(navigation).toMatchObject({
+          action: "PUSH"
+        });
+        expect(router).toBe(router);
+        done();
+      };
+
+      const router = curi(history, routes);
+      router.once(responseHandler);
+    });
+
+    it("is called once", () => {
+      const routes = [{ name: "Home", path: "" }];
+      const oneTime = jest.fn();
+      const responseHandler = jest.fn(() => {
+        expect(oneTime.mock.calls.length).toBe(1);
+        expect(responseHandler.mock.calls.length).toBe(1);
+      });
+      const router = curi(history, routes);
+      router.once(oneTime);
+      router.observe(responseHandler);
+    });
+
+    it("isn't re-called for new responses", done => {
+      const routes = [
+        { name: "Home", path: "" },
+        { name: "Contact", path: "contact" },
+        { name: "Not Found", path: "(.*)" }
+      ];
+      const oneTime = jest.fn();
+      let called = false;
+      const responseHandler = jest.fn(() => {
+        if (called) {
+          expect(oneTime.mock.calls.length).toBe(1);
+          expect(responseHandler.mock.calls.length).toBe(2);
+          done();
+        } else {
+          called = true;
+          // trigger another navigation to verify that the once sub
+          // is not called again
+          router.navigate({ name: "Contact" });
+        }
+      });
+      const router = curi(history, routes);
+      router.once(oneTime);
+      router.observe(responseHandler);
+    });
+
+    it("[async] no initial response, called AFTER regular response handlers", done => {
+      const routes = [
+        {
+          name: "Home",
+          path: "",
+          resolve: {
+            test: () => Promise.resolve()
+          }
+        },
+        { name: "Catch All", path: "(.*)" }
+      ];
+      const oneTime = jest.fn(() => {
+        expect(responseHandler.mock.calls.length).toBe(1);
+        done();
+      });
+      let called = false;
+      const responseHandler = jest.fn();
+      const router = curi(history, routes);
+      router.once(oneTime);
+      router.observe(responseHandler);
+    });
+
+    describe("response handler options", () => {
+      describe("{ initial: true } (default)", () => {
+        it("immediately called with most recent response/navigation", () => {
+          const routes = [{ name: "Home", path: "" }];
+          const sub = jest.fn();
+          const router = curi(history, routes);
+          const { response, navigation } = router.current();
+          router.once(sub, { initial: true });
+          expect(sub.mock.calls.length).toBe(1);
+          const {
+            response: mockResponse,
+            navigation: mockNavigation
+          } = sub.mock.calls[0][0];
+          expect(mockResponse).toBe(response);
+          expect(mockNavigation).toBe(navigation);
         });
 
-        it("[async] no initial response, called AFTER regular response handlers", done => {
+        it("[async] immediately called if initial response has resolved", done => {
           const routes = [
             {
               name: "Home",
@@ -781,59 +914,18 @@ describe("curi", () => {
               resolve: {
                 test: () => Promise.resolve()
               }
-            },
-            { name: "Catch All", path: "(.*)" }
+            }
           ];
-          const oneTime = jest.fn(() => {
-            expect(responseHandler.mock.calls.length).toBe(1);
-            done();
-          });
-          let called = false;
-          const responseHandler = jest.fn();
-          const router = curi(history, routes);
-          router.respond(oneTime);
-          router.respond(responseHandler, { observe: true });
-        });
-      });
-
-      describe("{ observe: true }", () => {
-        it("has response, immediate call", done => {
-          const routes = [{ name: "Home", path: "" }];
           const sub = jest.fn();
           const router = curi(history, routes);
-          router.respond(() => {
-            router.respond(sub, { observe: true });
+          router.once(() => {
+            router.once(sub, { initial: true });
             expect(sub.mock.calls.length).toBe(1);
             done();
           });
         });
 
-        it("is re-called for new responses", done => {
-          const routes = [
-            { name: "Home", path: "" },
-            { name: "Contact", path: "contact" },
-            { name: "Not Found", path: "(.*)" }
-          ];
-          const everyTime = jest.fn();
-          let called = false;
-          const responseHandler = jest.fn(() => {
-            if (called) {
-              expect(everyTime.mock.calls.length).toBe(2);
-              expect(responseHandler.mock.calls.length).toBe(2);
-              done();
-            } else {
-              called = true;
-              // trigger another navigation to verify that the observer
-              // is called again
-              router.navigate({ name: "Contact" });
-            }
-          });
-          const router = curi(history, routes);
-          router.respond(everyTime, { observe: true });
-          router.respond(responseHandler, { observe: true });
-        });
-
-        it("[async] no initial response, is called before one time response handlers", done => {
+        it("[async] not immediately called if initial response hasn't resolved", () => {
           const routes = [
             {
               name: "Home",
@@ -841,18 +933,12 @@ describe("curi", () => {
               resolve: {
                 test: () => Promise.resolve()
               }
-            },
-            { name: "Catch All", path: "(.*)" }
+            }
           ];
-          const oneTime = jest.fn();
-          let called = false;
-          const responseHandler = jest.fn(() => {
-            expect(oneTime.mock.calls.length).toBe(0);
-            done();
-          });
+          const sub = jest.fn();
           const router = curi(history, routes);
-          router.respond(oneTime);
-          router.respond(responseHandler, { observe: true });
+          router.once(sub, { initial: true });
+          expect(sub.mock.calls.length).toBe(0);
         });
       });
 
@@ -861,21 +947,8 @@ describe("curi", () => {
           const routes = [{ name: "Home", path: "" }];
           const oneTime = jest.fn();
           const router = curi(history, routes);
-          router.respond(() => {
-            router.respond(oneTime, { initial: false });
-            expect(oneTime.mock.calls.length).toBe(0);
-            done();
-          });
-        });
-      });
-
-      describe("{ observe: false, initial: false }", () => {
-        it("has response, is not immediately called", done => {
-          const routes = [{ name: "Home", path: "" }];
-          const oneTime = jest.fn();
-          const router = curi(history, routes);
-          router.respond(() => {
-            router.respond(oneTime, { initial: false, observe: false });
+          router.once(() => {
+            router.once(oneTime, { initial: false });
             expect(oneTime.mock.calls.length).toBe(0);
             done();
           });
@@ -891,8 +964,8 @@ describe("curi", () => {
             done();
           });
           const router = curi(history, routes);
-          router.respond(() => {
-            router.respond(oneTime, { initial: false, observe: false });
+          router.once(() => {
+            router.once(oneTime, { initial: false });
             expect(oneTime.mock.calls.length).toBe(0);
             history.navigate("/somewhere-else");
           });
@@ -1053,7 +1126,7 @@ describe("curi", () => {
           params: { id: 1 },
           cancelled
         });
-        router.respond(
+        router.once(
           ({ response }) => {
             // verify this is running after the first navigation completes
             expect(response.name).toBe("Loader");
@@ -1129,7 +1202,7 @@ describe("curi", () => {
           params: { id: 1 },
           finished
         });
-        router.respond(
+        router.once(
           ({ response }) => {
             // verify this is running after the first navigation completes
             expect(response.name).toBe("Loader");

--- a/packages/router/tests/path.spec.ts
+++ b/packages/router/tests/path.spec.ts
@@ -6,7 +6,7 @@ import { curi } from "@curi/router";
 
 describe("route.pathOptions matching", () => {
   describe("default options", () => {
-    it("sensitive = false", done => {
+    it("sensitive = false", () => {
       const history = InMemory({ locations: ["/Here"] });
       const routes = [
         {
@@ -19,13 +19,11 @@ describe("route.pathOptions matching", () => {
         }
       ];
       const router = curi(history, routes);
-      router.respond(({ response }) => {
-        expect(response.name).toBe("Test");
-        done();
-      });
+      const { response } = router.current();
+      expect(response.name).toBe("Test");
     });
 
-    it("strict = false", done => {
+    it("strict = false", () => {
       const history = InMemory({ locations: ["/here/"] });
       const routes = [
         {
@@ -38,13 +36,11 @@ describe("route.pathOptions matching", () => {
         }
       ];
       const router = curi(history, routes);
-      router.respond(({ response }) => {
-        expect(response.name).toBe("Test");
-        done();
-      });
+      const { response } = router.current();
+      expect(response.name).toBe("Test");
     });
 
-    it("end = true", done => {
+    it("end = true", () => {
       const history = InMemory({ locations: ["/here/again"] });
       const routes = [
         {
@@ -57,15 +53,13 @@ describe("route.pathOptions matching", () => {
         }
       ];
       const router = curi(history, routes);
-      router.respond(({ response }) => {
-        expect(response.name).toBe("Not Found");
-        done();
-      });
+      const { response } = router.current();
+      expect(response.name).toBe("Not Found");
     });
   });
 
   describe("user provided options", () => {
-    it("sensitive = true", done => {
+    it("sensitive = true", () => {
       const history = InMemory({ locations: ["/Here"] });
       const routes = [
         {
@@ -79,13 +73,11 @@ describe("route.pathOptions matching", () => {
         }
       ];
       const router = curi(history, routes);
-      router.respond(({ response }) => {
-        expect(response.name).toBe("Not Found");
-        done();
-      });
+      const { response } = router.current();
+      expect(response.name).toBe("Not Found");
     });
 
-    it("strict = true", done => {
+    it("strict = true", () => {
       const history = InMemory({ locations: ["/here/"] });
       const routes = [
         {
@@ -99,13 +91,11 @@ describe("route.pathOptions matching", () => {
         }
       ];
       const router = curi(history, routes);
-      router.respond(({ response }) => {
-        expect(response.name).toBe("Not Found");
-        done();
-      });
+      const { response } = router.current();
+      expect(response.name).toBe("Not Found");
     });
 
-    it("end = false", done => {
+    it("end = false", () => {
       const history = InMemory({ locations: ["/here/again"] });
       const routes = [
         {
@@ -119,10 +109,8 @@ describe("route.pathOptions matching", () => {
         }
       ];
       const router = curi(history, routes);
-      router.respond(({ response }) => {
-        expect(response.name).toBe("Test");
-        done();
-      });
+      const { response } = router.current();
+      expect(response.name).toBe("Test");
     });
   });
 });

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -6,7 +6,7 @@ import { curi } from "@curi/router";
 
 describe("route matching/response generation", () => {
   describe("route matching", () => {
-    it("ignores leading slash on the pathname", done => {
+    it("ignores leading slash on the pathname", () => {
       const history = InMemory({ locations: ["/test"] });
       const routes = [
         {
@@ -15,13 +15,11 @@ describe("route matching/response generation", () => {
         }
       ];
       const router = curi(history, routes);
-      router.respond(({ response }) => {
-        expect(response.name).toBe("Test");
-        done();
-      });
+      const { response } = router.current();
+      expect(response.name).toBe("Test");
     });
 
-    it("does exact matching", done => {
+    it("does exact matching", () => {
       const history = InMemory({ locations: ["/test/leftovers"] });
       const routes = [
         {
@@ -34,10 +32,8 @@ describe("route matching/response generation", () => {
         }
       ];
       const router = curi(history, routes);
-      router.respond(({ response }) => {
-        expect(response.name).toBe("Not Found");
-        done();
-      });
+      const { response } = router.current();
+      expect(response.name).toBe("Not Found");
     });
 
     describe("no matching routes", () => {
@@ -54,7 +50,7 @@ describe("route matching/response generation", () => {
         const router = curi(history, routes);
 
         const observer = jest.fn();
-        router.respond(observer);
+        router.once(observer);
         expect(observer.mock.calls.length).toBe(0);
       });
 
@@ -64,7 +60,7 @@ describe("route matching/response generation", () => {
         const router = curi(history, routes);
         const observer = jest.fn();
 
-        router.respond(observer);
+        router.once(observer);
         expect(fakeError.mock.calls[0][0]).toBe(
           `The current location (/test) has no matching route, so a response could not be emitted. A catch-all route ({ path: "(.*)" }) can be used to match locations with no other matching route.`
         );
@@ -72,7 +68,7 @@ describe("route matching/response generation", () => {
     });
 
     describe("nested routes", () => {
-      it("includes parent if partials if a child matches", done => {
+      it("includes parent if partials if a child matches", () => {
         const history = InMemory({ locations: ["/ND/Fargo"] });
         const routes = [
           {
@@ -87,14 +83,12 @@ describe("route matching/response generation", () => {
           }
         ];
         const router = curi(history, routes);
-        router.respond(({ response }) => {
-          expect(response.name).toBe("City");
-          expect(response.partials).toEqual(["State"]);
-          done();
-        });
+        const { response } = router.current();
+        expect(response.name).toBe("City");
+        expect(response.partials).toEqual(["State"]);
       });
 
-      it("does non-end parent matching when there are child routes, even if pathOptions.end=true", done => {
+      it("does non-end parent matching when there are child routes, even if pathOptions.end=true", () => {
         const history = InMemory({ locations: ["/ND/Fargo"] });
         const routes = [
           {
@@ -110,14 +104,12 @@ describe("route matching/response generation", () => {
           }
         ];
         const router = curi(history, routes);
-        router.respond(({ response }) => {
-          expect(response.name).toBe("City");
-          expect(response.partials).toEqual(["State"]);
-          done();
-        });
+        const { response } = router.current();
+        expect(response.name).toBe("City");
+        expect(response.partials).toEqual(["State"]);
       });
 
-      it("skips parent match if no children match", done => {
+      it("skips parent match if no children match", () => {
         const history = InMemory({ locations: ["/MT/Bozeman"] });
         const routes = [
           {
@@ -136,15 +128,13 @@ describe("route matching/response generation", () => {
           }
         ];
         const router = curi(history, routes);
-        router.respond(({ response }) => {
-          expect(response.name).toBe("Not Found");
-          expect(response.partials).toEqual([]);
-          done();
-        });
+        const { response } = router.current();
+        expect(response.name).toBe("Not Found");
+        expect(response.partials).toEqual([]);
       });
     });
 
-    it("matches partial routes if route.pathOptions.end=false", done => {
+    it("matches partial routes if route.pathOptions.end=false", () => {
       const history = InMemory({ locations: ["/SD/Sioux City"] });
       const routes = [
         {
@@ -158,10 +148,8 @@ describe("route matching/response generation", () => {
         }
       ];
       const router = curi(history, routes);
-      router.respond(({ response }) => {
-        expect(response.name).toBe("State");
-        done();
-      });
+      const { response } = router.current();
+      expect(response.name).toBe("State");
     });
 
     describe("optional path parameters", () => {
@@ -179,9 +167,8 @@ describe("route matching/response generation", () => {
           }
         ];
         const router = curi(history, routes);
-        router.respond(({ response }) => {
-          expect(response.name).toBe("State");
-        });
+        const { response } = router.current();
+        expect(response.name).toBe("State");
       });
 
       it("works when optional param is NOT included", () => {
@@ -198,9 +185,8 @@ describe("route matching/response generation", () => {
           }
         ];
         const router = curi(history, routes);
-        router.respond(({ response }) => {
-          expect(response.name).toBe("State");
-        });
+        const { response } = router.current();
+        expect(response.name).toBe("State");
       });
     });
   });
@@ -208,19 +194,17 @@ describe("route matching/response generation", () => {
   describe("response", () => {
     describe("properties", () => {
       describe("location", () => {
-        it("is the location used to match routes", done => {
+        it("is the location used to match routes", () => {
           const routes = [{ name: "Catch All", path: "(.*)" }];
           const history = InMemory({ locations: ["/other-page"] });
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.location).toBe(history.location);
-            done();
-          });
+          const { response } = router.current();
+          expect(response.location).toBe(history.location);
         });
       });
 
       describe("body", () => {
-        it("is undefined if not set by route.response()", done => {
+        it("is undefined if not set by route.response()", () => {
           const history = InMemory({ locations: ["/test"] });
           const routes = [
             {
@@ -229,13 +213,11 @@ describe("route matching/response generation", () => {
             }
           ];
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.body).toBeUndefined();
-            done();
-          });
+          const { response } = router.current();
+          expect(response.body).toBeUndefined();
         });
 
-        it("is the body value of the object returned by route.response()", done => {
+        it("is the body value of the object returned by route.response()", () => {
           const history = InMemory({ locations: ["/test"] });
           const body = () => "anybody out there?";
           const routes = [
@@ -250,15 +232,13 @@ describe("route matching/response generation", () => {
             }
           ];
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.body).toBe(body);
-            done();
-          });
+          const { response } = router.current();
+          expect(response.body).toBe(body);
         });
       });
 
       describe("status", () => {
-        it("is undefined if not set by route.response()", done => {
+        it("is undefined if not set by route.response()", () => {
           const routes = [
             {
               name: "Contact",
@@ -271,13 +251,11 @@ describe("route matching/response generation", () => {
           ];
           const history = InMemory({ locations: ["/contact"] });
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.status).toBeUndefined();
-            done();
-          });
+          const { response } = router.current();
+          expect(response.status).toBeUndefined();
         });
 
-        it("is the status value of object returned by route.response()", done => {
+        it("is the status value of object returned by route.response()", () => {
           const routes = [
             {
               name: "A Route",
@@ -291,15 +269,13 @@ describe("route matching/response generation", () => {
           ];
           const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.status).toBe(451);
-            done();
-          });
+          const { response } = router.current();
+          expect(response.status).toBe(451);
         });
       });
 
       describe("data", () => {
-        it("is undefined if not set by route.response()", done => {
+        it("is undefined if not set by route.response()", () => {
           const routes = [
             {
               name: "A Route",
@@ -308,13 +284,11 @@ describe("route matching/response generation", () => {
           ];
           const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.data).toBeUndefined();
-            done();
-          });
+          const { response } = router.current();
+          expect(response.data).toBeUndefined();
         });
 
-        it("is the data value of the object returned by route.response()", done => {
+        it("is the data value of the object returned by route.response()", () => {
           const routes = [
             {
               name: "A Route",
@@ -330,15 +304,13 @@ describe("route matching/response generation", () => {
           ];
           const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.data).toMatchObject({ test: "value" });
-            done();
-          });
+          const { response } = router.current();
+          expect(response.data).toMatchObject({ test: "value" });
         });
       });
 
       describe("title", () => {
-        it("is undefined if not set by route.response()", done => {
+        it("is undefined if not set by route.response()", () => {
           const routes = [
             {
               name: "State",
@@ -348,13 +320,11 @@ describe("route matching/response generation", () => {
           const history = InMemory({ locations: ["/AZ"] });
           const router = curi(history, routes);
 
-          router.respond(({ response }) => {
-            expect(response.title).toBeUndefined();
-            done();
-          });
+          const { response } = router.current();
+          expect(response.title).toBeUndefined();
         });
 
-        it("is the title value of the object returned by route.response()", done => {
+        it("is the title value of the object returned by route.response()", () => {
           const routes = [
             {
               name: "State",
@@ -369,30 +339,26 @@ describe("route matching/response generation", () => {
           const history = InMemory({ locations: ["/VA"] });
           const router = curi(history, routes);
 
-          router.respond(({ response }) => {
-            expect(response.title).toBe("A State");
-            done();
-          });
+          const { response } = router.current();
+          expect(response.title).toBe("A State");
         });
       });
 
       describe("name", () => {
-        it("is the name of the best matching route", done => {
+        it("is the name of the best matching route", () => {
           const Route = {
             name: "A Route",
             path: "a-route"
           };
           const history = InMemory({ locations: ["/a-route"] });
           const router = curi(history, [Route]);
-          router.respond(({ response }) => {
-            expect(response.name).toBe("A Route");
-            done();
-          });
+          const { response } = router.current();
+          expect(response.name).toBe("A Route");
         });
       });
 
       describe("partials", () => {
-        it("is set using the names of all partially matching routes", done => {
+        it("is set using the names of all partially matching routes", () => {
           const history = InMemory({ locations: ["/TX/Austin"] });
           const routes = [
             {
@@ -407,15 +373,13 @@ describe("route matching/response generation", () => {
             }
           ];
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.partials).toEqual(["State"]);
-            done();
-          });
+          const { response } = router.current();
+          expect(response.partials).toEqual(["State"]);
         });
       });
 
       describe("params", () => {
-        it("includes params from partially matched routes", done => {
+        it("includes params from partially matched routes", () => {
           const history = InMemory({ locations: ["/MT/Bozeman"] });
           const routes = [
             {
@@ -430,16 +394,14 @@ describe("route matching/response generation", () => {
             }
           ];
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.params).toEqual({
-              state: "MT",
-              city: "Bozeman"
-            });
-            done();
+          const { response } = router.current();
+          expect(response.params).toEqual({
+            state: "MT",
+            city: "Bozeman"
           });
         });
 
-        it("overwrites param name conflicts", done => {
+        it("overwrites param name conflicts", () => {
           const history = InMemory({ locations: ["/1/2"] });
           const routes = [
             {
@@ -449,14 +411,12 @@ describe("route matching/response generation", () => {
             }
           ];
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.params["id"]).toBe("2");
-            done();
-          });
+          const { response } = router.current();
+          expect(response.params["id"]).toBe("2");
         });
 
         describe("parsing params", () => {
-          it("uses route.params to parse params", done => {
+          it("uses route.params to parse params", () => {
             const history = InMemory({ locations: ["/123"] });
             const routes = [
               {
@@ -468,13 +428,11 @@ describe("route matching/response generation", () => {
               }
             ];
             const router = curi(history, routes);
-            router.respond(({ response }) => {
-              expect(response.params).toEqual({ num: 123 });
-              done();
-            });
+            const { response } = router.current();
+            expect(response.params).toEqual({ num: 123 });
           });
 
-          it("parses params from parent routes", done => {
+          it("parses params from parent routes", () => {
             const history = InMemory({ locations: ["/123/456"] });
             const routes = [
               {
@@ -495,16 +453,14 @@ describe("route matching/response generation", () => {
               }
             ];
             const router = curi(history, routes);
-            router.respond(({ response }) => {
-              expect(response.params).toEqual({
-                first: 123,
-                second: 456
-              });
-              done();
+            const { response } = router.current();
+            expect(response.params).toEqual({
+              first: 123,
+              second: 456
             });
           });
 
-          it("uses string for any params not in route.params", done => {
+          it("uses string for any params not in route.params", () => {
             const history = InMemory({ locations: ["/123/456"] });
             const routes = [
               {
@@ -516,16 +472,14 @@ describe("route matching/response generation", () => {
               }
             ];
             const router = curi(history, routes);
-            router.respond(({ response }) => {
-              expect(response.params).toEqual({
-                first: 123,
-                second: "456"
-              });
-              done();
+            const { response } = router.current();
+            expect(response.params).toEqual({
+              first: 123,
+              second: "456"
             });
           });
 
-          it("falls back to string value if param parser throws", done => {
+          it("falls back to string value if param parser throws", () => {
             const originalError = console.error;
             const errorMock = jest.fn();
             console.error = errorMock;
@@ -543,35 +497,29 @@ describe("route matching/response generation", () => {
               }
             ];
             const router = curi(history, routes);
-            router.respond(({ response }) => {
-              expect(response.params).toEqual({
-                num: "123"
-              });
-              expect(errorMock.mock.calls.length).toBe(1);
-              expect(errorMock.mock.calls[0][0].message).toBe(
-                "This will fail."
-              );
-              console.error = originalError;
-              done();
+            const { response } = router.current();
+            expect(response.params).toEqual({
+              num: "123"
             });
+            expect(errorMock.mock.calls.length).toBe(1);
+            expect(errorMock.mock.calls[0][0].message).toBe("This will fail.");
+            console.error = originalError;
           });
         });
       });
 
       describe("error", () => {
-        it("is undefined for good responses", done => {
+        it("is undefined for good responses", () => {
           const routes = [{ name: "Contact", path: "contact" }];
           const history = InMemory({
             locations: ["/contact"]
           });
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.error).toBeUndefined();
-            done();
-          });
+          const { response } = router.current();
+          expect(response.error).toBeUndefined();
         });
 
-        it("is the error value on the object returned by route.response()", done => {
+        it("is the error value on the object returned by route.response()", () => {
           const routes = [
             {
               name: "A Route",
@@ -585,10 +533,8 @@ describe("route matching/response generation", () => {
           ];
           const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
-          router.respond(({ response }) => {
-            expect(response.error).toBe("woops");
-            done();
-          });
+          const { response } = router.current();
+          expect(response.error).toBe("woops");
         });
       });
 
@@ -666,7 +612,7 @@ describe("route matching/response generation", () => {
 
         const history = InMemory({ locations: ["/hello?one=two"] });
         const router = curi(history, [CatchAll]);
-        router.respond(() => {
+        router.once(() => {
           expect(one.mock.calls.length).toBe(1);
           expect(one.mock.calls.length).toBe(1);
           done();

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -13,8 +13,7 @@ export interface Emitted {
     router: CuriRouter;
 }
 export declare type Observer = (props?: Emitted) => void;
-export interface RespondOptions {
-    observe?: boolean;
+export interface ObserveOptions {
     initial?: boolean;
 }
 export declare type RemoveObserver = () => void;
@@ -40,7 +39,8 @@ export interface NavigationDetails {
 }
 export interface CuriRouter {
     refresh: (routeArray?: Array<RouteDescriptor>) => void;
-    respond: (fn: Observer, options?: RespondOptions) => RemoveObserver | void;
+    observe: (fn: Observer, options?: ObserveOptions) => RemoveObserver;
+    once: (fn: Observer, options?: ObserveOptions) => void;
     route: Interactions;
     history: History;
     current(): CurrentResponse;

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -13,7 +13,7 @@ export interface Emitted {
     router: CuriRouter;
 }
 export declare type Observer = (props?: Emitted) => void;
-export interface ObserveOptions {
+export interface ResponseHandlerOptions {
     initial?: boolean;
 }
 export declare type RemoveObserver = () => void;
@@ -39,8 +39,8 @@ export interface NavigationDetails {
 }
 export interface CuriRouter {
     refresh: (routeArray?: Array<RouteDescriptor>) => void;
-    observe: (fn: Observer, options?: ObserveOptions) => RemoveObserver;
-    once: (fn: Observer, options?: ObserveOptions) => void;
+    observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
+    once: (fn: Observer, options?: ResponseHandlerOptions) => void;
     route: Interactions;
     history: History;
     current(): CurrentResponse;

--- a/packages/router/types/types/index.d.ts
+++ b/packages/router/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
 export { Route, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, AsyncGroup, Resolved, ResolveResults } from "./route";
 export { Response, RawParams, Params, MatchResponseProperties, SettableResponseProperties } from "./response";
-export { CuriRouter, RouterOptions, Observer, Emitted, RemoveObserver, Navigation, CurrentResponse } from "./curi";
+export { CuriRouter, RouterOptions, Observer, Emitted, ResponseHandlerOptions, RemoveObserver, Navigation, CurrentResponse } from "./curi";

--- a/packages/svelte/src/store.js
+++ b/packages/svelte/src/store.js
@@ -13,12 +13,9 @@ export default function curiStore(router, store) {
     });
   }
 
-  router.respond(
-    ({ response, navigation }) => {
-      store.set({ curi: { response, navigation } });
-    },
-    { observe: true }
-  );
+  router.observe(({ response, navigation }) => {
+    store.set({ curi: { response, navigation } });
+  });
 
   return store;
 }

--- a/packages/svelte/tests/link.spec.js
+++ b/packages/svelte/tests/link.spec.js
@@ -1,7 +1,8 @@
 import InMemory from "@hickory/in-memory";
 import { curi } from "@curi/router";
-import { Store } from "svelte/store";
 import simulant from "simulant";
+import { curiStore } from "@curi/svelte";
+
 import Link from "../src/Link.html";
 
 describe("<Link>", () => {
@@ -12,8 +13,7 @@ describe("<Link>", () => {
       { name: "Not Found", path: "(.*)" }
     ];
     const router = curi(history, routes);
-
-    const store = new Store({ router });
+    const store = curiStore(router);
 
     const node = document.createElement("div");
     const link = new Link({
@@ -36,7 +36,7 @@ describe("<Link>", () => {
       { name: "Not Found", path: "(.*)" }
     ];
     const router = curi(history, routes);
-    const store = new Store({ router });
+    const store = curiStore(router);
 
     const node = document.createElement("div");
     const link = new Link({
@@ -52,40 +52,27 @@ describe("<Link>", () => {
     expect(a.pathname).toEqual("/u/1");
   });
 
-  it("falls back to current response's pathname if to isn't provided", done => {
+  it("falls back to current response's pathname if \"to\" isn't provided", () => {
     const history = InMemory({ locations: ["/u/2"] });
     const routes = [
       { name: "User", path: "u/:id" },
       { name: "Not Found", path: "(.*)" }
     ];
     const router = curi(history, routes);
-    const store = new Store({
-      router,
-      curi: { response: undefined, navigation: undefined }
+    const store = curiStore(router);
+
+    const node = document.createElement("div");
+    const link = new Link({
+      target: node,
+      store,
+      data: {
+        hash: "is-a-band"
+      }
     });
 
-    router.respond(
-      ({ response, navigation }) => {
-        store.set({ curi: { response, navigation } });
-      },
-      { observe: true }
-    );
-
-    router.respond(() => {
-      const node = document.createElement("div");
-      const link = new Link({
-        target: node,
-        store,
-        data: {
-          hash: "is-a-band"
-        }
-      });
-
-      const a = node.querySelector("a");
-      expect(a.pathname).toEqual("/u/2");
-      expect(a.hash).toEqual("#is-a-band");
-      done();
-    });
+    const a = node.querySelector("a");
+    expect(a.pathname).toEqual("/u/2");
+    expect(a.hash).toEqual("#is-a-band");
   });
 
   it("appends query & hash to end of URI", () => {
@@ -95,7 +82,7 @@ describe("<Link>", () => {
       { name: "Not Found", path: "(.*)" }
     ];
     const router = curi(history, routes);
-    const store = new Store({ router });
+    const store = curiStore(router);
 
     const node = document.createElement("div");
     const link = new Link({
@@ -122,7 +109,7 @@ describe("<Link>", () => {
         { name: "Not Found", path: "(.*)" }
       ];
       const router = curi(history, routes);
-      const store = new Store({ router });
+      const store = curiStore(router);
 
       const node = document.createElement("div");
       const link = new Link({
@@ -148,7 +135,7 @@ describe("<Link>", () => {
         { name: "Not Found", path: "(.*)" }
       ];
       const router = curi(history, routes);
-      const store = new Store({ router });
+      const store = curiStore(router);
 
       const node = document.createElement("div");
       const link = new Link({
@@ -177,7 +164,7 @@ describe("<Link>", () => {
         { name: "Not Found", path: "(.*)" }
       ];
       const router = curi(history, routes);
-      const store = new Store({ router });
+      const store = curiStore(router);
 
       const node = document.createElement("div");
       const link = new Link({
@@ -204,7 +191,7 @@ describe("<Link>", () => {
         { name: "Not Found", path: "(.*)" }
       ];
       const router = curi(history, routes);
-      const store = new Store({ router });
+      const store = curiStore(router);
 
       const node = document.createElement("div");
       const link = new Link({

--- a/packages/svelte/tests/store.spec.js
+++ b/packages/svelte/tests/store.spec.js
@@ -28,15 +28,13 @@ describe("curiStore", () => {
       expect(store.get().curi).toHaveProperty("navigation");
     });
 
-    it("initializes with current response/navigation", done => {
-      router.respond(({ response, navigation }) => {
-        const store = new Store({ foo: "oof" });
-        curiStore(router, store);
-        const $curi = store.get().curi;
-        expect($curi.response).toBe(response);
-        expect($curi.navigation).toBe(navigation);
-        done();
-      });
+    it("initializes with current response/navigation", () => {
+      const { response, navigation } = router.current();
+      const store = new Store({ foo: "oof" });
+      curiStore(router, store);
+      const $curi = store.get().curi;
+      expect($curi.response).toBe(response);
+      expect($curi.navigation).toBe(navigation);
     });
   });
 
@@ -46,14 +44,12 @@ describe("curiStore", () => {
       expect(store.get().router).toBe(router);
     });
 
-    it("initializes with current response/navigation", done => {
-      router.respond(({ response, navigation }) => {
-        const store = curiStore(router, store);
-        const $curi = store.get().curi;
-        expect($curi.response).toBe(response);
-        expect($curi.navigation).toBe(navigation);
-        done();
-      });
+    it("initializes with current response/navigation", () => {
+      const { response, navigation } = router.current();
+      const store = curiStore(router, store);
+      const $curi = store.get().curi;
+      expect($curi.response).toBe(response);
+      expect($curi.navigation).toBe(navigation);
     });
   });
 

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -25,13 +25,10 @@ const CuriPlugin: PluginObject<CuriPluginOptions> = {
       data: { response: null, navigation: null }
     });
 
-    options.router.respond(
-      ({ response, navigation }) => {
-        reactive.response = response;
-        reactive.navigation = navigation;
-      },
-      { observe: true }
-    );
+    options.router.observe(({ response, navigation }) => {
+      reactive.response = response;
+      reactive.navigation = navigation;
+    });
 
     _Vue.mixin({
       beforeCreate: function() {

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -236,7 +236,7 @@ describe("<curi-link>", () => {
           })
         );
 
-        router.respond(
+        router.once(
           ({ response }) => {
             // navigation is complete, wait for Vue to re-render
             Vue.nextTick(() => {
@@ -313,7 +313,7 @@ describe("<curi-link>", () => {
               button: 0
             })
           );
-          router.respond(
+          router.once(
             ({ response }) => {
               // navigation is cancelled, wait for Vue to re-render
               Vue.nextTick(() => {

--- a/packages/vue/tests/plugin.spec.ts
+++ b/packages/vue/tests/plugin.spec.ts
@@ -26,22 +26,19 @@ describe("CuriPlugin", () => {
   });
 
   describe("$curi", () => {
-    it("Adds $curi property to all components", done => {
+    it("Adds $curi property to all components", () => {
       const Vue = createLocalVue();
       const FakeComponent = {
         render: function(h) {
           return h("div");
         }
       };
-      router.respond(({ response, navigation }) => {
-        Vue.use(CuriPlugin, { router });
+      const { response, navigation } = router.current();
+      Vue.use(CuriPlugin, { router });
 
-        const el = new Vue();
-        expect(el.$curi.response).toBe(response);
-        expect(el.$curi.navigation).toBe(navigation);
-
-        done();
-      });
+      const el = new Vue();
+      expect(el.$curi.response).toBe(response);
+      expect(el.$curi.navigation).toBe(navigation);
     });
 
     describe("reactive properties", () => {


### PR DESCRIPTION
Previously, one function was used for setting up response handlers. The exact functionality was determined using an `options` object.

Now, the two functionalities are split into their own respective methods.

While this adds to the API surface area, it should also be easier to document.

```js
// setting up an observer

// old
const stop = router.respond(fn, { observe: true });
// new
const stop = router.observe(fn);

// setting up a one time function

// old
router.respond(fn);
// new
router.once(fn);
```
