### PR TITLE
Wrap console logs in dev check

### DIFF
--- a/packages/interactions/route-active/.size-snapshot.json
+++ b/packages/interactions/route-active/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-active.es.js": {
-    "bundled": 1820,
-    "minified": 773,
-    "gzipped": 469,
+    "bundled": 1921,
+    "minified": 809,
+    "gzipped": 496,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-route-active.js": {
-    "bundled": 1837,
-    "minified": 786,
-    "gzipped": 476
+    "bundled": 1938,
+    "minified": 822,
+    "gzipped": 504
   },
   "dist/curi-route-active.umd.js": {
-    "bundled": 2178,
+    "bundled": 2240,
     "minified": 888,
     "gzipped": 519
   },
   "dist/curi-route-active.min.js": {
-    "bundled": 2178,
-    "minified": 888,
-    "gzipped": 519
+    "bundled": 1722,
+    "minified": 617,
+    "gzipped": 365
   }
 }

--- a/packages/interactions/route-active/src/index.ts
+++ b/packages/interactions/route-active/src/index.ts
@@ -24,14 +24,16 @@ export default function checkIfActive(): Interaction {
       const fullKeys = Array.isArray(parentKeys)
         ? [...parentKeys, ...keys]
         : keys;
-      if (routeParams[name] !== undefined) {
-        console.warn(
-          '[@curi/route-active] A route with the name "' +
-            name +
-            '" already exists. Each route should' +
-            "have a unique name. By registering a route function with a name that already exists, " +
-            "you are overwriting the existing one. This may break your application."
-        );
+      if (process.env.NODE_ENV !== "production") {
+        if (routeParams[name] !== undefined) {
+          console.warn(
+            '[@curi/route-active] A route with the name "' +
+              name +
+              '" already exists. Each route should' +
+              "have a unique name. By registering a route function with a name that already exists, " +
+              "you are overwriting the existing one. This may break your application."
+          );
+        }
       }
       routeParams[name] = fullKeys;
       return fullKeys;

--- a/packages/interactions/route-ancestors/.size-snapshot.json
+++ b/packages/interactions/route-ancestors/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-ancestors.es.js": {
-    "bundled": 1268,
-    "minified": 558,
-    "gzipped": 351,
+    "bundled": 1369,
+    "minified": 594,
+    "gzipped": 379,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-route-ancestors.js": {
-    "bundled": 1285,
-    "minified": 571,
-    "gzipped": 359
+    "bundled": 1386,
+    "minified": 607,
+    "gzipped": 389
   },
   "dist/curi-route-ancestors.umd.js": {
-    "bundled": 1611,
+    "bundled": 1673,
     "minified": 707,
     "gzipped": 422
   },
   "dist/curi-route-ancestors.min.js": {
-    "bundled": 1611,
-    "minified": 707,
-    "gzipped": 422
+    "bundled": 1158,
+    "minified": 442,
+    "gzipped": 275
   }
 }

--- a/packages/interactions/route-ancestors/src/index.ts
+++ b/packages/interactions/route-ancestors/src/index.ts
@@ -26,14 +26,16 @@ export default function getRouteAncestors(): Interaction {
       parentRoutes: Array<string> = []
     ): Array<string> => {
       let { name } = route;
-      if (routeAncestors[name] !== undefined) {
-        console.warn(
-          '[@curi/route-ancestors] A route with the name "' +
-            name +
-            '" already exists. Each route should' +
-            "have a unique name. By registering a route with a name that already exists, " +
-            "you are overwriting the existing one. This may break your application."
-        );
+      if (process.env.NODE_ENV !== "production") {
+        if (routeAncestors[name] !== undefined) {
+          console.warn(
+            '[@curi/route-ancestors] A route with the name "' +
+              name +
+              '" already exists. Each route should' +
+              "have a unique name. By registering a route with a name that already exists, " +
+              "you are overwriting the existing one. This may break your application."
+          );
+        }
       }
       routeAncestors[name] = parentRoutes;
       return [name, ...parentRoutes];

--- a/packages/interactions/route-prefetch/.size-snapshot.json
+++ b/packages/interactions/route-prefetch/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-prefetch.es.js": {
-    "bundled": 2071,
-    "minified": 943,
-    "gzipped": 520,
+    "bundled": 2172,
+    "minified": 980,
+    "gzipped": 547,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-route-prefetch.js": {
-    "bundled": 2088,
-    "minified": 956,
-    "gzipped": 529
+    "bundled": 2189,
+    "minified": 993,
+    "gzipped": 556
   },
   "dist/curi-route-prefetch.umd.js": {
-    "bundled": 2443,
+    "bundled": 2505,
     "minified": 1099,
     "gzipped": 591
   },
   "dist/curi-route-prefetch.min.js": {
-    "bundled": 2443,
-    "minified": 1099,
-    "gzipped": 591
+    "bundled": 1995,
+    "minified": 832,
+    "gzipped": 442
   }
 }

