### PR TITLE
Improve v-curi-focus

### DIFF
--- a/packages/vue/.size-snapshot.json
+++ b/packages/vue/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-vue.es.js": {
-    "bundled": 4969,
-    "minified": 2454,
-    "gzipped": 1080,
+    "bundled": 5274,
+    "minified": 2579,
+    "gzipped": 1134,
     "treeshaked": {
       "rollup": {
         "code": 12,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-vue.js": {
-    "bundled": 5194,
-    "minified": 2632,
-    "gzipped": 1142
+    "bundled": 5499,
+    "minified": 2757,
+    "gzipped": 1197
   },
   "dist/curi-vue.umd.js": {
-    "bundled": 5692,
-    "minified": 2583,
-    "gzipped": 1131
+    "bundled": 6007,
+    "minified": 2732,
+    "gzipped": 1192
   },
   "dist/curi-vue.min.js": {
-    "bundled": 5291,
-    "minified": 2328,
-    "gzipped": 984
+    "bundled": 5606,
+    "minified": 2477,
+    "gzipped": 1050
   }
 }

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `v-curi-focus` takes a `FocusDirectiveProperties` object with `key` (re-focus on `key` value change), `preserve` (don't steal focus from already focused child element), and `preventScroll` (don't scroll to focused element) properties.
+
 ## 1.0.0-beta.23
 
 * Revert dual-mode (not ready yet!).

--- a/packages/vue/src/focus.ts
+++ b/packages/vue/src/focus.ts
@@ -2,9 +2,20 @@ import Vue, { DirectiveOptions } from "vue";
 
 export interface FocusComponent extends Vue {}
 
-function scheduleFocus(el: HTMLElement) {
+export interface FocusDirectiveProperties {
+  key: any;
+  preventScroll?: boolean;
+  preserve?: boolean;
+}
+
+function focus(el: HTMLElement, options: FocusDirectiveProperties) {
+  const { preserve = false, preventScroll = false } = options;
+  if (preserve && el.contains(document.activeElement)) {
+    return;
+  }
   setTimeout(() => {
-    el.focus();
+    // @ts-ignore
+    el.focus({ preventScroll });
   });
 }
 
@@ -19,11 +30,11 @@ const focusDirection: DirectiveOptions = {
         );
       }
     }
-    scheduleFocus(el);
+    focus(el, binding.value);
   },
   update(el, binding) {
-    if (binding.value !== binding.oldValue) {
-      scheduleFocus(el);
+    if (binding.value.key !== binding.oldValue.key) {
+      focus(el, binding.value);
     }
   }
 };

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -2,6 +2,7 @@ export { BlockComponent } from "./Block";
 export { LinkComponent } from "./Link";
 export { ReactiveResponse } from "./interface";
 export { CuriPluginOptions } from "./plugin";
+export { FocusDirectiveProperties } from "./focus";
 
 import CuriPlugin from "./plugin";
 

--- a/packages/vue/tests/focus.spec.ts
+++ b/packages/vue/tests/focus.spec.ts
@@ -30,107 +30,114 @@ describe("curi-focus directive", () => {
     document.body.innerHTML = "";
   });
 
