### PR TITLE
response.redirectTo includes url, name, params

### DIFF
--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 18303,
-    "minified": 6609,
-    "gzipped": 2733,
+    "bundled": 18450,
+    "minified": 6674,
+    "gzipped": 2759,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 18538,
-    "minified": 6792,
-    "gzipped": 2802
+    "bundled": 18685,
+    "minified": 6857,
+    "gzipped": 2829
   },
   "dist/curi-router.umd.js": {
-    "bundled": 31686,
-    "minified": 9252,
-    "gzipped": 3921
+    "bundled": 31841,
+    "minified": 9310,
+    "gzipped": 3952
   },
   "dist/curi-router.min.js": {
-    "bundled": 30824,
-    "minified": 8712,
-    "gzipped": 3663
+    "bundled": 30979,
+    "minified": 8770,
+    "gzipped": 3690
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `url` property to `response.redirectTo`, which is the `pathname`, `query` and `hash` concatenated. Also adds the `name` and `params` to the `redirectTo` object.
+
 ## 1.0.4
 
 * Add `sideEffects: false` hint for Webpack.

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -142,7 +142,12 @@ export default function createRouter(
     navigation: Navigation,
     resolved: ResolveResults | null
   ) {
-    const response = finishResponse(match, routeInteractions, resolved);
+    const response = finishResponse(
+      match,
+      routeInteractions,
+      resolved,
+      history
+    );
     pending.finish();
     emitImmediate(response, navigation);
     activeNavigation = undefined;

--- a/packages/router/src/finishResponse.ts
+++ b/packages/router/src/finishResponse.ts
@@ -1,25 +1,34 @@
+import { History } from "@hickory/root";
 import { Interactions } from "./types/interaction";
-import { Response, SettableResponseProperties } from "./types/response";
+import {
+  Response,
+  RedirectLocation,
+  SettableResponseProperties
+} from "./types/response";
 import { ResolveResults } from "./types/route";
 import { Match } from "./types/match";
-import { PartialLocation } from "@hickory/root";
 
 function createRedirect(
   redirectTo: any,
-  interactions: Interactions
-): PartialLocation {
+  interactions: Interactions,
+  history: History
+): RedirectLocation {
   const { name, params, ...rest } = redirectTo;
   const pathname = interactions.pathname(name, params);
   return {
+    name,
+    params,
     pathname,
-    ...rest
+    ...rest,
+    url: history.toHref({ pathname, ...rest })
   };
 }
 
 export default function finishResponse(
   routeMatch: Match,
   interactions: Interactions,
-  resolvedResults: ResolveResults | null
+  resolvedResults: ResolveResults | null,
+  history: History
 ): Response {
   const { route, match } = routeMatch;
   const response: Response = match;
@@ -48,7 +57,11 @@ export default function finishResponse(
     if (responseModifiers.hasOwnProperty(p)) {
       if (p === "redirectTo") {
         // special case
-        response[p] = createRedirect(responseModifiers[p], interactions);
+        response[p] = createRedirect(
+          responseModifiers[p],
+          interactions,
+          history
+        );
       } else {
         response[p] = responseModifiers[p];
       }

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -19,6 +19,7 @@ export {
   Response,
   RawParams,
   Params,
+  RedirectLocation,
   MatchResponseProperties,
   SettableResponseProperties
 } from "./response";

--- a/packages/router/src/types/response.ts
+++ b/packages/router/src/types/response.ts
@@ -19,13 +19,19 @@ export interface SettableResponseProperties {
   redirectTo?: RedirectProps;
 }
 
+export interface RedirectLocation extends PartialLocation {
+  name: string;
+  params?: Params;
+  url: string;
+}
+
 export interface Response extends MatchResponseProperties {
   status?: number;
   error?: any;
   body?: any;
   data?: any;
   title?: string;
-  redirectTo?: PartialLocation;
+  redirectTo?: RedirectLocation;
 }
 
 export interface RedirectProps {

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -562,7 +562,8 @@ describe("route matching/response generation", () => {
       });
 
       describe("redirectTo", () => {
-        it("is the redirectTo value of the object returned by route.response()", () => {
+        it("contains the expected properties", () => {
+          const history = InMemory({ locations: ["/"] });
           const routes = [
             {
               name: "A Route",
@@ -570,21 +571,33 @@ describe("route matching/response generation", () => {
               response: () => {
                 return {
                   redirectTo: {
-                    name: "B Route"
+                    name: "B Route",
+                    params: { id: "bee" },
+                    hash: "bay",
+                    query: "type=honey",
+                    state: { why: "not" }
                   }
                 };
               }
             },
             {
               name: "B Route",
-              path: "b"
+              path: "b/:id"
             }
           ];
-          const history = InMemory({ locations: ["/"] });
+
           let firstCall = true;
           const logger = ({ response }) => {
             if (firstCall) {
-              expect(response.redirectTo).toMatchObject({ pathname: "/b" });
+              expect(response.redirectTo).toMatchObject({
+                pathname: "/b/bee",
+                hash: "bay",
+                query: "type=honey",
+                url: "/b/bee?type=honey#bay",
+                state: { why: "not" },
+                name: "B Route",
+                params: { id: "bee" }
+              });
               firstCall = false;
             }
           };

--- a/packages/router/types/finishResponse.d.ts
+++ b/packages/router/types/finishResponse.d.ts
@@ -1,5 +1,6 @@
+import { History } from "@hickory/root";
 import { Interactions } from "./types/interaction";
 import { Response } from "./types/response";
 import { ResolveResults } from "./types/route";
 import { Match } from "./types/match";
-export default function finishResponse(routeMatch: Match, interactions: Interactions, resolvedResults: ResolveResults | null): Response;
+export default function finishResponse(routeMatch: Match, interactions: Interactions, resolvedResults: ResolveResults | null, history: History): Response;

--- a/packages/router/types/types/index.d.ts
+++ b/packages/router/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
 export { Route, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, AsyncGroup, Resolved, ResolveResults } from "./route";
-export { Response, RawParams, Params, MatchResponseProperties, SettableResponseProperties } from "./response";
+export { Response, RawParams, Params, RedirectLocation, MatchResponseProperties, SettableResponseProperties } from "./response";
 export { CuriRouter, RouterOptions, Observer, Emitted, ResponseHandlerOptions, RemoveObserver, Navigation, CurrentResponse } from "./curi";

--- a/packages/router/types/types/response.d.ts
+++ b/packages/router/types/types/response.d.ts
@@ -19,13 +19,18 @@ export interface SettableResponseProperties {
     title?: string;
     redirectTo?: RedirectProps;
 }
+export interface RedirectLocation extends PartialLocation {
+    name: string;
+    params?: Params;
+    url: string;
+}
 export interface Response extends MatchResponseProperties {
     status?: number;
     error?: any;
     body?: any;
     data?: any;
     title?: string;
-    redirectTo?: PartialLocation;
+    redirectTo?: RedirectLocation;
 }
 export interface RedirectProps {
     name: string;


### PR DESCRIPTION
Currently, redirecting manually (on the server) requires the user to concatenate `response.redirectTo`'s `pathname`, `query` and `hash`. This PR adds a `url` property to the object, which is those three properties joined into a string.

The `name` and `params` are also forwarded onto `response.redirectTo` in case the user needs to access them.