### PR TITLE
Add <Focus preserve={true}> to not steal focus

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 7708,
+    "bundled": 7725,
     "minified": 3658,
     "gzipped": 1519,
     "treeshaked": {
@@ -14,17 +14,17 @@
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 8033,
+    "bundled": 8050,
     "minified": 3923,
     "gzipped": 1619
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 14798,
+    "bundled": 14819,
     "minified": 6080,
     "gzipped": 2144
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 13800,
+    "bundled": 13821,
     "minified": 5433,
     "gzipped": 1818
   }

--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 7367,
-    "minified": 3445,
-    "gzipped": 1445,
+    "bundled": 7708,
+    "minified": 3658,
+    "gzipped": 1519,
     "treeshaked": {
       "rollup": {
         "code": 2191,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 7692,
-    "minified": 3710,
-    "gzipped": 1546
+    "bundled": 8033,
+    "minified": 3923,
+    "gzipped": 1619
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 14468,
-    "minified": 5903,
-    "gzipped": 2077
+    "bundled": 14798,
+    "minified": 6080,
+    "gzipped": 2144
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 13656,
-    "minified": 5349,
-    "gzipped": 1787
+    "bundled": 13800,
+    "minified": 5433,
+    "gzipped": 1818
   }
 }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `preserve` prop to `<Focus>` to preserve an existing focus (do not steal). Only works if the existing focused element is a child of the one the `ref` is attached to.
+
 ## 1.0.0-beta.4
 
 * Revert dual-mode (not ready yet!).

--- a/packages/react-dom/src/Focus.tsx
+++ b/packages/react-dom/src/Focus.tsx
@@ -6,7 +6,8 @@ import { Response } from "@curi/router";
 
 export interface FocusProps {
   children(ref: Ref<any>): ReactNode;
-  preventScroll: boolean;
+  preventScroll?: boolean;
+  preserve?: boolean;
 }
 
 interface FocusPropsWithResponse extends FocusProps {
@@ -59,10 +60,22 @@ class FocusWithResponse extends React.Component<FocusPropsWithResponse> {
           );
         }
       }
+      if (
+        this.props.preserve &&
+        this.eleToFocus.contains(document.activeElement)
+      ) {
+        return;
+      }
       setTimeout(() => {
         // @ts-ignore
         this.eleToFocus.focus({ preventScroll: this.props.preventScroll });
       });
+    } else {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          "There is no element to focus. Did you forget to add the ref to an element?"
+        );
+      }
     }
   }
 }

--- a/packages/react-dom/tests/Focus.spec.tsx
+++ b/packages/react-dom/tests/Focus.spec.tsx
@@ -27,112 +27,358 @@ describe("<Focus>", () => {
     document.body.removeChild(node);
   });
 
