### PR TITLE
Add automaticRedirects option to router

### DIFF
--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 17615,
-    "minified": 6201,
-    "gzipped": 2572,
+    "bundled": 17718,
+    "minified": 6243,
+    "gzipped": 2593,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17848,
-    "minified": 6383,
-    "gzipped": 2646
+    "bundled": 17951,
+    "minified": 6425,
+    "gzipped": 2667
   },
   "dist/curi-router.umd.js": {
-    "bundled": 30803,
-    "minified": 8933,
-    "gzipped": 3763
+    "bundled": 30906,
+    "minified": 8975,
+    "gzipped": 3788
   },
   "dist/curi-router.min.js": {
-    "bundled": 30660,
-    "minified": 8847,
-    "gzipped": 3717
+    "bundled": 30763,
+    "minified": 8889,
+    "gzipped": 3741
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `automaticRedirects` option to router. When `false`, redirects will have to be triggered by the user. This is mostly useful for server-side rendering.
+
 ## 1.0.0-beta.43
 
 * Revert dual-mode (not ready yet!).

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -31,7 +31,8 @@ export default function createRouter(
   const {
     route: userInteractions = [],
     sideEffects = [],
-    emitRedirects = true
+    emitRedirects = true,
+    automaticRedirects = true
   } = options;
 
   let routes: Array<InternalRoute> = [];
@@ -177,7 +178,7 @@ export default function createRouter(
       callOneTimersAndSideEffects({ response, navigation, router });
     }
 
-    if (response.redirectTo !== undefined) {
+    if (response.redirectTo !== undefined && automaticRedirects) {
       history.navigate(response.redirectTo, "REPLACE");
     }
   }

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -28,6 +28,7 @@ export interface RouterOptions {
   sideEffects?: Array<Observer>;
   pathnameOptions?: PathFunctionOptions;
   emitRedirects?: boolean;
+  automaticRedirects?: boolean;
 }
 
 export interface CurrentResponse {

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -296,6 +296,75 @@ describe("curi", () => {
           });
         });
       });
+
+      describe("automaticRedirects", () => {
+        it("automatically redirects by default", () => {
+          const routes = [
+            {
+              name: "Start",
+              path: "",
+              response: () => {
+                return {
+                  redirectTo: {
+                    name: "Other"
+                  }
+                };
+              }
+            },
+            {
+              name: "Other",
+              path: "other"
+            }
+          ];
+          const router = curi(history, routes);
+          // because the routes are not asynchronous, an automatic redirect
+          // will be triggered before once is called, so its response
+          // will be for the redirected location
+          router.once(({ response, navigation }) => {
+            expect(response).toMatchObject({
+              name: "Other"
+            });
+            expect(navigation).toMatchObject({
+              action: "REPLACE",
+              previous: {
+                name: "Start"
+              }
+            });
+          });
+        });
+
+        it("does not automatically redirect when automaticRedirects = false", () => {
+          const routes = [
+            {
+              name: "Start",
+              path: "",
+              response: () => {
+                return {
+                  redirectTo: {
+                    name: "Other"
+                  }
+                };
+              }
+            },
+            {
+              name: "Other",
+              path: "other"
+            }
+          ];
+          const router = curi(history, routes, {
+            automaticRedirects: false
+          });
+          router.once(({ response, navigation }) => {
+            expect(response).toMatchObject({
+              name: "Start"
+            });
+            expect(navigation).toMatchObject({
+              action: "PUSH",
+              previous: null
+            });
+          });
+        });
+      });
     });
 
     describe("sync/async matching", () => {

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -22,6 +22,7 @@ export interface RouterOptions {
     sideEffects?: Array<Observer>;
     pathnameOptions?: PathFunctionOptions;
     emitRedirects?: boolean;
+    automaticRedirects?: boolean;
 }
 export interface CurrentResponse {
     response: Response | null;

--- a/website/src/client/pages/Packages/Router.js
+++ b/website/src/client/pages/Packages/Router.js
@@ -236,6 +236,57 @@ const router = curi(history, routes, {
                     <SideBySide>
                       <Explanation>
                         <p>
+                          <IJS>automaticRedirects</IJS> - When the initially
+                          matched route is synchronous and redirects, the
+                          router's automatic redirect will occur before any
+                          response handlers (registered with <IJS>once()</IJS>{" "}
+                          or <IJS>observer()</IJS>) are called. This means that
+                          they will be called with the response for the location
+                          that was redirected to instead of the initial
+                          location. This is fine on the client side, but causes
+                          issues with server side rendering. When{" "}
+                          <IJS>automaticRedirects</IJS> is <IJS>false</IJS>, the
+                          automatic redirect will not happen.{" "}
+                          <strong>
+                            Using <IJS>automaticRedirects = false</IJS> is
+                            recommend for server side rendering.
+                          </strong>
+                        </p>
+                      </Explanation>
+                      <CodeBlock>
+                        {`const routes = [
+  {
+    name: "Old",
+    path: "old/:id",
+    response({ params }) {
+      // setup a redirect to the "New" route
+      return {
+        redirectTo: {
+          name: "New",
+          params
+        }
+      };
+    }
+  },
+  {
+    name: "New",
+    path: "new/:id"
+  }
+];
+const history = InMemory({ locations: ["old/1" ]});
+const router = curi(history, routes, {
+  automaticRedirects: false                 
+});
+router.once(({ response }) => {
+  // response = { name: "Old", ... }
+});`}
+                      </CodeBlock>
+                    </SideBySide>
+                  </li>
+                  <li>
+                    <SideBySide>
+                      <Explanation>
+                        <p>
                           <IJS>pathnameOptions</IJS> - Curi uses{" "}
                           <a href="https://github.com/pillarjs/path-to-regexp">
                             <IJS>path-to-regexp</IJS>


### PR DESCRIPTION
This is primarily a server side rendering feature.

With automatic redirects and synchronous routes, calling `router.once()` (or `observe()`) will occur after the redirect, so the response handler is called with the redirected location's `response`. This is fine on the client side where the response handler only cares about the most up-to-date location, but on the server, `once()` should be called with the real first `response`.