### PR TITLE
[static] Catch errors thrown by async routes

### DIFF
--- a/packages/static/.size-snapshot.json
+++ b/packages/static/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/curi-static.js": {
-    "bundled": 7150,
-    "minified": 2987,
-    "gzipped": 1409
+    "bundled": 7460,
+    "minified": 3042,
+    "gzipped": 1416
   }
 }

--- a/packages/static/CHANGELOG.md
+++ b/packages/static/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Catch errors that occur while rendering/inserting/saving asynchronous routes.
+
 ## 1.0.0-alpha.1
 
 * `render()` can return anything, not just a string. This supports more advanced output.

--- a/packages/static/src/staticFiles.ts
+++ b/packages/static/src/staticFiles.ts
@@ -63,21 +63,25 @@ export default async function staticFiles(
 
           router.once(
             (emitted: Emitted) => {
-              const { response } = emitted;
-              if (response.redirectTo && !outputRedirects) {
-                resolve({
-                  pathname,
-                  success: false,
-                  error: new Error("redirect")
+              try {
+                const { response } = emitted;
+                if (response.redirectTo && !outputRedirects) {
+                  resolve({
+                    pathname,
+                    success: false,
+                    error: new Error("redirect")
+                  });
+                  return;
+                }
+                const markup = render(emitted);
+                const html = insert(markup);
+                const outputFilename = join(outputDir, pathname, "index.html");
+                outputFile(outputFilename, html).then(() => {
+                  resolve({ pathname, success: true });
                 });
-                return;
+              } catch (e) {
+                resolve({ pathname, success: false, error: e });
               }
-              const markup = render(emitted);
-              const html = insert(markup);
-              const outputFilename = join(outputDir, pathname, "index.html");
-              outputFile(outputFilename, html).then(() => {
-                resolve({ pathname, success: true });
-              });
             },
             { initial: true }
           );

--- a/packages/static/tests/staticFiles.spec.ts
+++ b/packages/static/tests/staticFiles.spec.ts
@@ -231,4 +231,43 @@ describe("staticFiles()", () => {
       expect(getRouterOptions.mock.calls.length).toBe(2);
     });
   });
+
+  describe("errors", () => {
+    describe("async routes", () => {
+      it("catches errors", async () => {
+        const fixtures = join(FIXTURES_ROOT, "render-errors");
+        await remove(fixtures);
+        await ensureDir(fixtures);
+
+        const routes = [
+          {
+            name: "Home",
+            path: "",
+            resolve: {
+              async: () => Promise.resolve(true)
+            },
+            response() {
+              return { body: "Home" };
+            }
+          }
+        ];
+        const pages = [{ name: "Home" }];
+        const getRouterOptions = jest.fn();
+        const results = await staticFiles({
+          routes,
+          pages,
+          render: () => {
+            throw new Error("uh oh");
+          },
+          insert: DEFAULT_INSERT,
+          outputDir: fixtures,
+          getRouterOptions
+        });
+        expect(results[0]).toMatchObject({
+          pathname: "/",
+          success: false
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Previously, only errors thrown by synchronous routes were caught because the `try...catch` wrapped `router.once()`, so it would only catch errors that occur when `router.once()` was called immediately.