### PR TITLE
Make async navigation cancellable

### DIFF
--- a/examples/react/async-nav/src/index.js
+++ b/examples/react/async-nav/src/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import Browser from "@hickory/browser";
 import { curi } from "@curi/router";
-import { curiProvider } from "@curi/react-dom";
+import { curiProvider, Navigating } from "@curi/react-dom";
 
 import routes from "./routes";
 import Controls from "./components/Controls";
@@ -18,10 +18,23 @@ router.once(() => {
         const { body: Body, data } = response;
 
         return (
-          <div>
+          <React.Fragment>
             <Controls />
+            <Navigating>
+              {cancel => {
+                return cancel ? (
+                  <button
+                    onClick={() => {
+                      cancel();
+                    }}
+                  >
+                    cancel navigation
+                  </button>
+                ) : null;
+              }}
+            </Navigating>
             <Body response={response} />
-          </div>
+          </React.Fragment>
         );
       }}
     </Router>,

--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 1645
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 14802,
-    "minified": 6072,
-    "gzipped": 2109
+    "bundled": 16485,
+    "minified": 6784,
+    "gzipped": 2228
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 13804,
-    "minified": 5425,
-    "gzipped": 1786
+    "bundled": 15487,
+    "minified": 6137,
+    "gzipped": 1902
   }
 }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `<Navigation>` component, which lets the user know when asynchronous routes are navigating and cancel the navigation.
+
 ## 1.1.2
 
 * Guard `setState()` calls for unmounted `<Link>`.

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `<Navigation>` component, which lets the user know when asynchronous routes are navigating and cancel the navigation.
+
 ## 1.0.2
 
 * Guard `setState()` calls for unmounted `<Link>`.

--- a/packages/react-universal/.size-snapshot.json
+++ b/packages/react-universal/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "dist/curi-react-universal.es.js": {
-    "bundled": 5304,
-    "minified": 2676,
-    "gzipped": 1062,
+    "bundled": 6805,
+    "minified": 3469,
+    "gzipped": 1207,
     "treeshaked": {
       "rollup": {
-        "code": 304,
+        "code": 441,
         "import_statements": 21
       },
       "webpack": {
-        "code": 1421
+        "code": 1435
       }
     }
   },
   "dist/curi-react-universal.js": {
-    "bundled": 5582,
-    "minified": 2901,
-    "gzipped": 1144
+    "bundled": 7104,
+    "minified": 3713,
+    "gzipped": 1295
   },
   "dist/curi-react-universal.umd.js": {
-    "bundled": 6037,
-    "minified": 2744,
-    "gzipped": 1120
+    "bundled": 7643,
+    "minified": 3469,
+    "gzipped": 1254
   },
   "dist/curi-react-universal.min.js": {
-    "bundled": 5676,
-    "minified": 2456,
-    "gzipped": 974
+    "bundled": 7282,
+    "minified": 3181,
+    "gzipped": 1106
   }
 }

--- a/packages/react-universal/.size-snapshot.json
+++ b/packages/react-universal/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-universal.es.js": {
-    "bundled": 6805,
-    "minified": 3469,
-    "gzipped": 1207,
+    "bundled": 6794,
+    "minified": 3460,
+    "gzipped": 1205,
     "treeshaked": {
       "rollup": {
         "code": 441,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-react-universal.js": {
-    "bundled": 7104,
-    "minified": 3713,
-    "gzipped": 1295
+    "bundled": 7093,
+    "minified": 3704,
+    "gzipped": 1292
   },
   "dist/curi-react-universal.umd.js": {
-    "bundled": 7643,
-    "minified": 3469,
-    "gzipped": 1254
+    "bundled": 7632,
+    "minified": 3460,
+    "gzipped": 1250
   },
   "dist/curi-react-universal.min.js": {
-    "bundled": 7282,
-    "minified": 3181,
-    "gzipped": 1106
+    "bundled": 7271,
+    "minified": 3172,
+    "gzipped": 1102
   }
 }

--- a/packages/react-universal/CHANGELOG.md
+++ b/packages/react-universal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `<Navigation>` component, which lets the user know when asynchronous routes are navigating and cancel the navigation.
+
 ## 1.0.1
 
 * Add `sideEffects: false` hint for Webpack.

