### PR TITLE
Re-use state object for curiProvider() component's context

### DIFF
--- a/packages/react-universal/.size-snapshot.json
+++ b/packages/react-universal/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-universal.es.js": {
-    "bundled": 5471,
-    "minified": 2741,
-    "gzipped": 1083,
+    "bundled": 5304,
+    "minified": 2676,
+    "gzipped": 1062,
     "treeshaked": {
       "rollup": {
         "code": 304,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-react-universal.js": {
-    "bundled": 5749,
-    "minified": 2966,
-    "gzipped": 1166
+    "bundled": 5582,
+    "minified": 2901,
+    "gzipped": 1144
   },
   "dist/curi-react-universal.umd.js": {
-    "bundled": 6210,
-    "minified": 2809,
-    "gzipped": 1140
+    "bundled": 6037,
+    "minified": 2744,
+    "gzipped": 1120
   },
   "dist/curi-react-universal.min.js": {
-    "bundled": 5849,
-    "minified": 2521,
-    "gzipped": 994
+    "bundled": 5676,
+    "minified": 2456,
+    "gzipped": 974
   }
 }

--- a/packages/react-universal/.size-snapshot.json
+++ b/packages/react-universal/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-universal.es.js": {
-    "bundled": 5578,
-    "minified": 2760,
-    "gzipped": 1097,
+    "bundled": 5471,
+    "minified": 2741,
+    "gzipped": 1083,
     "treeshaked": {
       "rollup": {
         "code": 304,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-react-universal.js": {
-    "bundled": 5856,
-    "minified": 2985,
-    "gzipped": 1180
+    "bundled": 5749,
+    "minified": 2966,
+    "gzipped": 1166
   },
   "dist/curi-react-universal.umd.js": {
-    "bundled": 6321,
-    "minified": 2835,
-    "gzipped": 1157
+    "bundled": 6210,
+    "minified": 2809,
+    "gzipped": 1140
   },
   "dist/curi-react-universal.min.js": {
-    "bundled": 5960,
-    "minified": 2547,
-    "gzipped": 1010
+    "bundled": 5849,
+    "minified": 2521,
+    "gzipped": 994
   }
 }

--- a/packages/react-universal/CHANGELOG.md
+++ b/packages/react-universal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Component returned by `curiProvider()` fully stores `emitted` value in state.
+
 ## 1.0.0-beta.3
 
 * Revert dual-mode (not ready yet!).

--- a/packages/react-universal/src/curiProvider.tsx
+++ b/packages/react-universal/src/curiProvider.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { Provider } from "./Context";
 
-import {
-  CuriRouter,
-  CurrentResponse,
-  Emitted,
-  RemoveObserver
-} from "@curi/router";
+import { CuriRouter, Emitted } from "@curi/router";
 
 export type CuriRenderFn = (props: Emitted) => React.ReactNode;
 
@@ -15,7 +10,7 @@ export interface RouterProps {
 }
 
 export interface RouterState {
-  emitted: CurrentResponse;
+  emitted: Emitted;
 }
 
 export default function curiProvider(router: CuriRouter) {
@@ -26,7 +21,10 @@ export default function curiProvider(router: CuriRouter) {
     constructor(props: RouterProps) {
       super(props);
       this.state = {
-        emitted: router.current()
+        emitted: {
+          ...router.current(),
+          router
+        }
       };
     }
 
@@ -39,7 +37,7 @@ export default function curiProvider(router: CuriRouter) {
         ({ response, navigation }) => {
           if (!this.removed) {
             this.setState({
-              emitted: { response, navigation }
+              emitted: { response, navigation, router }
             });
           }
         },
@@ -57,10 +55,11 @@ export default function curiProvider(router: CuriRouter) {
 
     render() {
       const { children } = this.props;
-      const { response, navigation } = this.state.emitted;
-      const value = { router, response, navigation };
-
-      return <Provider value={value}>{children(value)}</Provider>;
+      return (
+        <Provider value={this.state.emitted}>
+          {children(this.state.emitted)}
+        </Provider>
+      );
     }
   };
 }

--- a/packages/react-universal/src/curiProvider.tsx
+++ b/packages/react-universal/src/curiProvider.tsx
@@ -34,11 +34,9 @@ export default function curiProvider(router: CuriRouter) {
 
     setupRespond(router: CuriRouter) {
       this.stopResponding = router.observe(
-        ({ response, navigation }) => {
+        (emitted: Emitted) => {
           if (!this.removed) {
-            this.setState({
-              emitted: { response, navigation, router }
-            });
+            this.setState({ emitted });
           }
         },
         { initial: false }

--- a/packages/react-universal/types/curiProvider.d.ts
+++ b/packages/react-universal/types/curiProvider.d.ts
@@ -1,11 +1,11 @@
 import React from "react";
-import { CuriRouter, CurrentResponse, Emitted } from "@curi/router";
+import { CuriRouter, Emitted } from "@curi/router";
 export declare type CuriRenderFn = (props: Emitted) => React.ReactNode;
 export interface RouterProps {
     children: CuriRenderFn;
 }
 export interface RouterState {
-    emitted: CurrentResponse;
+    emitted: Emitted;
 }
 export default function curiProvider(router: CuriRouter): {
     new (props: RouterProps): {


### PR DESCRIPTION
Previously, a new object was created every time the `curiProvider()`'s component's `render()` function was called. Now, this object is stored in state so that it is re-used for re-renders not triggered by new responses.