--- a/packages/interactions/route-prefetch/src/index.ts
+++ b/packages/interactions/route-prefetch/src/index.ts
@@ -16,14 +16,16 @@ export default function prefetchRoute(): Interaction {
     name: "prefetch",
     register: (route: Route) => {
       const { name, resolve } = route;
-      if (loaders[name] !== undefined) {
-        console.warn(
-          '[@curi/route-prefetch] A route with the name "' +
-            name +
-            '" already exists. Each route should' +
-            "have a unique name. By registering a function with a name that already exists, " +
-            "you are overwriting the existing one. This may break your application."
-        );
+      if (process.env.NODE_ENV !== "production") {
+        if (loaders[name] !== undefined) {
+          console.warn(
+            '[@curi/route-prefetch] A route with the name "' +
+              name +
+              '" already exists. Each route should' +
+              "have a unique name. By registering a function with a name that already exists, " +
+              "you are overwriting the existing one. This may break your application."
+          );
+        }
       }
       if (resolve && Object.keys(resolve).length) {
         loaders[name] = resolve;

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 17985,
-    "minified": 6279,
-    "gzipped": 2606,
+    "bundled": 18070,
+    "minified": 6315,
+    "gzipped": 2610,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 18218,
-    "minified": 6461,
-    "gzipped": 2681
+    "bundled": 18303,
+    "minified": 6497,
+    "gzipped": 2685
   },
   "dist/curi-router.umd.js": {
-    "bundled": 31193,
+    "bundled": 31243,
     "minified": 8996,
     "gzipped": 3804
   },
   "dist/curi-router.min.js": {
-    "bundled": 31050,
-    "minified": 8910,
-    "gzipped": 3758
+    "bundled": 30746,
+    "minified": 8689,
+    "gzipped": 3658
   }
 }

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -101,13 +101,15 @@ export default function createRouter(
     const match = matchLocation(pendingNav.location, routes);
     // if no routes match, do nothing
     if (!match.route) {
-      console.error(
-        `The current location (${
-          pendingNav.location.pathname
-        }) has no matching route, ` +
-          'so a response could not be emitted. A catch-all route ({ path: "(.*)" }) ' +
-          "can be used to match locations with no other matching route."
-      );
+      if (process.env.NODE_ENV !== "production") {
+        console.error(
+          `The current location (${
+            pendingNav.location.pathname
+          }) has no matching route, ` +
+            'so a response could not be emitted. A catch-all route ({ path: "(.*)" }) ' +
+            "can be used to match locations with no other matching route."
+        );
+      }
       pendingNav.finish();
       if (finishCallback) {
         finishCallback();

--- a/packages/static/.size-snapshot.json
+++ b/packages/static/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/curi-static.js": {
-    "bundled": 7460,
-    "minified": 3042,
-    "gzipped": 1416
+    "bundled": 7537,
+    "minified": 3078,
+    "gzipped": 1444
   }
 }

--- a/packages/static/src/pathnames.ts
+++ b/packages/static/src/pathnames.ts
@@ -21,12 +21,14 @@ export default function pathnames(
 
   return pages.map(page => {
     const pathname = router.route.pathname(page.name, page.params);
-    if (pathname == null) {
-      console.warn(
-        `Failed to create page URL for "${
-          page.name
-        }" with params ${JSON.stringify(page.params)}`
-      );
+    if (process.env.NODE_ENV !== "production") {
+      if (pathname == null) {
+        console.warn(
+          `Failed to create page URL for "${
+            page.name
+          }" with params ${JSON.stringify(page.params)}`
+        );
+      }
     }
     return pathname;
   });


### PR DESCRIPTION
Wrap `console.warn()`/`console.error()` in a `NODE_ENV` check so that they can be stripped out in production.