--- a/packages/react-universal/src/Navigating.tsx
+++ b/packages/react-universal/src/Navigating.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Curious } from "./Context";
+
+import { ReactNode } from "react";
+import {
+  CuriRouter,
+  CancelActiveNavigation,
+  RemoveCancellable
+} from "@curi/router";
+
+export interface NavigatingProps {
+  children(cancel: CancelActiveNavigation | void): ReactNode;
+}
+
+interface BaseNavigatingProps extends NavigatingProps {
+  router?: CuriRouter;
+}
+
+interface NavigatingState {
+  cancelFn: CancelActiveNavigation | void;
+}
+
+class BaseNavigating extends React.Component<
+  BaseNavigatingProps,
+  NavigatingState
+> {
+  removed: boolean;
+  stopCancelling: RemoveCancellable;
+
+  shouldComponentUpdate(
+    nextProps: BaseNavigatingProps,
+    nextState: NavigatingState
+  ) {
+    return (
+      nextState.cancelFn !== this.state.cancelFn ||
+      nextProps.children === this.props.children
+    );
+  }
+
+  constructor(props: BaseNavigatingProps) {
+    super(props);
+    this.state = {
+      cancelFn: undefined
+    };
+  }
+
+  render() {
+    const { cancelFn } = this.state;
+    return this.props.children(cancelFn);
+  }
+
+  componentDidMount() {
+    this.stopCancelling = this.props.router.whileNavigating(
+      (cancelFn: CancelActiveNavigation) => {
+        if (!this.removed) {
+          this.setState({
+            cancelFn
+          });
+        }
+      }
+    );
+  }
+
+  componentWillUnmount() {
+    this.removed = true;
+    if (this.stopCancelling) {
+      this.stopCancelling();
+    }
+  }
+}
+
+const Navigating = (props: NavigatingProps) => {
+  return (
+    <Curious>
+      {({ router }) => <BaseNavigating {...props} router={router} />}
+    </Curious>
+  );
+};
+
+export default Navigating;

