### PR TITLE
Don't call setState() for unmounted Links

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 7725,
-    "minified": 3658,
-    "gzipped": 1519,
+    "bundled": 7972,
+    "minified": 3741,
+    "gzipped": 1545,
     "treeshaked": {
       "rollup": {
-        "code": 2191,
+        "code": 2274,
         "import_statements": 69
       },
       "webpack": {
-        "code": 3251
+        "code": 3334
       }
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 8050,
-    "minified": 3923,
-    "gzipped": 1619
+    "bundled": 8297,
+    "minified": 4006,
+    "gzipped": 1645
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 14527,
-    "minified": 5989,
-    "gzipped": 2107
+    "bundled": 16630,
+    "minified": 6806,
+    "gzipped": 2241
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 13529,
-    "minified": 5342,
-    "gzipped": 1784
+    "bundled": 15632,
+    "minified": 6159,
+    "gzipped": 1912
   }
 }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Guard `setState()` calls for unmounted `<Link>`.
+
 ## 1.1.1
 
 * Add `sideEffects: false` hint for Webpack.

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -36,6 +36,8 @@ export interface LinkState {
 }
 
 class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
+  removed: boolean;
+
   state = {
     navigating: false
   };
@@ -53,9 +55,13 @@ class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
       // only trigger re-renders when children uses state
       if (typeof this.props.children === "function") {
         cancelled = finished = () => {
-          this.setState({ navigating: false });
+          if (!this.removed) {
+            this.setState({ navigating: false });
+          }
         };
-        this.setState({ navigating: true });
+        if (!this.removed) {
+          this.setState({ navigating: true });
+        }
       }
       router.navigate({
         name,
@@ -102,10 +108,14 @@ class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
         ref={forwardedRef}
       >
         {typeof children === "function"
-          ? children(this.state.navigating)
+          ? (children as NavigatingChildren)(this.state.navigating)
           : children}
       </Anchor>
     );
+  }
+
+  componentWillUnmount() {
+    this.removed = true;
   }
 }
 

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -450,7 +450,6 @@ describe("<Link>", () => {
                       console.error = realError;
                       done();
                     });
-                    //});
                   }, 100);
                 });
               }

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -428,6 +428,68 @@ describe("<Link>", () => {
           { initial: false }
         );
       });
+
+      it("does not call setState if component has unmounted", done => {
+        const realError = console.error;
+        const mockError = jest.fn();
+        console.error = mockError;
+
+        const history = InMemory();
+        const router = curi(history, [
+          { name: "Test", path: "test" },
+          {
+            name: "Slow",
+            path: "slow",
+            resolve: {
+              test: () => {
+                return new Promise(resolve => {
+                  setTimeout(() => {
+                    resolve("Finally finished");
+                    setTimeout(() => {
+                      expect(mockError.mock.calls.length).toBe(0);
+                      console.error = realError;
+                      done();
+                    });
+                    //});
+                  }, 100);
+                });
+              }
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const Router = curiProvider(router);
+
+        ReactDOM.render(
+          <Router>
+            {() => (
+              <Link to="Slow">
+                {navigating => {
+                  return <div>{navigating.toString()}</div>;
+                }}
+              </Link>
+            )}
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.textContent).toBe("false");
+        const leftClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        Simulate.click(a, leftClickEvent);
+
+        // unmount the Link to verify that it doesn't call setState()
+        ReactDOM.unmountComponentAtNode(node);
+      });
     });
 
     it("includes hash, query, and state in location passed to history.navigate", () => {

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 5048,
-    "minified": 2339,
-    "gzipped": 1044,
+    "bundled": 5295,
+    "minified": 2422,
+    "gzipped": 1077,
     "treeshaked": {
       "rollup": {
-        "code": 2139,
+        "code": 2222,
         "import_statements": 119
       },
       "webpack": {
-        "code": 3222
+        "code": 3305
       }
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 5346,
-    "minified": 2578,
-    "gzipped": 1141
+    "bundled": 5593,
+    "minified": 2661,
+    "gzipped": 1175
   }
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Guard `setState()` calls for unmounted `<Link>`.
+
 ## 1.0.1
 
 * Add `sideEffects: false` hint for Webpack.

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -33,6 +33,8 @@ export interface LinkState {
 }
 
 class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
+  removed: boolean;
+
   state = {
     navigating: false
   };
@@ -53,9 +55,13 @@ class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
       let cancelled, finished;
       if (typeof children === "function") {
         cancelled = finished = () => {
-          this.setState({ navigating: false });
+          if (!this.removed) {
+            this.setState({ navigating: false });
+          }
         };
-        this.setState({ navigating: true });
+        if (!this.removed) {
+          this.setState({ navigating: true });
+        }
       }
       router.navigate({
         name,
@@ -90,10 +96,14 @@ class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
     return (
       <Anchor {...rest} onPress={this.pressHandler} ref={forwardedRef}>
         {typeof children === "function"
-          ? children(this.state.navigating)
+          ? (children as NavigatingChildren)(this.state.navigating)
           : children}
       </Anchor>
     );
+  }
+
+  componentWillUnmount() {
+    this.removed = true;
   }
 }
 


### PR DESCRIPTION
If the `<Link>` unmounts before navigation is finished, it shouldn't call `setState()`.