-  it("focuses when mounting", () => {
-    ReactDOM.render(
-      <Router>
-        {() => (
-          <Focus>
-            {ref => (
-              <div id="test" tabIndex={-1} ref={ref}>
-                Testing!
-              </div>
-            )}
-          </Focus>
-        )}
-      </Router>,
-      node
-    );
-    jest.runAllTimers();
-    const wrapper = document.querySelector("#test");
-    const focused = document.activeElement;
-    expect(focused).toBe(wrapper);
+  describe("mounting", () => {
+    it("focuses ref when mounting", () => {
+      ReactDOM.render(
+        <Router>
+          {() => (
+            <Focus>
+              {ref => (
+                <div id="test" tabIndex={-1} ref={ref}>
+                  Testing!
+                </div>
+              )}
+            </Focus>
+          )}
+        </Router>,
+        node
+      );
+      jest.runAllTimers();
+      const wrapper = document.querySelector("#test");
+      const focused = document.activeElement;
+      expect(focused).toBe(wrapper);
+    });
+
+    it("warns if ref isn't attached to an element  (body focused)", () => {
+      const realWarn = console.warn;
+      const fakeWarn = (console.warn = jest.fn());
+
+      const Home = () => (
+        <div id="home">
+          <h1>Home</h1>
+        </div>
+      );
+
+      const routes = [
+        {
+          name: "Home",
+          path: "",
+          response() {
+            return { body: Home };
+          }
+        }
+      ];
+
+      const history = InMemory();
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+      ReactDOM.render(
+        <Router>
+          {({ response }) => {
+            const { body: Body } = response;
+            return <Focus>{ref => <Body innerRef={ref} />}</Focus>;
+          }}
+        </Router>,
+        node
+      );
+      jest.runAllTimers();
+
+      expect(document.activeElement).toBe(document.body);
+      expect(fakeWarn.mock.calls[0][0]).toBe(
+        "There is no element to focus. Did you forget to add the ref to an element?"
+      );
+      console.warn = realWarn;
+    });
   });
 
-  it("does not re-focus for regular re-renders", () => {
-    ReactDOM.render(
-      <Router>
-        {() => (
-          <Focus>
-            {ref => (
-              <div id="test" tabIndex={-1} ref={ref}>
-                <input type="text" />
-              </div>
+  describe("updates", () => {
+    it("does not re-focus ref for regular re-renders", () => {
+      ReactDOM.render(
+        <Router>
+          {() => (
+            <Focus>
+              {ref => (
+                <div id="test" tabIndex={-1} ref={ref}>
+                  <input type="text" />
+                </div>
+              )}
+            </Focus>
+          )}
+        </Router>,
+        node
+      );
+
+      jest.runAllTimers();
+
+      const wrapper = document.querySelector("#test");
+      const initialFocus = document.activeElement;
+      expect(initialFocus).toBe(wrapper);
+
+      const input = document.querySelector("input");
+      // steal the focus
+      input.focus();
+      const stolenFocus = document.activeElement;
+      expect(stolenFocus).toBe(input);
+
+      ReactDOM.render(
+        <Router>
+          {() => (
+            <Focus>
+              {ref => (
+                <div id="test" ref={ref}>
+                  <input type="number" />
+                </div>
+              )}
+            </Focus>
+          )}
+        </Router>,
+        node
+      );
+
+      jest.runAllTimers();
+
+      expect(stolenFocus).toBe(input);
+    });
+
+    describe("new response", () => {
+      it("re-focuses ref for new response re-renders", () => {
+        ReactDOM.render(
+          <Router>
+            {() => (
+              <Focus>
+                {ref => (
+                  <div id="test" tabIndex={-1} ref={ref}>
+                    <input type="text" />
+                  </div>
+                )}
+              </Focus>
             )}
-          </Focus>
-        )}
-      </Router>,
-      node
-    );
+          </Router>,
+          node
+        );
 
-    jest.runAllTimers();
+        jest.runAllTimers();
 
-    const wrapper = document.querySelector("#test");
-    const initialFocus = document.activeElement;
-    expect(initialFocus).toBe(wrapper);
+        const input = document.querySelector("input");
+        const wrapper = input.parentElement;
+        const initialFocused = document.activeElement;
 
-    const input = document.querySelector("input");
-    // steal the focus
-    input.focus();
-    const stolenFocus = document.activeElement;
-    expect(stolenFocus).toBe(input);
+        expect(wrapper).toBe(initialFocused);
 
-    ReactDOM.render(
-      <Router>
-        {() => (
-          <Focus>
-            {ref => (
-              <div id="test" ref={ref}>
-                <input type="number" />
-              </div>
-            )}
-          </Focus>
-        )}
-      </Router>,
-      node
-    );
+        // steal the focus
+        input.focus();
+        const stolenFocus = document.activeElement;
+        expect(input).toBe(stolenFocus);
 
-    jest.runAllTimers();
+        // navigate and verify wrapper is re-focused
+        router.navigate({ name: "About" });
 
-    expect(stolenFocus).toBe(input);
+        jest.runAllTimers();
+
+        const postNavFocus = document.activeElement;
+
+        expect(wrapper).toBe(postNavFocus);
+      });
+
+      it("focuses new ref for new responses", () => {
+        const Home = React.forwardRef((_, ref: React.Ref<any>) => (
+          <div id="home" tabIndex={-1} ref={ref}>
+            <h1>Home</h1>
+          </div>
+        ));
+        const About = React.forwardRef((_, ref: React.Ref<any>) => (
+          <div id="about" tabIndex={-1} ref={ref}>
+            <h1>About</h1>
+          </div>
+        ));
+        const routes = [
+          {
+            name: "Home",
+            path: "",
+            response() {
+              return { body: Home };
+            }
+          },
+          {
+            name: "About",
+            path: "about",
+            response() {
+              return { body: About };
+            }
+          }
+        ];
+
+        const history = InMemory();
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+        ReactDOM.render(
+          <Router>
+            {({ response }) => {
+              const { body: Body } = response;
+              return <Focus>{ref => <Body ref={ref} />}</Focus>;
+            }}
+          </Router>,
+          node
+        );
+        jest.runAllTimers();
+
+        const homeDiv = node.querySelector("#home");
+        expect(document.activeElement).toBe(homeDiv);
+
+        router.navigate({ name: "About" });
+
+        jest.runAllTimers();
+
+        const aboutDiv = node.querySelector("#about");
+        expect(document.activeElement).toBe(aboutDiv);
+      });
+
+      it("warns if ref isn't attached to an element (body focused)", () => {
+        const realWarn = console.warn;
+        const fakeWarn = (console.warn = jest.fn());
+
+        const Home = ({ innerRef }) => (
+          <div id="home" tabIndex={-1} ref={innerRef}>
+            <h1>Home</h1>
+          </div>
+        );
+
+        const About = () => (
+          <div id="about">
+            <h1>About</h1>
+          </div>
+        );
+
+        const routes = [
+          {
+            name: "Home",
+            path: "",
+            response() {
+              return { body: Home };
+            }
+          },
+          {
+            name: "About",
+            path: "about",
+            response() {
+              return { body: About };
+            }
+          }
+        ];
+
+        const history = InMemory();
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+        ReactDOM.render(
+          <Router>
+            {({ response }) => {
+              const { body: Body } = response;
+              return <Focus>{ref => <Body innerRef={ref} />}</Focus>;
+            }}
+          </Router>,
+          node
+        );
+        jest.runAllTimers();
+
+        const homeDiv = node.querySelector("#home");
+        expect(document.activeElement).toBe(homeDiv);
+        expect(fakeWarn.mock.calls.length).toBe(0);
+
+        router.navigate({ name: "About" });
+
+        jest.runAllTimers();
+
+        expect(document.activeElement).toBe(document.body);
+        expect(fakeWarn.mock.calls[0][0]).toBe(
+          "There is no element to focus. Did you forget to add the ref to an element?"
+        );
+        console.warn = realWarn;
+      });
+    });
   });
 
-  it("re-focuses for new response re-renders", () => {
-    ReactDOM.render(
-      <Router>
-        {() => (
-          <Focus>
-            {ref => (
-              <div id="test" tabIndex={-1} ref={ref}>
-                <input type="text" />
-              </div>
+  describe("preserve", () => {
+    describe("false (default)", () => {
+      it("re-focuses for new response re-renders", () => {
+        ReactDOM.render(
+          <Router>
+            {() => (
+              <Focus>
+                {ref => (
+                  <div id="test" tabIndex={-1} ref={ref}>
+                    <input type="text" />
+                  </div>
+                )}
+              </Focus>
             )}
-          </Focus>
-        )}
-      </Router>,
-      node
-    );
+          </Router>,
+          node
+        );
 
-    jest.runAllTimers();
+        jest.runAllTimers();
 
-    const input = document.querySelector("input");
-    const wrapper = input.parentElement;
-    const initialFocused = document.activeElement;
+        const input = document.querySelector("input");
+        const wrapper = input.parentElement;
+        const initialFocused = document.activeElement;
 
-    expect(wrapper).toBe(initialFocused);
+        expect(wrapper).toBe(initialFocused);
 
-    // steal the focus
-    input.focus();
-    const stolenFocus = document.activeElement;
-    expect(input).toBe(stolenFocus);
+        // steal the focus
+        input.focus();
+        const stolenFocus = document.activeElement;
+        expect(input).toBe(stolenFocus);
 
-    // navigate and verify wrapper is re-focused
-    router.navigate({ name: "About" });
+        // navigate and verify wrapper is re-focused
+        router.navigate({ name: "About" });
 
-    jest.runAllTimers();
+        jest.runAllTimers();
 
-    const postNavFocus = document.activeElement;
+        const postNavFocus = document.activeElement;
 
-    expect(wrapper).toBe(postNavFocus);
+        expect(wrapper).toBe(postNavFocus);
+      });
+    });
+
+    describe("true", () => {
+      it("does not focus ref if something is already ", () => {
+        ReactDOM.render(
+          <Router>
+            {() => (
+              <Focus preserve={true}>
+                {ref => (
+                  <div id="test" tabIndex={-1} ref={ref}>
+                    <input type="text" />
+                  </div>
+                )}
+              </Focus>
+            )}
+          </Router>,
+          node
+        );
+
+        jest.runAllTimers();
+
+        const input = document.querySelector("input");
+        const wrapper = input.parentElement;
+        const initialFocused = document.activeElement;
+
+        expect(wrapper).toBe(initialFocused);
+
+        // steal the focus
+        input.focus();
+        const stolenFocus = document.activeElement;
+        expect(input).toBe(stolenFocus);
+
+        // navigate and verify wrapper is re-focused
+        router.navigate({ name: "About" });
+
+        jest.runAllTimers();
+
+        const postNavFocus = document.activeElement;
+
+        expect(postNavFocus).toBe(input);
+      });
+    });
   });
 
   describe("preventScroll", () => {

--- a/packages/react-dom/types/Focus.d.ts
+++ b/packages/react-dom/types/Focus.d.ts
@@ -1,7 +1,8 @@
 import { ReactNode, Ref } from "react";
 export interface FocusProps {
     children(ref: Ref<any>): ReactNode;
-    preventScroll: boolean;
+    preventScroll?: boolean;
+    preserve?: boolean;
 }
 declare const Focus: (props: FocusProps) => JSX.Element;
 export default Focus;

--- a/website/src/pages/Packages/ReactPkg.js
+++ b/website/src/pages/Packages/ReactPkg.js
@@ -270,9 +270,7 @@ const Router = curiProvider(router);`}
             <Explanation>
               <p>
                 <Cmp>Focus</Cmp> lets you focus a DOM element whenever there is
-                a new response. Its <IJS>children</IJS> prop is a render-invoked
-                function that receives a React ref, which should be attached to
-                the DOM component that you want to be focused.
+                a new response.
               </p>
               <p>
                 The DOM component that gets the ref should either already be
@@ -301,6 +299,90 @@ const Router = curiProvider(router);`}
   )}
 </Focus>`}
             </CodeBlock>
+            <Section tag="h3" title="Props" id="focus-props">
+              <Subsection tag="h4" title="children()" id="focus-children">
+                <Explanation>
+                  <p>
+                    The <IJS>children()</IJS> function is a render-invoked prop
+                    that will be passed a <IJS>ref</IJS>. The <IJS>ref</IJS>{" "}
+                    should be attached to the element that you want focused.
+                  </p>
+                  <p>
+                    If you need to pass this through class/functional
+                    components, you should use either{" "}
+                    <IJS>React.forwardRef()</IJS> or pass it as a prop with a
+                    name other than <IJS>ref</IJS> (like <IJS>innerRef</IJS>).
+                  </p>
+                </Explanation>
+                <CodeBlock lang="jsx">
+                  {`<Focus>
+  {ref => (
+    <div tabIndex={-1} ref={ref} />
+  )}
+</Focus>
+
+<Focus>
+  {ref => <SomeComponent innerRef={ref} />}
+</Focus>`}
+                </CodeBlock>
+              </Subsection>
+              <Subsection
+                tag="h4"
+                title="preventScroll"
+                id="focus-preventScroll"
+              >
+                <Explanation>
+                  <p>
+                    The default behavior for focusing an element is to scroll to
+                    it. If you want to prevent this, pass{" "}
+                    <IJS>{`preventScroll=\{true\}`}</IJS> to the{" "}
+                    <Cmp>Focus</Cmp>.
+                  </p>
+                </Explanation>
+                <CodeBlock lang="jsx">
+                  {`// scrolls
+<Focus>{ref => ...}</Focus>
+
+// does not scroll
+<Focus preventScroll={true}>{ref => ...}</Focus>`}
+                </CodeBlock>
+              </Subsection>
+              <Subsection tag="h4" title="preserve" id="focus-preserve">
+                <Explanation>
+                  <p>
+                    The default focus behavior is to always focus the element
+                    that the ref is attached to. However, if you want to
+                    preserve the focus on some other element (e.g. an
+                    autofocused element), <IJS>{`preserve=\{true\}`}</IJS> will
+                    stop the <IJS>ref</IJS> element from claiming the focus.
+                  </p>
+                  <p>
+                    This only works when the already-focused element is a child
+                    of the <IJS>ref</IJS> element. If it is not a child, then
+                    the <IJS>ref</IJS> element will take the focus.
+                  </p>
+                </Explanation>
+                <CodeBlock lang="jsx">
+                  {`// claim focus for the <div>
+<Focus>
+  {ref => (
+    <div tabIndex={-1} ref={ref}>
+      <input autoFocus={true} />
+    </div>
+  )}
+</Focus>
+
+// preserve focus on the <input>
+<Focus preserve={true}>
+  {ref => (
+    <div tabIndex={-1} ref={ref}>
+      <input autoFocus={true} />
+    </div>
+  )}
+</Focus>`}
+                </CodeBlock>
+              </Subsection>
+            </Section>
           </Section>
 
           <Section title={<Cmp>Curious</Cmp>} id="Curious">

--- a/website/src/render.js
+++ b/website/src/render.js
@@ -10,7 +10,7 @@ export default function render({ response }) {
   return (
     <React.Fragment>
       <Header />
-      <Focus>
+      <Focus preventScroll={true}>
         {ref => (
           <main ref={ref} tabIndex={-1} style={{ outline: "none" }}>
             <Body response={response} />


### PR DESCRIPTION
When using `<Focus>`, a `ref` is attached to an element and that element is focused. If a child of the `ref` element has previously claimed the focus, it will be stolen. If the `preserve` prop is `true`, the focus will not be stolen.

This also adds documentation for `<Focus preventScroll={true}>`.