### PR TITLE
Fix bug when parent route ends with slash

### DIFF
--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 17718,
-    "minified": 6243,
-    "gzipped": 2593,
+    "bundled": 17985,
+    "minified": 6279,
+    "gzipped": 2606,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17951,
-    "minified": 6425,
-    "gzipped": 2667
+    "bundled": 18218,
+    "minified": 6461,
+    "gzipped": 2681
   },
   "dist/curi-router.umd.js": {
-    "bundled": 30906,
-    "minified": 8975,
-    "gzipped": 3788
+    "bundled": 31193,
+    "minified": 8996,
+    "gzipped": 3804
   },
   "dist/curi-router.min.js": {
-    "bundled": 30763,
-    "minified": 8889,
-    "gzipped": 3741
+    "bundled": 31050,
+    "minified": 8910,
+    "gzipped": 3758
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Fix bug in route matching when parent route ends with a forward slash.
+
 ## 1.0.1
 
 * Add `automaticRedirects` option to router. When `false`, redirects will have to be triggered by the user. This is mostly useful for server-side rendering.

--- a/packages/router/src/matchLocation.ts
+++ b/packages/router/src/matchLocation.ts
@@ -1,4 +1,4 @@
-import { stripLeadingSlash } from "./utils/path";
+import { withLeadingSlash } from "./utils/path";
 import parseParams from "./utils/parseParams";
 
 import { HickoryLocation } from "@hickory/root";
@@ -14,6 +14,7 @@ function matchRoute(
   const regExpMatch: RegExpMatchArray | null = route.pathMatching.re.exec(
     testPath
   );
+
   if (!regExpMatch) {
     return [];
   }
@@ -33,12 +34,17 @@ function matchRoute(
 
   // children only need to match against unmatched segments
   const remainingSegments = testPath.slice(matchedSegment.length);
-  const childrenLength = route.children.length;
-  for (let i = 0; i < childrenLength; i++) {
-    const matched = matchRoute(route.children[i], remainingSegments);
-    if (matched.length) {
-      matches = matches.concat(matched);
-      break;
+  if (remainingSegments !== "") {
+    const childrenLength = route.children.length;
+    // a parent that ends with a slash will have stripped the leading
+    // slash from remaining segments, so re-add it
+    const fullSegments = withLeadingSlash(remainingSegments);
+    for (let i = 0; i < childrenLength; i++) {
+      const matched = matchRoute(route.children[i], fullSegments);
+      if (matched.length) {
+        matches = matches.concat(matched);
+        break;
+      }
     }
   }
 

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -68,7 +68,7 @@ describe("route matching/response generation", () => {
     });
 
     describe("nested routes", () => {
-      it("includes parent if partials if a child matches", () => {
+      it("includes parent in partials if a child matches", () => {
         const history = InMemory({ locations: ["/ND/Fargo"] });
         const routes = [
           {
@@ -86,6 +86,29 @@ describe("route matching/response generation", () => {
         const { response } = router.current();
         expect(response.name).toBe("City");
         expect(response.partials).toEqual(["State"]);
+      });
+
+      it("matches children when parent has trailing slash", () => {
+        const history = InMemory({ locations: ["/ND/Fargo/"] });
+        const routes = [
+          {
+            name: "State",
+            path: ":state/",
+            children: [
+              {
+                name: "City",
+                path: ":city/"
+              }
+            ]
+          },
+          {
+            name: "Not Found",
+            path: "(.*)"
+          }
+        ];
+        const router = curi(history, routes);
+        const { response } = router.current();
+        expect(response.name).toBe("City");
       });
 
       it("does non-end parent matching when there are child routes, even if pathOptions.end=true", () => {


### PR DESCRIPTION
Previously, when a parent route ended with a slash, the children route would be matched against a pathname that had no leading slash.

This bug was probably introduced in #100, which fixed an issue with optional parameters and required switching to testing against routes against pathnames with leading slashes.