--- a/packages/react-universal/src/Navigating.tsx
+++ b/packages/react-universal/src/Navigating.tsx
@@ -50,7 +50,7 @@ class BaseNavigating extends React.Component<
   }
 
   componentDidMount() {
-    this.stopCancelling = this.props.router.whileNavigating(
+    this.stopCancelling = this.props.router.cancel(
       (cancelFn: CancelActiveNavigation) => {
         if (!this.removed) {
           this.setState({

--- a/packages/react-universal/src/index.ts
+++ b/packages/react-universal/src/index.ts
@@ -1,10 +1,12 @@
 export { ActiveProps } from "./Active";
 export { BlockProps } from "./Block";
 export { RouterProps, CuriRenderFn } from "./curiProvider";
+export { NavigatingProps } from "./Navigating";
 
 import Active from "./Active";
 import Block from "./Block";
 import curiProvider from "./curiProvider";
 import { Curious } from "./Context";
+import Navigating from "./Navigating";
 
-export { Active, Block, curiProvider, Curious };
+export { Active, Block, curiProvider, Curious, Navigating };

--- a/packages/react-universal/tests/Navigating.spec.tsx
+++ b/packages/react-universal/tests/Navigating.spec.tsx
@@ -1,0 +1,190 @@
+import "jest";
+import React from "react";
+import ReactDOM from "react-dom";
+import InMemory from "@hickory/in-memory";
+import { curi } from "@curi/router";
+
+// resolved by jest
+import { curiProvider, Navigating } from "@curi/react-universal";
+
+describe("<Navigating>", () => {
+  let node;
+  const routes = [
+    { name: "Home", path: "" },
+    { name: "Sync", path: "sync" },
+    {
+      name: "Slow",
+      path: "slow",
+      resolve: {
+        data() {
+          return new Promise(resolve => {
+            setTimeout(resolve, 1000, "slow");
+          });
+        }
+      }
+    },
+    {
+      name: "Fast",
+      path: "fast",
+      resolve: {
+        data() {
+          return new Promise(resolve => {
+            setTimeout(resolve, 50, "slow");
+          });
+        }
+      }
+    },
+    { name: "Catch All", path: "(.*)" }
+  ];
+
+  beforeEach(() => {
+    node = document.createElement("div");
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  describe("mount", () => {
+    it("cancel is undefined", () => {
+      const history = InMemory();
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+      ReactDOM.render(
+        <Router>
+          {() => (
+            <Navigating>
+              {cancel => {
+                expect(cancel).toBeUndefined();
+                return null;
+              }}
+            </Navigating>
+          )}
+        </Router>,
+        node
+      );
+    });
+  });
+
+  describe("while navigating", () => {
+    describe("to synchronous routes", () => {
+      it("cancel is undefined", () => {
+        const history = InMemory();
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+        const children = jest.fn(() => null);
+        ReactDOM.render(
+          <Router>{() => <Navigating>{children}</Navigating>}</Router>,
+          node
+        );
+        const { response: beforeResponse } = router.current();
+        expect(beforeResponse.name).toBe("Home");
+
+        expect(children.mock.calls.length).toBe(1);
+
+        router.navigate({ name: "Sync" });
+
+        expect(children.mock.calls.length).toBe(2);
+        const { response: afterResponse } = router.current();
+        expect(afterResponse.name).toBe("Sync");
+      });
+    });
+
+    describe("to asynchronous routes", () => {
+      it("cancel is a function", done => {
+        const history = InMemory();
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+        const children = jest.fn(() => null);
+        ReactDOM.render(
+          <Router>{() => <Navigating>{children}</Navigating>}</Router>,
+          node
+        );
+        const { response: beforeResponse } = router.current();
+        expect(beforeResponse.name).toBe("Home");
+
+        router.navigate({ name: "Fast" });
+
+        expect(typeof children.mock.calls[1][0]).toBe("function");
+        router.once(
+          ({ response }) => {
+            expect(response.name).toBe("Fast");
+            expect(children.mock.calls[2][0]).toBeUndefined();
+            done();
+          },
+          { initial: false }
+        );
+      });
+    });
+  });
+
+  describe("calling the cancel function", () => {
+    it("cancels the navigation", done => {
+      const history = InMemory();
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+      let cancelFn;
+      const children = jest.fn(cancel => {
+        if (cancel === undefined) {
+          return null;
+        }
+        cancelFn = cancel;
+        return null;
+      });
+      ReactDOM.render(
+        <Router>{() => <Navigating>{children}</Navigating>}</Router>,
+        node
+      );
+      const { response: beforeResponse } = router.current();
+      expect(beforeResponse.name).toBe("Home");
+      expect(children.mock.calls[0][0]).toBeUndefined();
+
+      router.navigate({ name: "Slow" });
+
+      expect(children.mock.calls[1][0]).toBeDefined();
+
+      cancelFn();
+      setTimeout(() => {
+        expect(children.mock.calls[2][0]).toBeUndefined();
+        done();
+      }, 25);
+    });
+
+    it("does nothing if calling function after navigation finishes", done => {
+      const history = InMemory();
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+      let cancelFn;
+      const children = jest.fn(cancel => {
+        if (cancel === undefined) {
+          return null;
+        }
+        cancelFn = cancel;
+        return null;
+      });
+      ReactDOM.render(
+        <Router>{() => <Navigating>{children}</Navigating>}</Router>,
+        node
+      );
+      const { response: beforeResponse } = router.current();
+      expect(beforeResponse.name).toBe("Home");
+
+      router.navigate({ name: "Fast" });
+      router.once(
+        ({ response }) => {
+          expect(response.name).toBe("Fast");
+          const childrenCalls = children.mock.calls.length;
+
+          cancelFn();
+
+          setTimeout(() => {
+            // children is not called against after cancelling
+            expect(children.mock.calls.length).toBe(childrenCalls);
+            done();
+          }, 25);
+        },
+        { initial: false }
+      );
+    });
+  });
+});

--- a/packages/react-universal/types/Navigating.d.ts
+++ b/packages/react-universal/types/Navigating.d.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from "react";
+import { CancelActiveNavigation } from "@curi/router";
+export interface NavigatingProps {
+    children(cancel: CancelActiveNavigation | void): ReactNode;
+}
+declare const Navigating: (props: NavigatingProps) => JSX.Element;
+export default Navigating;

--- a/packages/react-universal/types/index.d.ts
+++ b/packages/react-universal/types/index.d.ts
@@ -1,8 +1,10 @@
 export { ActiveProps } from "./Active";
 export { BlockProps } from "./Block";
 export { RouterProps, CuriRenderFn } from "./curiProvider";
+export { NavigatingProps } from "./Navigating";
 import Active from "./Active";
 import Block from "./Block";
 import curiProvider from "./curiProvider";
 import { Curious } from "./Context";
-export { Active, Block, curiProvider, Curious };
+import Navigating from "./Navigating";
+export { Active, Block, curiProvider, Curious, Navigating };

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 20225,
-    "minified": 7685,
-    "gzipped": 3054,
+    "bundled": 21420,
+    "minified": 7974,
+    "gzipped": 3149,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 20484,
-    "minified": 7890,
-    "gzipped": 3131
+    "bundled": 21679,
+    "minified": 8179,
+    "gzipped": 3225
   },
   "dist/curi-router.umd.js": {
-    "bundled": 33704,
-    "minified": 10112,
-    "gzipped": 4225
+    "bundled": 35055,
+    "minified": 10400,
+    "gzipped": 4301
   },
   "dist/curi-router.min.js": {
-    "bundled": 31910,
-    "minified": 8958,
-    "gzipped": 3739
+    "bundled": 33261,
+    "minified": 9246,
+    "gzipped": 3813
   }
 }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 21420,
-    "minified": 7974,
-    "gzipped": 3149,
+    "bundled": 21411,
+    "minified": 7965,
+    "gzipped": 3142,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 21679,
-    "minified": 8179,
-    "gzipped": 3225
+    "bundled": 21670,
+    "minified": 8170,
+    "gzipped": 3218
   },
   "dist/curi-router.umd.js": {
-    "bundled": 35055,
-    "minified": 10400,
-    "gzipped": 4301
+    "bundled": 35046,
+    "minified": 10391,
+    "gzipped": 4295
   },
   "dist/curi-router.min.js": {
-    "bundled": 33261,
-    "minified": 9246,
-    "gzipped": 3813
+    "bundled": 33252,
+    "minified": 9237,
+    "gzipped": 3807
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Add `router.whileNavigating()` function, which let's a function know what the router is navigating and gives it the opportunity to cancel the navigation.
 * Add `globals` option when creating router. This value will be available to `route.resolve` functions and `route.response()`.
 * Export `prepareRoutes()` function to pre-build routes. Pre-building routes is encouraged and a warning message will be displayed to users who do not pre-build. In `@curi/router` v2, pre-building routes will be required.
 * Throw if routes have duplicate names.

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Add `router.whileNavigating()` function, which let's a function know what the router is navigating and gives it the opportunity to cancel the navigation.
+* Add `router.cancel()` function, which let's a function know what the router is navigating and gives it the opportunity to cancel the navigation.
 * Add `globals` option when creating router. This value will be available to `route.resolve` functions and `route.response()`.
 * Export `prepareRoutes()` function to pre-build routes. Pre-building routes is encouraged and a warning message will be displayed to users who do not pre-build. In `@curi/router` v2, pre-building routes will be required.
 * Throw if routes have duplicate names.

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -258,7 +258,7 @@ export default function createRouter(
         oneTimers.push(fn);
       }
     },
-    whileNavigating(fn: Cancellable): RemoveCancellable {
+    cancel(fn: Cancellable): RemoveCancellable {
       cancellers.push(fn);
       return () => {
         cancellers = cancellers.filter(can => {

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -5,7 +5,7 @@ import matchLocation from "./matchLocation";
 import resolveMatchedRoute from "./resolveMatchedRoute";
 import { privatePrepareRoutes } from "./prepareRoutes";
 
-import { History, PendingNavigation } from "@hickory/root";
+import { History, PendingNavigation, Action } from "@hickory/root";
 
 import {
   RouteDescriptor,
@@ -25,7 +25,9 @@ import {
   RemoveObserver,
   CurrentResponse,
   Navigation,
-  NavigationDetails
+  NavigationDetails,
+  Cancellable,
+  RemoveCancellable
 } from "./types/curi";
 
 export default function createRouter(
@@ -62,6 +64,7 @@ export default function createRouter(
 
   let observers: Array<Observer> = [];
   const oneTimers: Array<Observer> = [];
+  let cancellers: Array<Cancellable> = [];
 
   function setupRoutesAndInteractions(userRoutes?: UserRoutes): void {
     if (userRoutes) {
@@ -86,10 +89,7 @@ export default function createRouter(
   }
 
   function navigationHandler(pendingNav: PendingNavigation): void {
-    if (activeNavigation) {
-      activeNavigation.cancel(pendingNav.action);
-      activeNavigation.cancelled = true;
-    }
+    cancelActiveNavigation(pendingNav.action);
     activeNavigation = pendingNav;
 
     const navigation: Navigation = {
@@ -126,6 +126,7 @@ export default function createRouter(
     if (match.route.sync) {
       finalizeResponseAndEmit(match as Match, pendingNav, navigation, null);
     } else {
+      activateCancellers(pendingNav.action);
       resolveMatchedRoute(match as Match, external).then(
         (resolved: ResolveResults) => {
           if (pendingNav.cancelled) {
@@ -148,6 +149,7 @@ export default function createRouter(
     navigation: Navigation,
     resolved: ResolveResults | null
   ) {
+    deactivateCancellers();
     const response = finishResponse(
       match,
       routeInteractions,
@@ -197,6 +199,40 @@ export default function createRouter(
     }
   }
 
+  let canCancel: boolean;
+  function activateCancellers(action: Action) {
+    if (cancellers.length) {
+      canCancel = true;
+      const cancel = () => {
+        cancelActiveNavigation(action);
+        deactivateCancellers();
+        if (cancelCallback) {
+          cancelCallback();
+        }
+        resetCallbacks();
+      };
+      cancellers.forEach(fn => {
+        fn(cancel);
+      });
+    }
+  }
+
+  function deactivateCancellers() {
+    if (canCancel) {
+      canCancel = false;
+      cancellers.forEach(fn => {
+        fn();
+      });
+    }
+  }
+
+  function cancelActiveNavigation(action: Action) {
+    if (activeNavigation) {
+      activeNavigation.cancel(action);
+      activeNavigation.cancelled = true;
+    }
+  }
+
   const router: CuriRouter = {
     route: routeInteractions,
     history,
@@ -221,6 +257,14 @@ export default function createRouter(
       } else {
         oneTimers.push(fn);
       }
+    },
+    whileNavigating(fn: Cancellable): RemoveCancellable {
+      cancellers.push(fn);
+      return () => {
+        cancellers = cancellers.filter(can => {
+          return can !== fn;
+        });
+      };
     },
     refresh(routes?: Array<RouteDescriptor>) {
       refreshing = true;

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -56,7 +56,7 @@ export interface CuriRouter {
   refresh: (routeArray?: UserRoutes) => void;
   observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
   once: (fn: Observer, options?: ResponseHandlerOptions) => void;
-  whileNavigating: (fn: Cancellable) => RemoveCancellable;
+  cancel: (fn: Cancellable) => RemoveCancellable;
   route: Interactions;
   history: History;
   current(): CurrentResponse;

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -23,6 +23,10 @@ export interface ResponseHandlerOptions {
 }
 export type RemoveObserver = () => void;
 
+export type CancelActiveNavigation = () => void;
+export type Cancellable = (cancelActive?: CancelActiveNavigation) => void;
+export type RemoveCancellable = () => void;
+
 export interface RouterOptions {
   route?: Array<Interaction>;
   sideEffects?: Array<Observer>;
@@ -52,6 +56,7 @@ export interface CuriRouter {
   refresh: (routeArray?: UserRoutes) => void;
   observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
   once: (fn: Observer, options?: ResponseHandlerOptions) => void;
+  whileNavigating: (fn: Cancellable) => RemoveCancellable;
   route: Interactions;
   history: History;
   current(): CurrentResponse;

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -34,5 +34,8 @@ export {
   ResponseHandlerOptions,
   RemoveObserver,
   Navigation,
-  CurrentResponse
+  CurrentResponse,
+  Cancellable,
+  CancelActiveNavigation,
+  RemoveCancellable
 } from "./curi";

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -1405,6 +1405,176 @@ describe("curi", () => {
     });
   });
 
+  describe("whileNavigating(fn)", () => {
+    it("does not call function for sync routes", () => {
+      const history = InMemory();
+      const routes = prepareRoutes([
+        { name: "Home", path: "" },
+        { name: "About", path: "about" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const cancellable = jest.fn();
+      router.whileNavigating(cancellable);
+
+      router.navigate({ name: "About" });
+
+      const { response } = router.current();
+      // just to verify that navigation did occur
+      expect(response.name).toBe("About");
+      expect(cancellable.mock.calls.length).toBe(0);
+    });
+
+    it("calls function with cancel fn when navigating to async routes", () => {
+      const history = InMemory();
+      const routes = prepareRoutes([
+        { name: "Home", path: "" },
+        {
+          name: "About",
+          path: "about",
+          resolve: {
+            wait: () => Promise.resolve("wait")
+          }
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const cancellable = jest.fn();
+      router.whileNavigating(cancellable);
+
+      router.navigate({ name: "About" });
+      // called immediately after navigation
+      expect(cancellable.mock.calls.length).toBe(1);
+      expect(typeof cancellable.mock.calls[0][0]).toBe("function");
+    });
+
+    describe("non-cancelled navigation", () => {
+      it("calls function with no args once async actions are complete", done => {
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Home", path: "" },
+          {
+            name: "About",
+            path: "about",
+            resolve: {
+              wait: () => Promise.resolve("wait")
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const cancellable = jest.fn();
+        router.whileNavigating(cancellable);
+
+        router.navigate({ name: "About" });
+
+        router.once(
+          ({ response }) => {
+            expect(response.name).toBe("About");
+            // second call is for deactivation
+            expect(cancellable.mock.calls.length).toBe(2);
+            expect(cancellable.mock.calls[1][0]).toBeUndefined();
+            done();
+          },
+          { initial: false }
+        );
+      });
+    });
+
+    describe("cancelling active navigation", () => {
+      it("deactivates immediately if cancel function is called", () => {
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Home", path: "" },
+          {
+            name: "About",
+            path: "about",
+            resolve: {
+              wait: () => Promise.resolve("wait")
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        let cancel;
+        const cancellable = jest.fn(cancelFn => {
+          cancel = cancelFn;
+        });
+        router.whileNavigating(cancellable);
+
+        router.navigate({ name: "About" });
+        // called immediately after navigation
+        expect(cancellable.mock.calls.length).toBe(1);
+        cancel();
+        // called after navigation is cancelled
+        expect(cancellable.mock.calls.length).toBe(2);
+      });
+
+      it("doesn't change locations", () => {
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Home", path: "" },
+          {
+            name: "About",
+            path: "about",
+            resolve: {
+              wait: () => Promise.resolve("wait")
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        let cancel;
+        const cancellable = jest.fn(cancelFn => {
+          cancel = cancelFn;
+        });
+        router.whileNavigating(cancellable);
+        const { response: beforeResponse } = router.current();
+        expect(beforeResponse.name).toBe("Home");
+
+        router.navigate({ name: "About" });
+        // called immediately after navigation
+        expect(cancellable.mock.calls.length).toBe(1);
+        cancel();
+        const { response: afterResponse } = router.current();
+        expect(afterResponse.name).toBe("Home");
+      });
+    });
+
+    it("returns a function to stop being called", () => {
+      const history = InMemory();
+      const routes = prepareRoutes([
+        { name: "Home", path: "" },
+        {
+          name: "About",
+          path: "about",
+          resolve: {
+            wait: () => Promise.resolve("wait")
+          }
+        },
+        {
+          name: "Contact",
+          path: "contact",
+          resolve: {
+            wait: () => Promise.resolve("wait")
+          }
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const cancellable = jest.fn();
+      const stopCancelling = router.whileNavigating(cancellable);
+
+      router.navigate({ name: "About" });
+      expect(cancellable.mock.calls.length).toBe(1);
+
+      stopCancelling();
+
+      router.navigate({ name: "Contact" });
+      expect(cancellable.mock.calls.length).toBe(1);
+    });
+  });
+
   describe("response.redirectTo", () => {
     it("triggers a replace navigation AFTER emitting initial response", done => {
       let callPosition = 0;

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -1405,7 +1405,7 @@ describe("curi", () => {
     });
   });
 
-  describe("whileNavigating(fn)", () => {
+  describe("cancel(fn)", () => {
     it("does not call function for sync routes", () => {
       const history = InMemory();
       const routes = prepareRoutes([
@@ -1415,7 +1415,7 @@ describe("curi", () => {
       ]);
       const router = curi(history, routes);
       const cancellable = jest.fn();
-      router.whileNavigating(cancellable);
+      router.cancel(cancellable);
 
       router.navigate({ name: "About" });
 
@@ -1440,7 +1440,7 @@ describe("curi", () => {
       ]);
       const router = curi(history, routes);
       const cancellable = jest.fn();
-      router.whileNavigating(cancellable);
+      router.cancel(cancellable);
 
       router.navigate({ name: "About" });
       // called immediately after navigation
@@ -1464,7 +1464,7 @@ describe("curi", () => {
         ]);
         const router = curi(history, routes);
         const cancellable = jest.fn();
-        router.whileNavigating(cancellable);
+        router.cancel(cancellable);
 
         router.navigate({ name: "About" });
 
@@ -1500,7 +1500,7 @@ describe("curi", () => {
         const cancellable = jest.fn(cancelFn => {
           cancel = cancelFn;
         });
-        router.whileNavigating(cancellable);
+        router.cancel(cancellable);
 
         router.navigate({ name: "About" });
         // called immediately after navigation
@@ -1528,7 +1528,7 @@ describe("curi", () => {
         const cancellable = jest.fn(cancelFn => {
           cancel = cancelFn;
         });
-        router.whileNavigating(cancellable);
+        router.cancel(cancellable);
         const { response: beforeResponse } = router.current();
         expect(beforeResponse.name).toBe("Home");
 
@@ -1563,7 +1563,7 @@ describe("curi", () => {
       ]);
       const router = curi(history, routes);
       const cancellable = jest.fn();
-      const stopCancelling = router.whileNavigating(cancellable);
+      const stopCancelling = router.cancel(cancellable);
 
       router.navigate({ name: "About" });
       expect(cancellable.mock.calls.length).toBe(1);

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -17,6 +17,9 @@ export interface ResponseHandlerOptions {
     initial?: boolean;
 }
 export declare type RemoveObserver = () => void;
+export declare type CancelActiveNavigation = () => void;
+export declare type Cancellable = (cancelActive?: CancelActiveNavigation) => void;
+export declare type RemoveCancellable = () => void;
 export interface RouterOptions {
     route?: Array<Interaction>;
     sideEffects?: Array<Observer>;
@@ -43,6 +46,7 @@ export interface CuriRouter {
     refresh: (routeArray?: UserRoutes) => void;
     observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
     once: (fn: Observer, options?: ResponseHandlerOptions) => void;
+    whileNavigating: (fn: Cancellable) => RemoveCancellable;
     route: Interactions;
     history: History;
     current(): CurrentResponse;

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -46,7 +46,7 @@ export interface CuriRouter {
     refresh: (routeArray?: UserRoutes) => void;
     observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
     once: (fn: Observer, options?: ResponseHandlerOptions) => void;
-    whileNavigating: (fn: Cancellable) => RemoveCancellable;
+    cancel: (fn: Cancellable) => RemoveCancellable;
     route: Interactions;
     history: History;
     current(): CurrentResponse;

--- a/packages/router/types/types/index.d.ts
+++ b/packages/router/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
 export { Route, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, AsyncGroup, Resolved, ResolveResults, CompiledRoute, CompiledRouteArray, UserRoutes } from "./route";
 export { Response, RawParams, Params, RedirectLocation, MatchResponseProperties, SettableResponseProperties } from "./response";
-export { CuriRouter, RouterOptions, Observer, Emitted, ResponseHandlerOptions, RemoveObserver, Navigation, CurrentResponse } from "./curi";
+export { CuriRouter, RouterOptions, Observer, Emitted, ResponseHandlerOptions, RemoveObserver, Navigation, CurrentResponse, Cancellable, CancelActiveNavigation, RemoveCancellable } from "./curi";

--- a/website/src/pages/Packages/react-dom.js
+++ b/website/src/pages/Packages/react-dom.js
@@ -563,6 +563,57 @@ const router = curi(history, routes, {
             </Section>
           </Section>
 
+          <Section title={<Cmp>Navigating</Cmp>} id="Navigating">
+            <Explanation>
+              <p>
+                The <Cmp>Navigating</Cmp> component lets you know when the
+                application is navigating and let users cancel the navigation.
+                Its <IJS>children</IJS> prop is a render-invoked function that
+                is passed a function to cancel the navigation.
+              </p>
+              <p>
+                When navigation starts, <IJS>children()</IJS> will be called
+                with a function that will cancel navigation when it is called.
+              </p>
+              <p>
+                When navigation finishes, <IJS>children()</IJS> will be called
+                with no arguments.
+              </p>
+            </Explanation>
+            <CodeBlock lang="jsx">
+              {`import { Navigating } from "@curi/react-dom";
+              
+<Navigating>
+  {cancel => {
+    if (cancel === undefined) {
+      return null;
+    }
+    return (
+      <button onClick={cancel}>
+        Cancel Navigation
+      </button>
+    );
+  }}
+</Navigating>`}
+            </CodeBlock>
+            <Section tag="h3" title="Props" id="Navigating-props">
+              <Subsection tag="h4" title="children()" id="Navigating-children">
+                <Explanation>
+                  <p>
+                    A function that returns a React node. The function will be
+                    called with a <IJS>cancel</IJS> function when navigation
+                    starts and with no arguments when the navigation is
+                    finished.
+                  </p>
+                  <p>
+                    Calling the <IJS>cancel</IJS> function after the navigation
+                    is finished has no effect.
+                  </p>
+                </Explanation>
+              </Subsection>
+            </Section>
+          </Section>
+
           <Section title={<Cmp>Block</Cmp>} id="Block">
             <Explanation>
               <p>

--- a/website/src/pages/Packages/react-native.js
+++ b/website/src/pages/Packages/react-native.js
@@ -450,6 +450,57 @@ const router = curi(history, routes, {
             </Section>
           </Section>
 
+          <Section title={<Cmp>Navigating</Cmp>} id="Navigating">
+            <Explanation>
+              <p>
+                The <Cmp>Navigating</Cmp> component lets you know when the
+                application is navigating and let users cancel the navigation.
+                Its <IJS>children</IJS> prop is a render-invoked function that
+                is passed a function to cancel the navigation.
+              </p>
+              <p>
+                When navigation starts, <IJS>children()</IJS> will be called
+                with a function that will cancel navigation when it is called.
+              </p>
+              <p>
+                When navigation finishes, <IJS>children()</IJS> will be called
+                with no arguments.
+              </p>
+            </Explanation>
+            <CodeBlock lang="jsx">
+              {`import { Navigating } from "@curi/react-native";
+              
+<Navigating>
+  {cancel => {
+    if (cancel === undefined) {
+      return null;
+    }
+    return (
+      <TouchableHighlight onPress={cancel}>
+        <Text>Cancel Navigation</Text>
+      </TouchableHighlight>
+    );
+  }}
+</Navigating>`}
+            </CodeBlock>
+            <Section tag="h3" title="Props" id="Navigating-props">
+              <Subsection tag="h4" title="children()" id="Navigating-children">
+                <Explanation>
+                  <p>
+                    A function that returns a React node. The function will be
+                    called with a <IJS>cancel</IJS> function when navigation
+                    starts and with no arguments when the navigation is
+                    finished.
+                  </p>
+                  <p>
+                    Calling the <IJS>cancel</IJS> function after the navigation
+                    is finished has no effect.
+                  </p>
+                </Explanation>
+              </Subsection>
+            </Section>
+          </Section>
+
           <Section title={<Cmp>Block</Cmp>} id="Block">
             <Explanation>
               <p>

--- a/website/src/pages/Packages/router.js
+++ b/website/src/pages/Packages/router.js
@@ -598,7 +598,45 @@ stopObserving();
                 </Section>
               </Section>
 
-              <Section tag="h5" title="current()" id="current-property">
+              <Subsection
+                tag="h5"
+                title="whileNavigating(fn)"
+                id="while-navigating-property"
+              >
+                <Explanation>
+                  <p>
+                    With asynchronous routes, after a user begins navigation,
+                    but before the route's asynchronous actions have finished,
+                    the user does not have a good way to cancel the navigation.
+                    They can either refresh the page (causing a full reload) or
+                    click a link with the same URL as the current location, but
+                    neither of these are intuitive or ideal.
+                  </p>
+                  <p>
+                    <IJS>whileNavigating()</IJS> takes an observer function that
+                    will be called when navigation starts and when the
+                    navigation is finished. When the navigation starts, the
+                    observer function will be given a function to cancel the
+                    navigation. When the navigation finishes, the function will
+                    be called with <IJS>undefined</IJS>.
+                  </p>
+                  <p>
+                    Calling <IJS>whileNavigating()</IJS> returns a function to
+                    stop observing.
+                  </p>
+                </Explanation>
+                <CodeBlock>
+                  {`const stopCancelling = router.whileNavigating(fn => {
+  if (fn === undefined) {
+    // the navigation has finished/been cancelled
+  } else {
+    // calling fn will cancel the navigation
+  }
+});`}
+                </CodeBlock>
+              </Subsection>
+
+              <Subsection tag="h5" title="current()" id="current-property">
                 <Explanation>
                   <p>
                     The <IJS>router.current()</IJS> method returns the current{" "}

--- a/website/src/pages/Packages/router.js
+++ b/website/src/pages/Packages/router.js
@@ -598,11 +598,7 @@ stopObserving();
                 </Section>
               </Section>
 
-              <Subsection
-                tag="h5"
-                title="whileNavigating(fn)"
-                id="while-navigating-property"
-              >
+              <Section tag="h5" title="cancel(fn)" id="cancel-property">
                 <Explanation>
                   <p>
                     With asynchronous routes, after a user begins navigation,
@@ -613,20 +609,20 @@ stopObserving();
                     neither of these are intuitive or ideal.
                   </p>
                   <p>
-                    <IJS>whileNavigating()</IJS> takes an observer function that
-                    will be called when navigation starts and when the
-                    navigation is finished. When the navigation starts, the
-                    observer function will be given a function to cancel the
-                    navigation. When the navigation finishes, the function will
-                    be called with <IJS>undefined</IJS>.
+                    <IJS>cancel()</IJS> takes an observer function that will be
+                    called when navigation starts and when the navigation is
+                    finished. When the navigation starts, the observer function
+                    will be given a function to cancel the navigation. When the
+                    navigation finishes, the function will be called with{" "}
+                    <IJS>undefined</IJS>.
                   </p>
                   <p>
-                    Calling <IJS>whileNavigating()</IJS> returns a function to
-                    stop observing.
+                    Calling <IJS>cancel()</IJS> returns a function to stop
+                    observing.
                   </p>
                 </Explanation>
                 <CodeBlock>
-                  {`const stopCancelling = router.whileNavigating(fn => {
+                  {`const stopCancelling = router.cancel(fn => {
   if (fn === undefined) {
     // the navigation has finished/been cancelled
   } else {
@@ -634,9 +630,9 @@ stopObserving();
   }
 });`}
                 </CodeBlock>
-              </Subsection>
+              </Section>
 
-              <Subsection tag="h5" title="current()" id="current-property">
+              <Section tag="h5" title="current()" id="current-property">
                 <Explanation>
                   <p>
                     The <IJS>router.current()</IJS> method returns the current{" "}


### PR DESCRIPTION
The one downside of async navigation is that the user is unable easily to cancel navigation. Currently, they either have to refresh the page or click a link to the same location as the current one.

This PR lets you pass an observer to the `router` through a new `cancel()` method. The observer will be called when navigation starts and when the navigation finishes (either because it actually finishes or because it was cancelled). When navigation starts, the observer will be passed a `cancel` function; calling that function will cancel the navigation. When the navigation is finished, the observer will be passed `undefined`.

```js
function observer(fn) {
  // fn is a function while navigating and undefined while it is not
}

router.cancel(observer);
```

A `<Navigating>` component is added to all of the React packages, which adds a `cancel()` observer to the router. This uses `children` as a render-invoked prop that passes the `cancel` function as an argument.

```jsx
<Navigating>
  {cancel => {
    return cancel !== undefined
      ? <button onClick={() => cancel();}>Cancel</button>
      : null;
  }}
</Navigating>
```

Demo Video: https://twitter.com/pshrmn/status/1052370412221415426