-  it("focuses when it renders", done => {
-    vueWrapper = new Vue({
-      template: `
-        <div>
-          <main
-            v-curi-focus="$curi.response"
-            tabIndex="-1"
-          />
-        </div>
-      `,
-      el: node
-    });
-
-    setTimeout(() => {
-      const main = document.querySelector("main");
-      expect(document.activeElement).toBe(main);
-      done();
-    }, 25);
-  });
-
-  it("does not re-focus for regular re-renders", done => {
-    vueWrapper = new Vue({
-      template: `
-        <div>
-          <main
-            v-curi-focus="$curi.response"
-            tabIndex="-1"
-          >
-            <input :type="type" />
-          </main>
-        </div>
-      `,
-      el: node,
-      data: {
-        type: "text"
-      }
-    });
-
-    setTimeout(() => {
-      const wrapper = document.querySelector("main");
-      const initialFocus = document.activeElement;
-      expect(initialFocus).toBe(wrapper);
-
-      const input = document.querySelector("input");
-      // steal the focus
-      input.focus();
-      const stolenFocus = document.activeElement;
-      expect(stolenFocus).toBe(input);
-
-      vueWrapper.type = "number";
+  describe("mounting", () => {
+    it("focuses when it renders", done => {
+      vueWrapper = new Vue({
+        template: `
+          <div>
+            <main
+              v-curi-focus="{ key: $curi.response }"
+              tabIndex="-1"
+            />
+          </div>
+        `,
+        el: node
+      });
 
       setTimeout(() => {
+        const main = document.querySelector("main");
+        expect(document.activeElement).toBe(main);
+        done();
+      }, 25);
+    });
+  });
+
+  describe("updates", () => {
+    it("does not re-focus for regular re-renders", done => {
+      vueWrapper = new Vue({
+        template: `
+          <div>
+            <main
+              v-curi-focus="{ key: $curi.response }"
+              tabIndex="-1"
+            >
+              <input :type="type" />
+            </main>
+          </div>
+        `,
+        el: node,
+        data: {
+          type: "text"
+        }
+      });
+
+      setTimeout(() => {
+        const wrapper = document.querySelector("main");
+        const initialFocus = document.activeElement;
+        expect(initialFocus).toBe(wrapper);
+
+        const input = document.querySelector("input");
+        // steal the focus
+        input.focus();
+        const stolenFocus = document.activeElement;
         expect(stolenFocus).toBe(input);
-        done();
-      }, 25);
-    }, 25);
-  });
 
-  it("re-focuses for new response re-renders", done => {
-    vueWrapper = new Vue({
-      template: `
-        <div>
-          <main
-            v-curi-focus="$curi.response"
-            tabIndex="-1"
-          >
-            <input />
-          </main>
-        </div>
-      `,
-      el: node
+        vueWrapper.type = "number";
+
+        setTimeout(() => {
+          expect(stolenFocus).toBe(input);
+          done();
+        }, 25);
+      }, 25);
     });
 
-    setTimeout(() => {
-      const input = document.querySelector("input");
-      const wrapper = input.parentElement;
-      const initialFocused = document.activeElement;
-
-      expect(initialFocused).toBe(wrapper);
-
-      // steal the focus
-      input.focus();
-      const stolenFocus = document.activeElement;
-      expect(stolenFocus).toBe(input);
-
-      // navigate and verify wrapper is re-focused
-      router.navigate({ name: "Place", params: { name: "Hawaii" } });
+    it("re-focuses for new response re-renders", done => {
+      vueWrapper = new Vue({
+        template: `
+          <div>
+            <main
+              v-curi-focus="{ key: $curi.response }"
+              tabIndex="-1"
+            >
+              <input />
+            </main>
+          </div>
+        `,
+        el: node
+      });
 
       setTimeout(() => {
-        const postNavFocus = document.activeElement;
-        expect(postNavFocus).toBe(wrapper);
-        done();
+        const input = document.querySelector("input");
+        const wrapper = input.parentElement;
+        const initialFocused = document.activeElement;
+
+        expect(initialFocused).toBe(wrapper);
+
+        // steal the focus
+        input.focus();
+        const stolenFocus = document.activeElement;
+        expect(stolenFocus).toBe(input);
+
+        // navigate and verify wrapper is re-focused
+        router.navigate({ name: "Place", params: { name: "Hawaii" } });
+        setTimeout(() => {
+          const postNavFocus = document.activeElement;
+          expect(postNavFocus).toBe(wrapper);
+          done();
+        }, 25);
       }, 25);
-    }, 25);
+    });
   });
 
   it("isn't affected by prop changes", done => {
     vueWrapper = new Vue({
       template: `
         <div>
-          <main v-curi-focus="$curi.response" tabIndex="-1" :class="wat">
+          <main
+            v-curi-focus="{ key: $curi.response }"
+            tabIndex="-1"
+            :class="wat"
+          >
             <input />
           </main>
         </div>
@@ -166,6 +173,168 @@ describe("curi-focus directive", () => {
     }, 25);
   });
 
+  describe("preserve", () => {
+    describe("false (default)", () => {
+      it("re-focuses for new response re-renders", done => {
+        vueWrapper = new Vue({
+          template: `
+            <div>
+              <main
+                v-curi-focus="{ key: $curi.response }"
+                tabIndex="-1"
+              >
+                <input />
+              </main>
+            </div>
+          `,
+          el: node
+        });
+
+        setTimeout(() => {
+          const input = document.querySelector("input");
+          const wrapper = input.parentElement;
+          const initialFocused = document.activeElement;
+
+          expect(wrapper).toBe(initialFocused);
+
+          // steal the focus
+          input.focus();
+          const stolenFocus = document.activeElement;
+          expect(input).toBe(stolenFocus);
+
+          // navigate and verify wrapper is re-focused
+          router.navigate({ name: "Place", params: { name: "maybe" } });
+
+          setTimeout(() => {
+            const postNavFocus = document.activeElement;
+            expect(wrapper).toBe(postNavFocus);
+            done();
+          }, 25);
+        }, 25);
+      });
+    });
+
+    describe("true", () => {
+      it("does not focus ref if something is already ", done => {
+        vueWrapper = new Vue({
+          template: `
+            <div>
+              <main
+                v-curi-focus="{ key: $curi.response, preserve: true }"
+                tabIndex="-1"
+              >
+                <input />
+              </main>
+            </div>
+          `,
+          el: node
+        });
+
+        setTimeout(() => {
+          const input = document.querySelector("input");
+          const wrapper = input.parentElement;
+          const initialFocused = document.activeElement;
+
+          expect(wrapper).toBe(initialFocused);
+
+          // steal the focus
+          input.focus();
+          const stolenFocus = document.activeElement;
+          expect(input).toBe(stolenFocus);
+
+          // navigate and verify wrapper is re-focused
+          router.navigate({ name: "Place", params: { name: "maybe" } });
+
+          setTimeout(() => {
+            const postNavFocus = document.activeElement;
+            expect(postNavFocus).toBe(input);
+            done();
+          }, 25);
+        }, 25);
+      });
+    });
+  });
+
+  describe("preventScroll", () => {
+    const realFocus = HTMLElement.prototype.focus;
+    let fakeFocus;
+
+    beforeEach(() => {
+      fakeFocus = HTMLElement.prototype.focus = jest.fn();
+    });
+
+    afterEach(() => {
+      fakeFocus.mockReset();
+      HTMLElement.prototype.focus = realFocus;
+    });
+
+    it("calls focus({ preventScroll: false }} when not provided", done => {
+      vueWrapper = new Vue({
+        template: `
+          <div>
+            <main
+              v-curi-focus="{ key: $curi.response }"
+              tabIndex="-1"
+            >
+              <input />
+            </main>
+          </div>
+        `,
+        el: node
+      });
+      setTimeout(() => {
+        expect(fakeFocus.mock.calls[0][0]).toMatchObject({
+          preventScroll: false
+        });
+        done();
+      }, 25);
+    });
+
+    it("calls focus({ preventScroll: true }} when preventScroll = true", done => {
+      vueWrapper = new Vue({
+        template: `
+          <div>
+            <main
+              v-curi-focus="{ key: $curi.response, preventScroll: true }"
+              tabIndex="-1"
+            >
+              <input />
+            </main>
+          </div>
+        `,
+        el: node
+      });
+      setTimeout(() => {
+        expect(fakeFocus.mock.calls[0][0]).toMatchObject({
+          preventScroll: true
+        });
+        done();
+      }, 25);
+    });
+
+    it("calls focus({ preventScroll: false }} when preventScroll = false", done => {
+      vueWrapper = new Vue({
+        template: `
+          <div>
+            <main
+              v-curi-focus="{ key: $curi.response, preventScroll: false }"
+              tabIndex="-1"
+            >
+              <input />
+            </main>
+          </div>
+        `,
+        el: node
+      });
+      setTimeout(() => {
+        expect(fakeFocus.mock.calls[0][0]).toMatchObject({
+          preventScroll: false
+        });
+        done();
+      }, 25);
+    });
+  });
+
   describe("tabIndex", () => {
     it("warns when element with directive does not have a tabIndex attribute", () => {
       const realWarn = console.warn;
@@ -174,7 +343,7 @@ describe("curi-focus directive", () => {
       vueWrapper = new Vue({
         template: `
           <div>
-            <main v-curi-focus="$curi.response" />
+            <main v-curi-focus="{ key: $curi.response }" />
           </div>
         `,
         el: node
@@ -193,7 +362,7 @@ describe("curi-focus directive", () => {
           <div>
             <input
               type="text"
-              v-curi-focus="$curi.response"
+              v-curi-focus="{ key: $curi.response }"
             />
           </div>
         `,

--- a/packages/vue/types/focus.d.ts
+++ b/packages/vue/types/focus.d.ts
@@ -1,5 +1,10 @@
 import Vue, { DirectiveOptions } from "vue";
 export interface FocusComponent extends Vue {
 }
+export interface FocusDirectiveProperties {
+    key: any;
+    preventScroll?: boolean;
+    preserve?: boolean;
+}
 declare const focusDirection: DirectiveOptions;
 export default focusDirection;

--- a/packages/vue/types/index.d.ts
+++ b/packages/vue/types/index.d.ts
@@ -2,5 +2,6 @@ export { BlockComponent } from "./Block";
 export { LinkComponent } from "./Link";
 export { ReactiveResponse } from "./interface";
 export { CuriPluginOptions } from "./plugin";
+export { FocusDirectiveProperties } from "./focus";
 import CuriPlugin from "./plugin";
 export { CuriPlugin };


### PR DESCRIPTION
Instead of passing a unique object to the directive, pass an object with `key`, `preserve` and `preventScroll`  properties.

When the `key` changes, the element will be re-focused.

When `preserve` is `true` (default `false`), the element will not be focused if one of its children is already focused.

When `preventScroll` is `true` (default `false`), the element will not be scrolled to when it is focused (requires browser support for the option).