### PR TITLE
Add prepareRoutes() to @curi/router

### DIFF
--- a/examples/misc/code-splitting/src/routes.js
+++ b/examples/misc/code-splitting/src/routes.js
@@ -1,7 +1,7 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 import NotFound from "./components/NotFound"; // not splitting this
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/misc/code-splitting/src/routes.js
+++ b/examples/misc/code-splitting/src/routes.js
@@ -1,6 +1,7 @@
+import { buildRoutes } from "@curi/router";
 import NotFound from "./components/NotFound"; // not splitting this
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -35,4 +36,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/misc/server-rendering/src/routes.js
+++ b/examples/misc/server-rendering/src/routes.js
@@ -1,6 +1,6 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/misc/server-rendering/src/routes.js
+++ b/examples/misc/server-rendering/src/routes.js
@@ -1,4 +1,6 @@
-export default [
+import { buildRoutes } from "@curi/router";
+
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -63,4 +65,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/misc/side-effect/src/routes.js
+++ b/examples/misc/side-effect/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/misc/side-effect/src/routes.js
+++ b/examples/misc/side-effect/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -46,4 +48,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/misc/updating-routes/src/routes/index.js
+++ b/examples/misc/updating-routes/src/routes/index.js
@@ -1,7 +1,7 @@
-import baseRoutes from './base';
-import adminRoutes from './admin';
+import { buildRoutes } from "@curi/router";
 
-export {
-  baseRoutes,
-  adminRoutes
-};
+import plainBaseRoutes from "./base";
+import plainAdminRoutes from "./admin";
+
+export const baseRoutes = buildRoutes(plainBaseRoutes);
+export const adminRoutes = buildRoutes(plainAdminRoutes);

--- a/examples/misc/updating-routes/src/routes/index.js
+++ b/examples/misc/updating-routes/src/routes/index.js
@@ -1,7 +1,7 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import plainBaseRoutes from "./base";
 import plainAdminRoutes from "./admin";
 
-export const baseRoutes = buildRoutes(plainBaseRoutes);
-export const adminRoutes = buildRoutes(plainAdminRoutes);
+export const baseRoutes = prepareRoutes(plainBaseRoutes);
+export const adminRoutes = prepareRoutes(plainAdminRoutes);

--- a/examples/react/accessibility/src/routes.js
+++ b/examples/react/accessibility/src/routes.js
@@ -1,4 +1,4 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
@@ -46,4 +46,4 @@ const routes = [
   }
 ];
 
-export default buildRoutes(routes);
+export default prepareRoutes(routes);

--- a/examples/react/accessibility/src/routes.js
+++ b/examples/react/accessibility/src/routes.js
@@ -1,3 +1,5 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
@@ -44,4 +46,4 @@ const routes = [
   }
 ];
 
-export default routes;
+export default buildRoutes(routes);

--- a/examples/react/active-links/src/routes.js
+++ b/examples/react/active-links/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/react/active-links/src/routes.js
+++ b/examples/react/active-links/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -42,4 +44,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/react/async-nav/src/routes.js
+++ b/examples/react/async-nav/src/routes.js
@@ -1,8 +1,8 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import { movies, movie } from "./api";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/react/async-nav/src/routes.js
+++ b/examples/react/async-nav/src/routes.js
@@ -1,6 +1,8 @@
+import { buildRoutes } from "@curi/router";
+
 import { movies, movie } from "./api";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -55,4 +57,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/react/authentication/src/routes.js
+++ b/examples/react/authentication/src/routes.js
@@ -1,3 +1,5 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Protected from "./components/Protected";
 import Login from "./components/Login";
@@ -6,7 +8,7 @@ import NotFound from "./components/NotFound";
 
 import fakeAuth from "./fakeAuth";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -76,4 +78,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/react/authentication/src/routes.js
+++ b/examples/react/authentication/src/routes.js
@@ -1,4 +1,4 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Protected from "./components/Protected";
@@ -8,7 +8,7 @@ import NotFound from "./components/NotFound";
 
 import fakeAuth from "./fakeAuth";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/react/basic/src/routes.js
+++ b/examples/react/basic/src/routes.js
@@ -1,4 +1,4 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
@@ -46,4 +46,4 @@ const routes = [
   }
 ];
 
-export default buildRoutes(routes);
+export default prepareRoutes(routes);

--- a/examples/react/basic/src/routes.js
+++ b/examples/react/basic/src/routes.js
@@ -1,3 +1,5 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
@@ -44,4 +46,4 @@ const routes = [
   }
 ];
 
-export default routes;
+export default buildRoutes(routes);

--- a/examples/react/blocking-navigation/src/routes.js
+++ b/examples/react/blocking-navigation/src/routes.js
@@ -1,7 +1,9 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -20,4 +22,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/react/blocking-navigation/src/routes.js
+++ b/examples/react/blocking-navigation/src/routes.js
@@ -1,9 +1,9 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/react/breadcrumbs/src/routes.js
+++ b/examples/react/breadcrumbs/src/routes.js
@@ -1,3 +1,5 @@
+import { buildRoutes } from "@curi/router";
+
 import api from "./api";
 
 import Home from "./components/Home";
@@ -6,7 +8,7 @@ import Category from "./components/Category";
 import Product from "./components/Product";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -83,4 +85,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/react/breadcrumbs/src/routes.js
+++ b/examples/react/breadcrumbs/src/routes.js
@@ -1,4 +1,4 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import api from "./api";
 
@@ -8,7 +8,7 @@ import Category from "./components/Category";
 import Product from "./components/Product";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/react/data-loading/src/routes.js
+++ b/examples/react/data-loading/src/routes.js
@@ -1,4 +1,4 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import fakeAPI from "./fakeAPI";
 
@@ -6,7 +6,7 @@ import Home from "./components/Home";
 import Album from "./components/Album";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/react/data-loading/src/routes.js
+++ b/examples/react/data-loading/src/routes.js
@@ -1,10 +1,12 @@
+import { buildRoutes } from "@curi/router";
+
 import fakeAPI from "./fakeAPI";
 
 import Home from "./components/Home";
 import Album from "./components/Album";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -42,4 +44,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/react/modal/src/routes.js
+++ b/examples/react/modal/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Product from "./components/Product";
 import Detail from "./components/Detail";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -42,4 +44,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/react/modal/src/routes.js
+++ b/examples/react/modal/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Product from "./components/Product";
 import Detail from "./components/Detail";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/react/multi-body/src/routes.js
+++ b/examples/react/multi-body/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import { Home, HomeMenu } from "./components/Home";
 import { Contact, ContactMenu } from "./components/Contact";
 import { Method, MethodMenu } from "./components/Method";
 import { NotFound, NotFoundMenu } from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -54,4 +56,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/react/multi-body/src/routes.js
+++ b/examples/react/multi-body/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import { Home, HomeMenu } from "./components/Home";
 import { Contact, ContactMenu } from "./components/Contact";
 import { Method, MethodMenu } from "./components/Method";
 import { NotFound, NotFoundMenu } from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/react/transitions/src/routes.js
+++ b/examples/react/transitions/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/react/transitions/src/routes.js
+++ b/examples/react/transitions/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -42,4 +44,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/svelte/basic/src/routes.js
+++ b/examples/svelte/basic/src/routes.js
@@ -1,4 +1,4 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home.html";
 import Contact from "./components/Contact.html";
@@ -46,4 +46,4 @@ const routes = [
   }
 ];
 
-export default buildRoutes(routes);
+export default prepareRoutes(routes);

--- a/examples/svelte/basic/src/routes.js
+++ b/examples/svelte/basic/src/routes.js
@@ -1,3 +1,5 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home.html";
 import Contact from "./components/Contact.html";
 import Method from "./components/Method.html";
@@ -44,4 +46,4 @@ const routes = [
   }
 ];
 
-export default routes;
+export default buildRoutes(routes);

--- a/examples/vue/accessibility/src/routes.js
+++ b/examples/vue/accessibility/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/vue/accessibility/src/routes.js
+++ b/examples/vue/accessibility/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -42,4 +44,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/vue/active-links/src/routes.js
+++ b/examples/vue/active-links/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/vue/active-links/src/routes.js
+++ b/examples/vue/active-links/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -42,4 +44,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/vue/async-nav/src/routes.js
+++ b/examples/vue/async-nav/src/routes.js
@@ -1,8 +1,8 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import { movies, movie } from "./api";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/vue/async-nav/src/routes.js
+++ b/examples/vue/async-nav/src/routes.js
@@ -1,6 +1,8 @@
+import { buildRoutes } from "@curi/router";
+
 import { movies, movie } from "./api";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -55,4 +57,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/vue/authentication/src/routes.js
+++ b/examples/vue/authentication/src/routes.js
@@ -1,4 +1,4 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Protected from "./components/Protected";
@@ -8,7 +8,7 @@ import NotFound from "./components/NotFound";
 
 import store from "./store";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/vue/authentication/src/routes.js
+++ b/examples/vue/authentication/src/routes.js
@@ -1,3 +1,5 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Protected from "./components/Protected";
 import Login from "./components/Login";
@@ -6,7 +8,7 @@ import NotFound from "./components/NotFound";
 
 import store from "./store";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -78,4 +80,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/vue/basic/src/routes.js
+++ b/examples/vue/basic/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/vue/basic/src/routes.js
+++ b/examples/vue/basic/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -42,4 +44,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/vue/blocking-navigation/src/routes.js
+++ b/examples/vue/blocking-navigation/src/routes.js
@@ -1,10 +1,10 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/vue/blocking-navigation/src/routes.js
+++ b/examples/vue/blocking-navigation/src/routes.js
@@ -1,8 +1,10 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -30,4 +32,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/vue/breadcrumbs/src/routes.js
+++ b/examples/vue/breadcrumbs/src/routes.js
@@ -1,4 +1,4 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import api from "./api";
 
@@ -8,7 +8,7 @@ import Category from "./components/Category";
 import Product from "./components/Product";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/vue/breadcrumbs/src/routes.js
+++ b/examples/vue/breadcrumbs/src/routes.js
@@ -1,3 +1,5 @@
+import { buildRoutes } from "@curi/router";
+
 import api from "./api";
 
 import Home from "./components/Home";
@@ -6,7 +8,7 @@ import Category from "./components/Category";
 import Product from "./components/Product";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -82,4 +84,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/vue/modal/src/routes.js
+++ b/examples/vue/modal/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Product from "./components/Product";
 import Detail from "./components/Detail";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -42,4 +44,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/examples/vue/modal/src/routes.js
+++ b/examples/vue/modal/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Product from "./components/Product";
 import Detail from "./components/Detail";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/vue/transitions/src/routes.js
+++ b/examples/vue/transitions/src/routes.js
@@ -1,11 +1,11 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/examples/vue/transitions/src/routes.js
+++ b/examples/vue/transitions/src/routes.js
@@ -1,9 +1,11 @@
+import { buildRoutes } from "@curi/router";
+
 import Home from "./components/Home";
 import Contact from "./components/Contact";
 import Method from "./components/Method";
 import NotFound from "./components/NotFound";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -42,4 +44,4 @@ export default [
       };
     }
   }
-];
+]);

--- a/packages/interactions/route-active/.size-snapshot.json
+++ b/packages/interactions/route-active/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-active.es.js": {
-    "bundled": 1921,
-    "minified": 809,
-    "gzipped": 496,
+    "bundled": 1361,
+    "minified": 502,
+    "gzipped": 313,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,17 +14,17 @@
     }
   },
   "dist/curi-route-active.js": {
-    "bundled": 1938,
-    "minified": 822,
-    "gzipped": 504
+    "bundled": 1378,
+    "minified": 515,
+    "gzipped": 320
   },
   "dist/curi-route-active.umd.js": {
-    "bundled": 2240,
-    "minified": 888,
-    "gzipped": 519
+    "bundled": 1703,
+    "minified": 617,
+    "gzipped": 365
   },
   "dist/curi-route-active.min.js": {
-    "bundled": 1722,
+    "bundled": 1703,
     "minified": 617,
     "gzipped": 365
   }

--- a/packages/interactions/route-active/.size-snapshot.json
+++ b/packages/interactions/route-active/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/curi-route-active.es.js": {
-    "bundled": 1361,
+    "bundled": 1378,
     "minified": 502,
     "gzipped": 313,
     "treeshaked": {
@@ -14,17 +14,17 @@
     }
   },
   "dist/curi-route-active.js": {
-    "bundled": 1378,
+    "bundled": 1395,
     "minified": 515,
     "gzipped": 320
   },
   "dist/curi-route-active.umd.js": {
-    "bundled": 1703,
+    "bundled": 1722,
     "minified": 617,
     "gzipped": 365
   },
   "dist/curi-route-active.min.js": {
-    "bundled": 1703,
+    "bundled": 1722,
     "minified": 617,
     "gzipped": 365
   }

--- a/packages/interactions/route-active/CHANGELOG.md
+++ b/packages/interactions/route-active/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* No longer warns when adding duplicate route name (should be caught be `prepareRoutes`).
+
 ## 1.0.2
 
 * Add `sideEffects: false` hint for Webpack.

--- a/packages/interactions/route-active/package.json
+++ b/packages/interactions/route-active/package.json
@@ -32,7 +32,8 @@
   "author": "Paul Sherman",
   "license": "MIT",
   "dependencies": {
-    "@curi/router": "^1.0.4"
+    "@curi/router": "^1.0.4",
+    "@hickory/in-memory": "^1.0.2"
   },
   "devDependencies": {
     "@types/jest": "^22.0.1",

--- a/packages/interactions/route-active/src/index.ts
+++ b/packages/interactions/route-active/src/index.ts
@@ -24,17 +24,6 @@ export default function checkIfActive(): Interaction {
       const fullKeys = Array.isArray(parentKeys)
         ? [...parentKeys, ...keys]
         : keys;
-      if (process.env.NODE_ENV !== "production") {
-        if (routeParams[name] !== undefined) {
-          console.warn(
-            '[@curi/route-active] A route with the name "' +
-              name +
-              '" already exists. Each route should' +
-              "have a unique name. By registering a route function with a name that already exists, " +
-              "you are overwriting the existing one. This may break your application."
-          );
-        }
-      }
       routeParams[name] = fullKeys;
       return fullKeys;
     },

--- a/packages/interactions/route-active/tests/active.spec.ts
+++ b/packages/interactions/route-active/tests/active.spec.ts
@@ -1,6 +1,6 @@
 import "jest";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import createActive from "@curi/route-active";
 
 describe("active route interaction", () => {
@@ -51,30 +51,6 @@ describe("active route interaction", () => {
       };
       const storedKeys = active.register(empty);
       expect(storedKeys).toEqual([]);
-    });
-
-    it("warns when registering the same name", () => {
-      const warn = console.warn;
-      const mockWarn = (console.warn = jest.fn());
-
-      const first = {
-        name: "Test",
-        path: ":first",
-        keys: ["first"]
-      };
-      const second = {
-        name: "Test",
-        path: ":second",
-        keys: ["second"]
-      };
-
-      active.register(first);
-      expect(mockWarn.mock.calls.length).toBe(0);
-
-      active.register(second);
-      expect(mockWarn.mock.calls.length).toBe(1);
-
-      console.warn = warn;
     });
   });
 

--- a/packages/interactions/route-active/tests/active.spec.ts
+++ b/packages/interactions/route-active/tests/active.spec.ts
@@ -1,154 +1,201 @@
 import "jest";
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
 
 // @ts-ignore (resolved by jest)
 import createActive from "@curi/route-active";
 
 describe("active route interaction", () => {
-  let active;
+  const history = InMemory();
 
-  beforeEach(() => {
-    active = createActive();
+  it("is called using router.route.ancestors()", () => {
+    const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
+    const router = curi(history, routes, {
+      route: [createActive()]
+    });
+    expect(router.route.active).toBeDefined();
   });
 
-  describe("name", () => {
-    it("is active", () => {
-      expect(active.name).toBe("active");
-    });
-  });
+  describe("routes", () => {
+    it("returns false if the route is not registered", () => {
+      const history = InMemory({
+        locations: ["/"]
+      });
+      const routes = prepareRoutes([
+        {
+          name: "Player",
+          path: "player/:id"
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes, {
+        route: [createActive()]
+      });
 
-  describe("register", () => {
-    it("returns the array of param keys for the route", () => {
-      const player = {
-        name: "Player",
-        path: "player/:id",
-        keys: ["id"]
-      };
-      const storedKeys = active.register(player);
-      expect(storedKeys).toEqual(["id"]);
-    });
-
-    it("also stores any ancestor route's keys", () => {
-      const album = {
-        name: "Album",
-        path: "a/:albumId",
-        keys: ["albumId"]
-      };
-      const photo = {
-        name: "Photo",
-        path: ":photoId",
-        keys: ["photoId"]
-      };
-      const parentKeys = active.register(album);
-      const storedKeys = active.register(photo, parentKeys);
-      expect(storedKeys).toEqual(["albumId", "photoId"]);
+      const { response } = router.current();
+      const playerIsActive = router.route.active("Does Not Exist", response, {
+        id: "6"
+      });
+      expect(playerIsActive).toBe(false);
     });
 
-    it("stores empty array when route has no params", () => {
-      const empty = {
-        name: "Empty",
-        path: "empty",
-        keys: undefined
-      };
-      const storedKeys = active.register(empty);
-      expect(storedKeys).toEqual([]);
-    });
-  });
-
-  describe("get", () => {
     it("returns false when name does not match", () => {
-      const player = {
-        name: "Player",
-        path: "player/:id",
-        keys: ["id"]
-      };
-      active.register(player);
-      const playerIsActive = active.get("Player", { name: "Coach" }, { id: 6 });
+      const history = InMemory({
+        locations: ["/"]
+      });
+      const routes = prepareRoutes([
+        {
+          name: "Player",
+          path: "player/:id"
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes, {
+        route: [createActive()]
+      });
+
+      const { response } = router.current();
+      const playerIsActive = router.route.active("Player", response, {
+        id: "6"
+      });
       expect(playerIsActive).toBe(false);
     });
 
     it("returns false when name matches but params do not", () => {
-      const player = {
-        name: "Player",
-        path: "player/:id",
-        keys: ["id"]
-      };
-      active.register(player);
-      const playerIsActive = active.get(
-        "Player",
-        { name: "Player", params: { id: 7 } },
-        { id: 6 }
-      );
+      const history = InMemory({
+        locations: ["/player/7"]
+      });
+      const routes = prepareRoutes([
+        {
+          name: "Player",
+          path: "player/:id"
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes, {
+        route: [createActive()]
+      });
+
+      const { response } = router.current();
+      const playerIsActive = router.route.active("Player", response, {
+        id: "6"
+      });
       expect(playerIsActive).toBe(false);
     });
 
     it("returns false when name is partial match but partial is not true", () => {
-      const player = {
-        name: "Player",
-        path: "player/:id",
-        keys: ["id"]
-      };
-      active.register(player);
-      const playerIsActive = active.get(
-        "Player",
-        { name: "Coach", partials: ["Player"], params: { id: 6 } },
-        { id: 6 }
-      );
+      const history = InMemory({
+        locations: ["/player/6/coach"]
+      });
+      const routes = prepareRoutes([
+        {
+          name: "Player",
+          path: "player/:id",
+          children: [
+            {
+              name: "Coach",
+              path: "coach"
+            }
+          ]
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes, {
+        route: [createActive()]
+      });
+
+      const { response } = router.current();
+      const playerIsActive = router.route.active("Player", response, {
+        id: "6"
+      });
       expect(playerIsActive).toBe(false);
     });
 
     it("returns true when name matches and params match", () => {
-      const player = {
-        name: "Player",
-        path: "player/:id",
-        keys: ["id"]
-      };
-      active.register(player);
-      const playerIsActive = active.get(
-        "Player",
-        { name: "Player", params: { id: 7 } },
-        { id: 7 }
-      );
+      const history = InMemory({
+        locations: ["/player/7"]
+      });
+      const routes = prepareRoutes([
+        {
+          name: "Player",
+          path: "player/:id"
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes, {
+        route: [createActive()]
+      });
+
+      const { response } = router.current();
+      const playerIsActive = router.route.active("Player", response, {
+        id: "7"
+      });
       expect(playerIsActive).toBe(true);
     });
 
     it("returns true when name is partial match and partial is true", () => {
-      const player = {
-        name: "Player",
-        path: "player/:id",
-        keys: ["id"]
-      };
-      active.register(player);
-      const playerIsActive = active.get(
+      const history = InMemory({
+        locations: ["/player/6/coach"]
+      });
+      const routes = prepareRoutes([
+        {
+          name: "Player",
+          path: "player/:id",
+          children: [
+            {
+              name: "Coach",
+              path: "coach"
+            }
+          ]
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes, {
+        route: [createActive()]
+      });
+
+      const { response } = router.current();
+      const playerIsActive = router.route.active(
         "Player",
-        { name: "Coach", partials: ["Player"], params: { id: 6 } },
-        { id: 6 },
+        response,
+        { id: "6" },
         true
       );
       expect(playerIsActive).toBe(true);
     });
   });
 
-  describe("reset", () => {
-    it("removes the registered routes", () => {
-      const player = {
-        name: "Player",
-        path: "player/:id",
-        keys: ["id"]
-      };
-      active.register(player);
-      const playerIsActive = active.get(
-        "Player",
-        { name: "Player", params: { id: 7 } },
-        { id: 7 }
-      );
-      expect(playerIsActive).toBe(true);
-      active.reset();
-      const playerIsActiveAfterReset = active.get(
-        "Player",
-        { name: "Player", params: { id: 7 } },
-        { id: 7 }
-      );
-      expect(playerIsActiveAfterReset).toBe(false);
+  it("refreshing removes the registered routes", () => {
+    const history = InMemory({
+      locations: ["/player/7"]
     });
+    const routes = prepareRoutes([
+      {
+        name: "Player",
+        path: "player/:id"
+      },
+      { name: "Catch All", path: "(.*)" }
+    ]);
+    const emptyRoutes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
+
+    const router = curi(history, routes, {
+      route: [createActive()]
+    });
+
+    const playerIsActive = router.route.active(
+      "Player",
+      router.current().response,
+      { id: "7" }
+    );
+    expect(playerIsActive).toBe(true);
+
+    router.refresh(emptyRoutes);
+
+    const playerIsActiveAfterRefresh = router.route.active(
+      "Player",
+      router.current().response,
+      { id: "7" }
+    );
+    expect(playerIsActiveAfterRefresh).toBe(false);
   });
 });

--- a/packages/interactions/route-ancestors/.size-snapshot.json
+++ b/packages/interactions/route-ancestors/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-ancestors.es.js": {
-    "bundled": 1369,
-    "minified": 594,
-    "gzipped": 379,
+    "bundled": 829,
+    "minified": 293,
+    "gzipped": 203,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,14 +14,14 @@
     }
   },
   "dist/curi-route-ancestors.js": {
-    "bundled": 1386,
-    "minified": 607,
-    "gzipped": 389
+    "bundled": 846,
+    "minified": 306,
+    "gzipped": 211
   },
   "dist/curi-route-ancestors.umd.js": {
-    "bundled": 1673,
-    "minified": 707,
-    "gzipped": 422
+    "bundled": 1158,
+    "minified": 442,
+    "gzipped": 275
   },
   "dist/curi-route-ancestors.min.js": {
     "bundled": 1158,

--- a/packages/interactions/route-ancestors/CHANGELOG.md
+++ b/packages/interactions/route-ancestors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* No longer warns when adding duplicate route name (should be caught be `prepareRoutes`).
+
 ## 1.0.2
 
 * Add `sideEffects: false` hint for Webpack.

--- a/packages/interactions/route-ancestors/package-lock.json
+++ b/packages/interactions/route-ancestors/package-lock.json
@@ -1,11 +1,38 @@
 {
-  "requires": true,
+  "name": "@curi/route-ancestors",
+  "version": "1.0.2",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "@hickory/in-memory": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-1.0.2.tgz",
+      "integrity": "sha512-qDE0MluMoFgZcKj5yMjzOBAMv8Luq1uBCKV1BUKc/W9afwhtNOaNzzPv2d9MaMCiyZYsM7kiDW+EWqSAI+x+ZQ==",
+      "dev": true,
+      "requires": {
+        "@hickory/root": "^1.0.2"
+      }
+    },
+    "@hickory/location-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-1.0.2.tgz",
+      "integrity": "sha512-6aFLOGADMu3u7M2KTOp2UzteR+WG+rAf+B2qeUkGpT1LvFuCUC/1NiQJqG098sL3A2OlOAweJic9PmayemuQ4Q==",
+      "dev": true
+    },
+    "@hickory/root": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hickory/root/-/root-1.0.2.tgz",
+      "integrity": "sha512-YL0JT/kd0Bj3wBqXOVT4eDYXFFrBxU0xsbigFTTJL//+eIKjB95gXvx4CEzV9FCLGvEsOcemZqHuxdr8PNN2yA==",
+      "dev": true,
+      "requires": {
+        "@hickory/location-utils": "^1.0.2"
+      }
+    },
     "ts-jest": {
       "version": "23.10.4",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.4.tgz",
       "integrity": "sha512-oV/wBwGUS7olSk/9yWMiSIJWbz5xO4zhftnY3gwv6s4SMg6WHF1m8XZNBvQOKQRiTAexZ9754Z13dxBq3Zgssw==",
+      "dev": true,
       "requires": {
         "bs-logger": "0.x",
         "buffer-from": "1.x",
@@ -21,6 +48,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.5.tgz",
           "integrity": "sha512-uFLE0LFMxrH8Z5Hd9QgivvRbrl/NFkOTHzGhlqQxsnmx5JBLrp4bc249afLL+GccyY/8hkcGi2LpVaOzaEY0nQ==",
+          "dev": true,
           "requires": {
             "fast-json-stable-stringify": "^2.0.0"
           }
@@ -28,22 +56,26 @@
         "buffer-from": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+          "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+          "dev": true
         },
         "json5": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
           "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -51,17 +83,20 @@
         "make-error": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-          "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+          "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           },
@@ -69,19 +104,22 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
             }
           }
         },
         "semver": {
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
         },
         "yargs-parser": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
           }

--- a/packages/interactions/route-ancestors/package.json
+++ b/packages/interactions/route-ancestors/package.json
@@ -36,6 +36,7 @@
     "@curi/router": "^1.0.4"
   },
   "devDependencies": {
+    "@hickory/in-memory": "^1.0.2",
     "@types/jest": "^22.0.1",
     "jest": "^23.6.0",
     "ts-jest": "^23.10.4"

--- a/packages/interactions/route-ancestors/src/index.ts
+++ b/packages/interactions/route-ancestors/src/index.ts
@@ -26,17 +26,6 @@ export default function getRouteAncestors(): Interaction {
       parentRoutes: Array<string> = []
     ): Array<string> => {
       let { name } = route;
-      if (process.env.NODE_ENV !== "production") {
-        if (routeAncestors[name] !== undefined) {
-          console.warn(
-            '[@curi/route-ancestors] A route with the name "' +
-              name +
-              '" already exists. Each route should' +
-              "have a unique name. By registering a route with a name that already exists, " +
-              "you are overwriting the existing one. This may break your application."
-          );
-        }
-      }
       routeAncestors[name] = parentRoutes;
       return [name, ...parentRoutes];
     },

--- a/packages/interactions/route-ancestors/tests/ancestors.spec.ts
+++ b/packages/interactions/route-ancestors/tests/ancestors.spec.ts
@@ -1,6 +1,6 @@
 import "jest";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import createAncestors from "@curi/route-ancestors";
 
 describe("ancestors route interaction", () => {
@@ -27,23 +27,6 @@ describe("ancestors route interaction", () => {
       const player = { name: "Player" };
       const older = ancestors.register(player, ["Team"]);
       expect(older).toEqual(["Player", "Team"]);
-    });
-
-    it("warns when registering the same name", () => {
-      const warn = console.warn;
-      const mockWarn = jest.fn();
-      console.warn = mockWarn;
-
-      const first = { name: "Test" };
-      const second = { name: "Test" };
-
-      ancestors.register(first);
-      expect(mockWarn.mock.calls.length).toBe(0);
-
-      ancestors.register(second);
-      expect(mockWarn.mock.calls.length).toBe(1);
-
-      console.warn = warn;
     });
   });
 

--- a/packages/interactions/route-prefetch/.size-snapshot.json
+++ b/packages/interactions/route-prefetch/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-prefetch.es.js": {
-    "bundled": 2172,
-    "minified": 980,
-    "gzipped": 547,
+    "bundled": 1637,
+    "minified": 676,
+    "gzipped": 372,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,14 +14,14 @@
     }
   },
   "dist/curi-route-prefetch.js": {
-    "bundled": 2189,
-    "minified": 993,
-    "gzipped": 556
+    "bundled": 1654,
+    "minified": 689,
+    "gzipped": 380
   },
   "dist/curi-route-prefetch.umd.js": {
-    "bundled": 2505,
-    "minified": 1099,
-    "gzipped": 591
+    "bundled": 1995,
+    "minified": 832,
+    "gzipped": 442
   },
   "dist/curi-route-prefetch.min.js": {
     "bundled": 1995,

--- a/packages/interactions/route-prefetch/CHANGELOG.md
+++ b/packages/interactions/route-prefetch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* No longer warns when adding duplicate route name (should be caught be `prepareRoutes`).
+
 ## 1.0.2
 
 * Add `sideEffects: false` hint for Webpack.

--- a/packages/interactions/route-prefetch/package-lock.json
+++ b/packages/interactions/route-prefetch/package-lock.json
@@ -1,11 +1,40 @@
 {
-  "requires": true,
+  "name": "@curi/route-prefetch",
+  "version": "1.0.2",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "@hickory/in-memory": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-1.0.2.tgz",
+      "integrity": "sha512-qDE0MluMoFgZcKj5yMjzOBAMv8Luq1uBCKV1BUKc/W9afwhtNOaNzzPv2d9MaMCiyZYsM7kiDW+EWqSAI+x+ZQ==",
+      "dev": true,
+      "requires": {
+        "@hickory/root": "^1.0.2"
+      },
+      "dependencies": {
+        "@hickory/root": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@hickory/root/-/root-1.0.2.tgz",
+          "integrity": "sha512-YL0JT/kd0Bj3wBqXOVT4eDYXFFrBxU0xsbigFTTJL//+eIKjB95gXvx4CEzV9FCLGvEsOcemZqHuxdr8PNN2yA==",
+          "dev": true,
+          "requires": {
+            "@hickory/location-utils": "^1.0.2"
+          }
+        }
+      }
+    },
+    "@hickory/location-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-1.0.2.tgz",
+      "integrity": "sha512-6aFLOGADMu3u7M2KTOp2UzteR+WG+rAf+B2qeUkGpT1LvFuCUC/1NiQJqG098sL3A2OlOAweJic9PmayemuQ4Q==",
+      "dev": true
+    },
     "ts-jest": {
       "version": "23.10.4",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.4.tgz",
       "integrity": "sha512-oV/wBwGUS7olSk/9yWMiSIJWbz5xO4zhftnY3gwv6s4SMg6WHF1m8XZNBvQOKQRiTAexZ9754Z13dxBq3Zgssw==",
+      "dev": true,
       "requires": {
         "bs-logger": "0.x",
         "buffer-from": "1.x",
@@ -21,6 +50,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.5.tgz",
           "integrity": "sha512-uFLE0LFMxrH8Z5Hd9QgivvRbrl/NFkOTHzGhlqQxsnmx5JBLrp4bc249afLL+GccyY/8hkcGi2LpVaOzaEY0nQ==",
+          "dev": true,
           "requires": {
             "fast-json-stable-stringify": "^2.0.0"
           }
@@ -28,22 +58,26 @@
         "buffer-from": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+          "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+          "dev": true
         },
         "json5": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
           "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -51,17 +85,20 @@
         "make-error": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-          "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+          "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           },
@@ -69,19 +106,22 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
             }
           }
         },
         "semver": {
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
         },
         "yargs-parser": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
           }

--- a/packages/interactions/route-prefetch/package.json
+++ b/packages/interactions/route-prefetch/package.json
@@ -37,6 +37,7 @@
     "@hickory/root": "^1.0.0"
   },
   "devDependencies": {
+    "@hickory/in-memory": "^1.0.2",
     "@types/jest": "^22.0.1",
     "jest": "^23.6.0",
     "ts-jest": "^23.10.4"

--- a/packages/interactions/route-prefetch/src/index.ts
+++ b/packages/interactions/route-prefetch/src/index.ts
@@ -16,17 +16,6 @@ export default function prefetchRoute(): Interaction {
     name: "prefetch",
     register: (route: Route) => {
       const { name, resolve } = route;
-      if (process.env.NODE_ENV !== "production") {
-        if (loaders[name] !== undefined) {
-          console.warn(
-            '[@curi/route-prefetch] A route with the name "' +
-              name +
-              '" already exists. Each route should' +
-              "have a unique name. By registering a function with a name that already exists, " +
-              "you are overwriting the existing one. This may break your application."
-          );
-        }
-      }
       if (resolve && Object.keys(resolve).length) {
         loaders[name] = resolve;
       }

--- a/packages/interactions/route-prefetch/tests/prefetch.spec.ts
+++ b/packages/interactions/route-prefetch/tests/prefetch.spec.ts
@@ -1,6 +1,6 @@
 import "jest";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import createPrefetch from "@curi/route-prefetch";
 
 import { HickoryLocation } from "@hickory/root";
@@ -29,7 +29,7 @@ describe("prefetch route interaction", () => {
           test: () => Promise.resolve()
         }
       };
-      prefetch.register(route as Route);
+      prefetch.register(route);
 
       expect(prefetch.get("Player")).toBeDefined();
     });
@@ -46,37 +46,6 @@ describe("prefetch route interaction", () => {
         );
       });
     });
-
-    it("warns when registering a route the same name as one already registered", () => {
-      const warn = console.warn;
-      const mockWarn = jest.fn();
-      console.warn = mockWarn;
-
-      const first = {
-        name: "Test",
-        path: "first",
-        keys: [],
-        resolve: {
-          test: () => Promise.resolve()
-        }
-      };
-      const second = {
-        name: "Test",
-        path: "second",
-        keys: [],
-        resolve: {
-          test: () => Promise.resolve()
-        }
-      };
-
-      prefetch.register(first as Route);
-      expect(mockWarn.mock.calls.length).toBe(0);
-
-      prefetch.register(second as Route);
-      expect(mockWarn.mock.calls.length).toBe(1);
-
-      console.warn = warn;
-    });
   });
 
   describe("get", () => {
@@ -89,7 +58,7 @@ describe("prefetch route interaction", () => {
           test: () => Promise.resolve()
         }
       };
-      prefetch.register(route as Route);
+      prefetch.register(route);
       expect(prefetch.get("Player").then).toBeDefined();
     });
 
@@ -119,7 +88,7 @@ describe("prefetch route interaction", () => {
             })
         }
       };
-      prefetch.register(route as Route);
+      prefetch.register(route);
       const output = prefetch.get(name, { id: 123 });
       expect.assertions(2);
       expect(output).toBeInstanceOf(Promise);
@@ -147,7 +116,7 @@ describe("prefetch route interaction", () => {
         };
         const paramsToPass = { id: 1 };
         const locationToPass = {} as HickoryLocation;
-        prefetch.register(route as Route);
+        prefetch.register(route);
         prefetch.get("Player", {
           name: "Player",
           params: paramsToPass,
@@ -167,7 +136,7 @@ describe("prefetch route interaction", () => {
         }
       };
       const prefetch = createPrefetch();
-      prefetch.register(route as Route);
+      prefetch.register(route);
 
       afterEach(() => {
         route.resolve.one.mockReset();
@@ -200,7 +169,7 @@ describe("prefetch route interaction", () => {
           test: () => Promise.resolve()
         }
       };
-      prefetch.register(route as Route);
+      prefetch.register(route);
       expect(prefetch.get("Player").then).toBeDefined();
       prefetch.reset();
       expect.assertions(2);

--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 1645
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 16630,
-    "minified": 6806,
-    "gzipped": 2241
+    "bundled": 14802,
+    "minified": 6072,
+    "gzipped": 2109
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 15632,
-    "minified": 6159,
-    "gzipped": 1912
+    "bundled": 13804,
+    "minified": 5425,
+    "gzipped": 1786
   }
 }

--- a/packages/react-dom/tests/Focus.spec.tsx
+++ b/packages/react-dom/tests/Focus.spec.tsx
@@ -2,7 +2,7 @@ import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
 import InMemory from "@hickory/in-memory";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 // @ts-ignore (resolved by jest)
 import { curiProvider, Focus } from "@curi/react-dom";
@@ -12,7 +12,7 @@ jest.useFakeTimers();
 describe("<Focus>", () => {
   let node;
   let history, router, Router;
-  const routes = buildRoutes([
+  const routes = prepareRoutes([
     { name: "Home", path: "" },
     { name: "About", path: "about" }
   ]);
@@ -62,7 +62,7 @@ describe("<Focus>", () => {
         </div>
       );
 
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Home",
           path: "",
@@ -194,7 +194,7 @@ describe("<Focus>", () => {
             <h1>About</h1>
           </div>
         ));
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Home",
             path: "",
@@ -252,7 +252,7 @@ describe("<Focus>", () => {
           </div>
         );
 
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Home",
             path: "",

--- a/packages/react-dom/tests/Focus.spec.tsx
+++ b/packages/react-dom/tests/Focus.spec.tsx
@@ -2,9 +2,9 @@ import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
 import InMemory from "@hickory/in-memory";
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { curiProvider, Focus } from "@curi/react-dom";
 
 jest.useFakeTimers();
@@ -12,7 +12,10 @@ jest.useFakeTimers();
 describe("<Focus>", () => {
   let node;
   let history, router, Router;
-  const routes = [{ name: "Home", path: "" }, { name: "About", path: "about" }];
+  const routes = buildRoutes([
+    { name: "Home", path: "" },
+    { name: "About", path: "about" }
+  ]);
 
   beforeEach(() => {
     node = document.createElement("div");
@@ -59,7 +62,7 @@ describe("<Focus>", () => {
         </div>
       );
 
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Home",
           path: "",
@@ -67,7 +70,7 @@ describe("<Focus>", () => {
             return { body: Home };
           }
         }
-      ];
+      ]);
 
       const history = InMemory();
       const router = curi(history, routes);
@@ -191,7 +194,7 @@ describe("<Focus>", () => {
             <h1>About</h1>
           </div>
         ));
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "Home",
             path: "",
@@ -206,7 +209,7 @@ describe("<Focus>", () => {
               return { body: About };
             }
           }
-        ];
+        ]);
 
         const history = InMemory();
         const router = curi(history, routes);
@@ -249,7 +252,7 @@ describe("<Focus>", () => {
           </div>
         );
 
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "Home",
             path: "",
@@ -264,7 +267,7 @@ describe("<Focus>", () => {
               return { body: About };
             }
           }
-        ];
+        ]);
 
         const history = InMemory();
         const router = curi(history, routes);

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -3,15 +3,15 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Simulate } from "react-dom/test-utils";
 import InMemory from "@hickory/in-memory";
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { curiProvider, Link } from "@curi/react-dom";
 
 describe("<Link>", () => {
   let node;
   let history, router, Router;
-  const routes = [{ name: "Test", path: "" }];
+  const routes = buildRoutes([{ name: "Test", path: "" }]);
 
   beforeEach(() => {
     node = document.createElement("div");
@@ -68,7 +68,8 @@ describe("<Link>", () => {
       const history = InMemory({
         locations: ["/the-initial-location"]
       });
-      const router = curi(history, [{ name: "Catch All", path: "(.*)" }]);
+      const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
       ReactDOM.render(
         <Router>{() => <Link to={null}>Test</Link>}</Router>,
@@ -81,10 +82,10 @@ describe("<Link>", () => {
 
   describe("params", () => {
     let history, router, Router;
-    const routes = [
+    const routes = buildRoutes([
       { name: "Park", path: "park/:name" },
       { name: "Catch All", path: "(.*)" }
-    ];
+    ]);
 
     beforeEach(() => {
       history = InMemory();
@@ -142,10 +143,11 @@ describe("<Link>", () => {
   describe("hash & query", () => {
     it("merges hash & query props with the pathname when creating href", () => {
       const history = InMemory();
-      const router = curi(history, [
+      const routes = buildRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
       ReactDOM.render(
         <Router>
@@ -165,10 +167,11 @@ describe("<Link>", () => {
   describe("ref", () => {
     it("returns the anchor's ref, not the link's", () => {
       const history = InMemory();
-      const router = curi(history, [
+      const routes = buildRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
       const ref = React.createRef();
       ReactDOM.render(
@@ -190,10 +193,11 @@ describe("<Link>", () => {
     describe("React Node", () => {
       it("renders the provided children value(s)", () => {
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
         const children = "Test Value";
         ReactDOM.render(
@@ -208,10 +212,11 @@ describe("<Link>", () => {
     describe("render-invoked function", () => {
       it("calls the function with the component's navigating state (initial navigating=false)", () => {
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
         ReactDOM.render(
           <Router>
@@ -236,8 +241,11 @@ describe("<Link>", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
-
-      const router = curi(history, [{ name: "Test", path: "" }]);
+      const routes = buildRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
       ReactDOM.render(
         <Router>{() => <Link to="Test">Test</Link>}</Router>,
@@ -265,7 +273,7 @@ describe("<Link>", () => {
         // immediately (although this style should only be used for routes
         // with on methods)
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           {
             name: "Test",
             path: "test",
@@ -281,6 +289,7 @@ describe("<Link>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -314,7 +323,7 @@ describe("<Link>", () => {
 
       it("children(false) when navigation is cancelled", () => {
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           { name: "Test", path: "test" },
           {
             name: "Slow",
@@ -336,6 +345,7 @@ describe("<Link>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -379,7 +389,7 @@ describe("<Link>", () => {
 
       it("children(false) when navigation is finished", done => {
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           { name: "Test", path: "test" },
           {
             name: "Loader",
@@ -390,6 +400,7 @@ describe("<Link>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -435,7 +446,7 @@ describe("<Link>", () => {
         console.error = mockError;
 
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           { name: "Test", path: "test" },
           {
             name: "Slow",
@@ -457,6 +468,7 @@ describe("<Link>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -495,8 +507,11 @@ describe("<Link>", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
-
-      const router = curi(history, [{ name: "Test", path: "" }]);
+      const routes = buildRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
 
       ReactDOM.render(
@@ -524,7 +539,7 @@ describe("<Link>", () => {
       Simulate.click(a, leftClickEvent);
       const mockLocation = mockNavigate.mock.calls[0][0];
       expect(mockLocation).toMatchObject({
-        pathname: "/",
+        pathname: "/test",
         hash: "thing",
         query: "one=1",
         state: "yo"
@@ -537,7 +552,11 @@ describe("<Link>", () => {
         const mockNavigate = jest.fn();
         history.navigate = mockNavigate;
         const onClick = jest.fn();
-        const router = curi(history, [{ name: "Test", path: "" }]);
+        const routes = buildRoutes([
+          { name: "Test", path: "test" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -574,7 +593,11 @@ describe("<Link>", () => {
         const onClick = jest.fn(event => {
           event.preventDefault();
         });
-        const router = curi(history, [{ name: "Test", path: "" }]);
+        const routes = buildRoutes([
+          { name: "Test", path: "test" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -610,7 +633,11 @@ describe("<Link>", () => {
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
 
-      const router = curi(history, [{ name: "Test", path: "" }]);
+      const routes = buildRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
 
       ReactDOM.render(
@@ -643,7 +670,11 @@ describe("<Link>", () => {
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
 
-      const router = curi(history, [{ name: "Test", path: "" }]);
+      const routes = buildRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
 
       ReactDOM.render(

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Simulate } from "react-dom/test-utils";
 import InMemory from "@hickory/in-memory";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 // @ts-ignore (resolved by jest)
 import { curiProvider, Link } from "@curi/react-dom";
@@ -11,7 +11,7 @@ import { curiProvider, Link } from "@curi/react-dom";
 describe("<Link>", () => {
   let node;
   let history, router, Router;
-  const routes = buildRoutes([{ name: "Test", path: "" }]);
+  const routes = prepareRoutes([{ name: "Test", path: "" }]);
 
   beforeEach(() => {
     node = document.createElement("div");
@@ -68,7 +68,7 @@ describe("<Link>", () => {
       const history = InMemory({
         locations: ["/the-initial-location"]
       });
-      const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+      const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
       const router = curi(history, routes);
       const Router = curiProvider(router);
       ReactDOM.render(
@@ -82,7 +82,7 @@ describe("<Link>", () => {
 
   describe("params", () => {
     let history, router, Router;
-    const routes = buildRoutes([
+    const routes = prepareRoutes([
       { name: "Park", path: "park/:name" },
       { name: "Catch All", path: "(.*)" }
     ]);
@@ -143,7 +143,7 @@ describe("<Link>", () => {
   describe("hash & query", () => {
     it("merges hash & query props with the pathname when creating href", () => {
       const history = InMemory();
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -167,7 +167,7 @@ describe("<Link>", () => {
   describe("ref", () => {
     it("returns the anchor's ref, not the link's", () => {
       const history = InMemory();
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -193,7 +193,7 @@ describe("<Link>", () => {
     describe("React Node", () => {
       it("renders the provided children value(s)", () => {
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -212,7 +212,7 @@ describe("<Link>", () => {
     describe("render-invoked function", () => {
       it("calls the function with the component's navigating state (initial navigating=false)", () => {
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -241,7 +241,7 @@ describe("<Link>", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -273,7 +273,7 @@ describe("<Link>", () => {
         // immediately (although this style should only be used for routes
         // with on methods)
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Test",
             path: "test",
@@ -323,7 +323,7 @@ describe("<Link>", () => {
 
       it("children(false) when navigation is cancelled", () => {
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
             name: "Slow",
@@ -389,7 +389,7 @@ describe("<Link>", () => {
 
       it("children(false) when navigation is finished", done => {
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
             name: "Loader",
@@ -446,7 +446,7 @@ describe("<Link>", () => {
         console.error = mockError;
 
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
             name: "Slow",
@@ -507,7 +507,7 @@ describe("<Link>", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -552,7 +552,7 @@ describe("<Link>", () => {
         const mockNavigate = jest.fn();
         history.navigate = mockNavigate;
         const onClick = jest.fn();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -593,7 +593,7 @@ describe("<Link>", () => {
         const onClick = jest.fn(event => {
           event.preventDefault();
         });
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -633,7 +633,7 @@ describe("<Link>", () => {
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
 
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -670,7 +670,7 @@ describe("<Link>", () => {
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
 
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import "react-native";
 import renderer from "react-test-renderer";
 import InMemory from "@hickory/in-memory";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 import { TouchableHighlight, Text } from "react-native";
 
 // @ts-ignore (resolved by jest)
@@ -26,7 +26,7 @@ describe("<Link>", () => {
   describe("anchor", () => {
     it("renders a <TouchableHighlight> by default", () => {
       const history = InMemory();
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -47,7 +47,7 @@ describe("<Link>", () => {
 
     it("when provided, it renders the component instead of an anchor", () => {
       const history = InMemory();
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -77,7 +77,7 @@ describe("<Link>", () => {
       const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
-      const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+      const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
       const router = curi(history, routes);
       const Router = curiProvider(router);
 
@@ -99,7 +99,7 @@ describe("<Link>", () => {
   });
 
   describe("params", () => {
-    const routes = buildRoutes([
+    const routes = prepareRoutes([
       { name: "Park", path: "park/:name" },
       { name: "Catch All", path: "(.*)" }
     ]);
@@ -169,7 +169,7 @@ describe("<Link>", () => {
       const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Parks", path: "parks" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -195,7 +195,7 @@ describe("<Link>", () => {
     describe("React Node", () => {
       it("renders the provided children value(s)", () => {
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -222,7 +222,7 @@ describe("<Link>", () => {
     describe("render-invoked function", () => {
       it("calls the function with the component's navigating state (initial navigating=false)", () => {
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -255,7 +255,7 @@ describe("<Link>", () => {
       });
 
       it("[default] navigates as ANCHOR", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -277,7 +277,7 @@ describe("<Link>", () => {
       });
 
       it("method='ANCHOR'", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -299,7 +299,7 @@ describe("<Link>", () => {
       });
 
       it("method='PUSH'", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -321,7 +321,7 @@ describe("<Link>", () => {
       });
 
       it("method='REPLACE'", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -343,7 +343,7 @@ describe("<Link>", () => {
       });
 
       it("[unknown] uses ANCHOR", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -371,7 +371,7 @@ describe("<Link>", () => {
         // immediately (although this style should only be used for routes
         // with resolve methods)
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Test",
             path: "test",
@@ -412,7 +412,7 @@ describe("<Link>", () => {
 
       it("children(false) when navigation is cancelled", () => {
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
             name: "Slow",
@@ -472,7 +472,7 @@ describe("<Link>", () => {
 
       it("children(false) when navigation is finished", done => {
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
             name: "Loader",
@@ -520,7 +520,7 @@ describe("<Link>", () => {
         console.error = mockError;
 
         const history = InMemory();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
             name: "Blork",
@@ -570,7 +570,7 @@ describe("<Link>", () => {
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
 
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -604,7 +604,7 @@ describe("<Link>", () => {
         history.navigate = mockNavigate;
         const onPress = jest.fn();
 
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -635,7 +635,7 @@ describe("<Link>", () => {
           event.preventDefault();
         });
 
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
@@ -663,7 +663,7 @@ describe("<Link>", () => {
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
 
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -2,12 +2,11 @@ import "jest";
 import React from "react";
 import "react-native";
 import renderer from "react-test-renderer";
-
 import InMemory from "@hickory/in-memory";
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 import { TouchableHighlight, Text } from "react-native";
 
-// resolved by Jest
+// @ts-ignore (resolved by jest)
 import { curiProvider, Link } from "@curi/react-native";
 
 import { NavType } from "@hickory/root";
@@ -27,7 +26,11 @@ describe("<Link>", () => {
   describe("anchor", () => {
     it("renders a <TouchableHighlight> by default", () => {
       const history = InMemory();
-      const router = curi(history, [{ name: "Test", path: "" }]);
+      const routes = buildRoutes([
+        { name: "Test", path: "" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
       const tree = renderer.create(
         <Router>
@@ -44,7 +47,11 @@ describe("<Link>", () => {
 
     it("when provided, it renders the component instead of an anchor", () => {
       const history = InMemory();
-      const router = curi(history, [{ name: "Test", path: "" }]);
+      const routes = buildRoutes([
+        { name: "Test", path: "" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
 
       const StyledAnchor = props => (
@@ -70,7 +77,7 @@ describe("<Link>", () => {
       const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
-      const routes = [{ name: "Catch All", path: "(.*)" }];
+      const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
       const router = curi(history, routes);
       const Router = curiProvider(router);
 
@@ -92,10 +99,10 @@ describe("<Link>", () => {
   });
 
   describe("params", () => {
-    const routes = [
+    const routes = buildRoutes([
       { name: "Park", path: "park/:name" },
       { name: "Catch All", path: "(.*)" }
-    ];
+    ]);
 
     it("uses params to generate the location to navigate to", () => {
       const history = InMemory();
@@ -162,10 +169,10 @@ describe("<Link>", () => {
       const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
-      const routes = [
+      const routes = buildRoutes([
         { name: "Parks", path: "parks" },
         { name: "Catch All", path: "(.*)" }
-      ];
+      ]);
       const router = curi(history, routes);
       const Router = curiProvider(router);
 
@@ -188,10 +195,11 @@ describe("<Link>", () => {
     describe("React Node", () => {
       it("renders the provided children value(s)", () => {
         const history = InMemory();
-        const router = curi(history, [
-          { name: "Test", path: "test" },
+        const routes = buildRoutes([
+          { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const children = "Test Value";
@@ -214,10 +222,11 @@ describe("<Link>", () => {
     describe("render-invoked function", () => {
       it("calls the function with the component's navigating state (initial navigating=false)", () => {
         const history = InMemory();
-        const router = curi(history, [
-          { name: "Test", path: "test" },
+        const routes = buildRoutes([
+          { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -246,7 +255,11 @@ describe("<Link>", () => {
       });
 
       it("[default] navigates as ANCHOR", () => {
-        const router = curi(history, [{ name: "Test", path: "" }]);
+        const routes = buildRoutes([
+          { name: "Test", path: "" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -264,7 +277,11 @@ describe("<Link>", () => {
       });
 
       it("method='ANCHOR'", () => {
-        const router = curi(history, [{ name: "Test", path: "" }]);
+        const routes = buildRoutes([
+          { name: "Test", path: "" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -282,7 +299,11 @@ describe("<Link>", () => {
       });
 
       it("method='PUSH'", () => {
-        const router = curi(history, [{ name: "Test", path: "" }]);
+        const routes = buildRoutes([
+          { name: "Test", path: "" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -300,7 +321,11 @@ describe("<Link>", () => {
       });
 
       it("method='REPLACE'", () => {
-        const router = curi(history, [{ name: "Test", path: "" }]);
+        const routes = buildRoutes([
+          { name: "Test", path: "" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -318,7 +343,11 @@ describe("<Link>", () => {
       });
 
       it("[unknown] uses ANCHOR", () => {
-        const router = curi(history, [{ name: "Test", path: "" }]);
+        const routes = buildRoutes([
+          { name: "Test", path: "" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -342,7 +371,7 @@ describe("<Link>", () => {
         // immediately (although this style should only be used for routes
         // with resolve methods)
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           {
             name: "Test",
             path: "test",
@@ -358,6 +387,7 @@ describe("<Link>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -382,7 +412,7 @@ describe("<Link>", () => {
 
       it("children(false) when navigation is cancelled", () => {
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           { name: "Test", path: "test" },
           {
             name: "Slow",
@@ -404,6 +434,7 @@ describe("<Link>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -441,7 +472,7 @@ describe("<Link>", () => {
 
       it("children(false) when navigation is finished", done => {
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           { name: "Test", path: "test" },
           {
             name: "Loader",
@@ -452,6 +483,7 @@ describe("<Link>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -488,7 +520,7 @@ describe("<Link>", () => {
         console.error = mockError;
 
         const history = InMemory();
-        const router = curi(history, [
+        const routes = buildRoutes([
           { name: "Test", path: "test" },
           {
             name: "Blork",
@@ -511,6 +543,7 @@ describe("<Link>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -537,7 +570,11 @@ describe("<Link>", () => {
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
 
-      const router = curi(history, [{ name: "Test", path: "" }]);
+      const routes = buildRoutes([
+        { name: "Test", path: "" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
 
       const tree = renderer.create(
@@ -566,7 +603,12 @@ describe("<Link>", () => {
         const mockNavigate = jest.fn();
         history.navigate = mockNavigate;
         const onPress = jest.fn();
-        const router = curi(history, [{ name: "Test", path: "" }]);
+
+        const routes = buildRoutes([
+          { name: "Test", path: "" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -592,7 +634,12 @@ describe("<Link>", () => {
         const onPress = jest.fn(event => {
           event.preventDefault();
         });
-        const router = curi(history, [{ name: "Test", path: "" }]);
+
+        const routes = buildRoutes([
+          { name: "Test", path: "" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -616,7 +663,11 @@ describe("<Link>", () => {
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
 
-      const router = curi(history, [{ name: "Test", path: "" }]);
+      const routes = buildRoutes([
+        { name: "Test", path: "" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
       const Router = curiProvider(router);
 
       const tree = renderer.create(

--- a/packages/react-universal/tests/Active.spec.tsx
+++ b/packages/react-universal/tests/Active.spec.tsx
@@ -2,7 +2,7 @@ import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
 import InMemory from "@hickory/in-memory";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 import activeInteraction from "@curi/route-active";
 
 // @ts-ignore (resolved by jest)
@@ -12,7 +12,7 @@ describe("<Active>", () => {
   let node;
   let history;
   let router, Router;
-  const routes = buildRoutes([
+  const routes = prepareRoutes([
     { name: "Home", path: "" },
     {
       name: "Contact",

--- a/packages/react-universal/tests/Active.spec.tsx
+++ b/packages/react-universal/tests/Active.spec.tsx
@@ -2,24 +2,24 @@ import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
 import InMemory from "@hickory/in-memory";
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 import activeInteraction from "@curi/route-active";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { curiProvider, Active } from "@curi/react-universal";
 
 describe("<Active>", () => {
   let node;
   let history;
   let router, Router;
-  const routes = [
+  const routes = buildRoutes([
     { name: "Home", path: "" },
     {
       name: "Contact",
       path: "contact",
       children: [{ name: "Method", path: ":method" }]
     }
-  ];
+  ]);
 
   beforeEach(() => {
     node = document.createElement("div");

--- a/packages/react-universal/tests/Block.spec.tsx
+++ b/packages/react-universal/tests/Block.spec.tsx
@@ -1,7 +1,7 @@
 import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 import InMemory from "@hickory/in-memory";
 
 // @ts-ignore (resolved by jest)
@@ -19,7 +19,7 @@ describe("Block", () => {
   // overwrite with jest
   history.confirmWith = confirmWith;
   history.removeConfirmation = removeConfirmation;
-  const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+  const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
   const router = curi(history, routes);
   const Router = curiProvider(router);
 

--- a/packages/react-universal/tests/Block.spec.tsx
+++ b/packages/react-universal/tests/Block.spec.tsx
@@ -1,11 +1,10 @@
 import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
-
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 import InMemory from "@hickory/in-memory";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { curiProvider, Block } from "@curi/react-universal";
 
 describe("Block", () => {
@@ -20,7 +19,8 @@ describe("Block", () => {
   // overwrite with jest
   history.confirmWith = confirmWith;
   history.removeConfirmation = removeConfirmation;
-  const router = curi(history, [{ name: "Catch All", path: "(.*)" }]);
+  const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+  const router = curi(history, routes);
   const Router = curiProvider(router);
 
   beforeEach(() => {

--- a/packages/react-universal/tests/Curious.spec.tsx
+++ b/packages/react-universal/tests/Curious.spec.tsx
@@ -2,15 +2,18 @@ import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
 import InMemory from "@hickory/in-memory";
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { curiProvider, Curious } from "@curi/react-universal";
 
 describe("<Curious>", () => {
   let node;
   let history, router, Router;
-  const routes = [{ name: "Home", path: "" }];
+  const routes = buildRoutes([
+    { name: "Home", path: "" },
+    { name: "Catch All", path: "(.*)" }
+  ]);
 
   beforeEach(() => {
     node = document.createElement("div");

--- a/packages/react-universal/tests/Curious.spec.tsx
+++ b/packages/react-universal/tests/Curious.spec.tsx
@@ -2,7 +2,7 @@ import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
 import InMemory from "@hickory/in-memory";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 // @ts-ignore (resolved by jest)
 import { curiProvider, Curious } from "@curi/react-universal";
@@ -10,7 +10,7 @@ import { curiProvider, Curious } from "@curi/react-universal";
 describe("<Curious>", () => {
   let node;
   let history, router, Router;
-  const routes = buildRoutes([
+  const routes = prepareRoutes([
     { name: "Home", path: "" },
     { name: "Catch All", path: "(.*)" }
   ]);

--- a/packages/react-universal/tests/curiProvider.spec.tsx
+++ b/packages/react-universal/tests/curiProvider.spec.tsx
@@ -1,7 +1,7 @@
 import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 import InMemory from "@hickory/in-memory";
 
 // @ts-ignore (resolved by jest)
@@ -9,7 +9,7 @@ import { curiProvider, Curious } from "@curi/react-universal";
 
 describe("curiProvider()", () => {
   let node;
-  const routes = buildRoutes([
+  const routes = prepareRoutes([
     { name: "Home", path: "" },
     { name: "About", path: "about" },
     { name: "Catch All", path: "(.*)" }
@@ -28,7 +28,7 @@ describe("curiProvider()", () => {
   describe("children prop", () => {
     it("calls children() function when it renders", () => {
       const history = InMemory();
-      const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+      const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
       const router = curi(history, routes);
 
       const fn = jest.fn(() => {

--- a/packages/react-universal/tests/curiProvider.spec.tsx
+++ b/packages/react-universal/tests/curiProvider.spec.tsx
@@ -1,15 +1,19 @@
 import "jest";
 import React from "react";
 import ReactDOM from "react-dom";
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 import InMemory from "@hickory/in-memory";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { curiProvider, Curious } from "@curi/react-universal";
 
 describe("curiProvider()", () => {
   let node;
-  const routes = [{ name: "Home", path: "" }, { name: "About", path: "about" }];
+  const routes = buildRoutes([
+    { name: "Home", path: "" },
+    { name: "About", path: "about" },
+    { name: "Catch All", path: "(.*)" }
+  ]);
 
   beforeEach(() => {
     node = document.createElement("div");
@@ -24,7 +28,8 @@ describe("curiProvider()", () => {
   describe("children prop", () => {
     it("calls children() function when it renders", () => {
       const history = InMemory();
-      const router = curi(history, [{ name: "Catch All", path: "(.*)" }]);
+      const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+      const router = curi(history, routes);
 
       const fn = jest.fn(() => {
         return null;

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 19465,
-    "minified": 7306,
-    "gzipped": 2989,
+    "bundled": 19481,
+    "minified": 7322,
+    "gzipped": 2990,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 19722,
-    "minified": 7509,
-    "gzipped": 3065
+    "bundled": 19740,
+    "minified": 7527,
+    "gzipped": 3066
   },
   "dist/curi-router.umd.js": {
-    "bundled": 32915,
-    "minified": 9845,
-    "gzipped": 4162
+    "bundled": 32933,
+    "minified": 9853,
+    "gzipped": 4163
   },
   "dist/curi-router.min.js": {
-    "bundled": 31469,
-    "minified": 8899,
+    "bundled": 31481,
+    "minified": 8901,
     "gzipped": 3730
   }
 }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 19727,
-    "minified": 7412,
-    "gzipped": 3034,
+    "bundled": 19995,
+    "minified": 7527,
+    "gzipped": 3023,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 19986,
-    "minified": 7617,
-    "gzipped": 3110
+    "bundled": 20254,
+    "minified": 7732,
+    "gzipped": 3099
   },
   "dist/curi-router.umd.js": {
-    "bundled": 33207,
-    "minified": 9943,
-    "gzipped": 4200
+    "bundled": 33470,
+    "minified": 9954,
+    "gzipped": 4179
   },
   "dist/curi-router.min.js": {
-    "bundled": 31826,
-    "minified": 9066,
-    "gzipped": 3797
+    "bundled": 31802,
+    "minified": 8924,
+    "gzipped": 3719
   }
 }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 18450,
-    "minified": 6674,
-    "gzipped": 2759,
+    "bundled": 19465,
+    "minified": 7306,
+    "gzipped": 2989,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 18685,
-    "minified": 6857,
-    "gzipped": 2829
+    "bundled": 19722,
+    "minified": 7509,
+    "gzipped": 3065
   },
   "dist/curi-router.umd.js": {
-    "bundled": 31841,
-    "minified": 9310,
-    "gzipped": 3952
+    "bundled": 32915,
+    "minified": 9845,
+    "gzipped": 4162
   },
   "dist/curi-router.min.js": {
-    "bundled": 30979,
-    "minified": 8770,
-    "gzipped": 3690
+    "bundled": 31469,
+    "minified": 8899,
+    "gzipped": 3730
   }
 }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 19481,
-    "minified": 7322,
-    "gzipped": 2990,
+    "bundled": 19410,
+    "minified": 7251,
+    "gzipped": 2969,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,14 +14,14 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 19740,
-    "minified": 7527,
-    "gzipped": 3066
+    "bundled": 19669,
+    "minified": 7456,
+    "gzipped": 3045
   },
   "dist/curi-router.umd.js": {
-    "bundled": 32933,
-    "minified": 9853,
-    "gzipped": 4163
+    "bundled": 32862,
+    "minified": 9782,
+    "gzipped": 4140
   },
   "dist/curi-router.min.js": {
     "bundled": 31481,

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 19410,
-    "minified": 7251,
-    "gzipped": 2969,
+    "bundled": 19727,
+    "minified": 7412,
+    "gzipped": 3034,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 19669,
-    "minified": 7456,
-    "gzipped": 3045
+    "bundled": 19986,
+    "minified": 7617,
+    "gzipped": 3110
   },
   "dist/curi-router.umd.js": {
-    "bundled": 32862,
-    "minified": 9782,
-    "gzipped": 4140
+    "bundled": 33207,
+    "minified": 9943,
+    "gzipped": 4200
   },
   "dist/curi-router.min.js": {
-    "bundled": 31481,
-    "minified": 8901,
-    "gzipped": 3730
+    "bundled": 31826,
+    "minified": 9066,
+    "gzipped": 3797
   }
 }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 19995,
-    "minified": 7527,
-    "gzipped": 3023,
+    "bundled": 20121,
+    "minified": 7651,
+    "gzipped": 3045,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,14 +14,14 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 20254,
-    "minified": 7732,
-    "gzipped": 3099
+    "bundled": 20380,
+    "minified": 7856,
+    "gzipped": 3122
   },
   "dist/curi-router.umd.js": {
-    "bundled": 33470,
-    "minified": 9954,
-    "gzipped": 4179
+    "bundled": 33596,
+    "minified": 10078,
+    "gzipped": 4205
   },
   "dist/curi-router.min.js": {
     "bundled": 31802,

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Export `prepareRoutes()` function to pre-build routes. Pre-building routes is encouraged and a warning message will be displayed to users who do not pre-build. In `@curi/router` v2, pre-building routes will be required.
+* Throw if routes have duplicate names.
 * Add `url` property to `response.redirectTo`, which is the `pathname`, `query` and `hash` concatenated. Also adds the `name` and `params` to the `redirectTo` object.
 
 ## 1.0.4

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Export `buildRoutes()` function to pre-build routes. Pre-building routes is encouraged and a warning message will be displayed to users who do not pre-build. In `@curi/router` v2, pre-building routes will be required.
+* Export `prepareRoutes()` function to pre-build routes. Pre-building routes is encouraged and a warning message will be displayed to users who do not pre-build. In `@curi/router` v2, pre-building routes will be required.
 * Add `url` property to `response.redirectTo`, which is the `pathname`, `query` and `hash` concatenated. Also adds the `name` and `params` to the `redirectTo` object.
 
 ## 1.0.4

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Export `prepareRoutes()` function to pre-build routes. Pre-building routes is encouraged and a warning message will be displayed to users who do not pre-build. In `@curi/router` v2, pre-building routes will be required.
 * Throw if routes have duplicate names.
+* Deprecate `pathname()` export.
 * Add `url` property to `response.redirectTo`, which is the `pathname`, `query` and `hash` concatenated. Also adds the `name` and `params` to the `redirectTo` object.
 
 ## 1.0.4

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Export `buildRoutes()` function to pre-build routes. Pre-building routes is encouraged and a warning message will be displayed to users who do not pre-build. In `@curi/router` v2, pre-building routes will be required.
 * Add `url` property to `response.redirectTo`, which is the `pathname`, `query` and `hash` concatenated. Also adds the `name` and `params` to the `redirectTo` object.
 
 ## 1.0.4

--- a/packages/router/src/buildRoutes.ts
+++ b/packages/router/src/buildRoutes.ts
@@ -1,0 +1,46 @@
+import createRoute from "./createRoute";
+
+import {
+  UserRoutes,
+  CompiledRoute,
+  RouteDescriptor,
+  CompiledRouteArray
+} from "./types/route";
+
+export default function buildRoutes(
+  userRoutes: UserRoutes
+): CompiledRouteArray {
+  return privateBuildRoutes(userRoutes);
+}
+
+export function privateBuildRoutes(
+  userRoutes: UserRoutes,
+  _privateInternalCall: boolean = false
+): CompiledRouteArray {
+  let hasWarned = false;
+  return userRoutes.map(route => {
+    if ((route as CompiledRoute).public !== undefined) {
+      return route as CompiledRoute;
+    }
+    if (process.env.NODE_ENV !== "production") {
+      if (_privateInternalCall && !hasWarned) {
+        console.warn(`Deprecation Warning: You passed a plain array to your curi() call. This will be
+removed in the next major version. Instead, you should pass a compiled routes array.
+
+import { curi, buildRoutes } from "@curi/router";
+
+const router = curi(
+  history,
+  buildRoutes(routes)
+);
+
+or
+
+const routes = buildRoutes([...]);
+const router = curi(history, routes);`);
+        hasWarned = true;
+      }
+    }
+    return createRoute(route as RouteDescriptor);
+  });
+}

--- a/packages/router/src/createRoute.ts
+++ b/packages/router/src/createRoute.ts
@@ -2,10 +2,10 @@ import PathToRegexp from "path-to-regexp";
 
 import { withLeadingSlash } from "./utils/path";
 
-import { RouteDescriptor, InternalRoute } from "./types/route";
+import { RouteDescriptor, CompiledRoute } from "./types/route";
 import { Key } from "path-to-regexp";
 
-const createRoute = (options: RouteDescriptor): InternalRoute => {
+const createRoute = (options: RouteDescriptor): CompiledRoute => {
   let path = options.path;
 
   if (path.charAt(0) === "/") {
@@ -22,7 +22,7 @@ const createRoute = (options: RouteDescriptor): InternalRoute => {
   // set this resolve setting pathOptions.end for children
   const mustBeExact = pathOptions.end == null || pathOptions.end;
 
-  let children: Array<InternalRoute> = [];
+  let children: Array<CompiledRoute> = [];
   // when we have child routes, we need to perform non-end matching and
   // create route objects for each child
   if (options.children && options.children.length) {

--- a/packages/router/src/createRoute.ts
+++ b/packages/router/src/createRoute.ts
@@ -5,7 +5,19 @@ import { withLeadingSlash } from "./utils/path";
 import { RouteDescriptor, CompiledRoute } from "./types/route";
 import { Key } from "path-to-regexp";
 
-const createRoute = (options: RouteDescriptor): CompiledRoute => {
+const createRoute = (
+  options: RouteDescriptor,
+  usedNames: Set<string>
+): CompiledRoute => {
+  if (usedNames.has(options.name)) {
+    throw new Error(
+      `Multiple routes have the name "${
+        options.name
+      }". Route names must be unique.`
+    );
+  }
+  usedNames.add(options.name);
+
   let path = options.path;
 
   if (path.charAt(0) === "/") {
@@ -27,7 +39,9 @@ const createRoute = (options: RouteDescriptor): CompiledRoute => {
   // create route objects for each child
   if (options.children && options.children.length) {
     pathOptions.end = false;
-    children = options.children.map(createRoute);
+    children = options.children.map(child => {
+      return createRoute(child, usedNames);
+    });
   }
 
   // keys is populated by PathToRegexp

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -3,7 +3,7 @@ import pathnameInteraction from "./interactions/pathname";
 import finishResponse from "./finishResponse";
 import matchLocation from "./matchLocation";
 import resolveMatchedRoute from "./resolveMatchedRoute";
-import { privateBuildRoutes } from "./buildRoutes";
+import { privatePrepareRoutes } from "./prepareRoutes";
 
 import { History, PendingNavigation } from "@hickory/root";
 
@@ -64,7 +64,7 @@ export default function createRouter(
 
   function setupRoutesAndInteractions(userRoutes?: UserRoutes): void {
     if (userRoutes) {
-      routes = privateBuildRoutes(userRoutes, true);
+      routes = privatePrepareRoutes(userRoutes, true);
       for (let key in routeInteractions) {
         delete routeInteractions[key];
       }

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -3,11 +3,16 @@ import pathnameInteraction from "./interactions/pathname";
 import finishResponse from "./finishResponse";
 import matchLocation from "./matchLocation";
 import resolveMatchedRoute from "./resolveMatchedRoute";
-import createRoute from "./route";
+import { privateBuildRoutes } from "./buildRoutes";
 
 import { History, PendingNavigation } from "@hickory/root";
 
-import { RouteDescriptor, InternalRoute, ResolveResults } from "./types/route";
+import {
+  RouteDescriptor,
+  UserRoutes,
+  CompiledRouteArray,
+  ResolveResults
+} from "./types/route";
 import { Response } from "./types/response";
 import { Interactions } from "./types/interaction";
 import { Match } from "./types/match";
@@ -25,7 +30,7 @@ import {
 
 export default function createRouter(
   history: History,
-  routeArray: Array<RouteDescriptor>,
+  routeArray: UserRoutes,
   options: RouterOptions = {}
 ): CuriRouter {
   const {
@@ -35,7 +40,7 @@ export default function createRouter(
     automaticRedirects = true
   } = options;
 
-  let routes: Array<InternalRoute> = [];
+  let routes: CompiledRouteArray;
   const routeInteractions: Interactions = {};
 
   // the navigation currently being processed
@@ -57,11 +62,9 @@ export default function createRouter(
   let observers: Array<Observer> = [];
   const oneTimers: Array<Observer> = [];
 
-  function setupRoutesAndInteractions(
-    routeArray?: Array<RouteDescriptor>
-  ): void {
-    if (routeArray) {
-      routes = routeArray.map(createRoute);
+  function setupRoutesAndInteractions(userRoutes?: UserRoutes): void {
+    if (userRoutes) {
+      routes = privateBuildRoutes(userRoutes, true);
       for (let key in routeInteractions) {
         delete routeInteractions[key];
       }

--- a/packages/router/src/deprecatedOnce.ts
+++ b/packages/router/src/deprecatedOnce.ts
@@ -7,10 +7,10 @@ export default function deprecatedOnce(fn: AnyFn) {
   if (process.env.NODE_ENV !== "production") {
     if (!hasWarned) {
       console.warn(`Deprecation warning:
-  once() has been moved to the @curi/helpers package.
-  Please install @curi/helpers and import once() from that package instead.
-  
-  import { once } from "@curi/helpers";`);
+once() has been moved to the @curi/helpers package.
+Please install @curi/helpers and import once() from that package instead.
+
+import { once } from "@curi/helpers";`);
       hasWarned = true;
     }
   }

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -3,5 +3,6 @@ export * from "./types";
 import curi from "./curi";
 import pathname from "./interactions/pathname";
 import once from "./deprecatedOnce";
+import buildRoutes from "./buildRoutes";
 
-export { curi, pathname, once };
+export { curi, pathname, once, buildRoutes };

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -3,6 +3,6 @@ export * from "./types";
 import curi from "./curi";
 import pathname from "./interactions/pathname";
 import once from "./deprecatedOnce";
-import buildRoutes from "./buildRoutes";
+import prepareRoutes from "./prepareRoutes";
 
-export { curi, pathname, once, buildRoutes };
+export { curi, pathname, once, prepareRoutes };

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,7 +1,7 @@
 export * from "./types";
 
 import curi from "./curi";
-import pathname from "./interactions/pathname";
+import pathname from "./interactions/deprecatedPathname";
 import once from "./deprecatedOnce";
 import prepareRoutes from "./prepareRoutes";
 

--- a/packages/router/src/interactions/deprecatedPathname.ts
+++ b/packages/router/src/interactions/deprecatedPathname.ts
@@ -10,7 +10,11 @@ export default function deprecatedPathname(
   if (process.env.NODE_ENV !== "production") {
     if (!hasWarned) {
       console.warn(`Deprecation warning:
-pathname() should not be called manually. It will be removed in the next major version of @curi/router.`);
+pathname() should not be called manually. It will be removed in the next major version of @curi/router.
+Please use router.route.pathname() instead.
+
+const router = curi(history, routes);
+router.route.pathname("Route Name");`);
       hasWarned = true;
     }
   }

--- a/packages/router/src/interactions/deprecatedPathname.ts
+++ b/packages/router/src/interactions/deprecatedPathname.ts
@@ -1,0 +1,18 @@
+import pathname from "./pathname";
+
+import { PathFunction, PathFunctionOptions } from "path-to-regexp";
+import { Interaction } from "../types/interaction";
+
+export default function deprecatedPathname(
+  options?: PathFunctionOptions
+): Interaction {
+  let hasWarned = false;
+  if (process.env.NODE_ENV !== "production") {
+    if (!hasWarned) {
+      console.warn(`Deprecation warning:
+pathname() should not be called manually. It will be removed in the next major version of @curi/router.`);
+      hasWarned = true;
+    }
+  }
+  return pathname(options);
+}

--- a/packages/router/src/interactions/pathname.ts
+++ b/packages/router/src/interactions/pathname.ts
@@ -13,22 +13,16 @@ function generatePathname(options?: PathFunctionOptions): Interaction {
   return {
     name: "pathname",
     register: (route: Route, parent: string): string => {
-      const { name, path } = route;
-      if (knownPaths[name] !== undefined) {
-        console.warn(
-          'A route with the name "' +
-            name +
-            '" already exists. Each route should' +
-            "have a unique name. By registering a route with a name that already exists, " +
-            "you are overwriting the existing one. This may break your application."
-        );
-      }
+      const { name, path, pathname } = route;
 
       let base;
       if (parent && knownPaths[parent]) {
         base = knownPaths[parent];
       }
       knownPaths[name] = withLeadingSlash(base ? join(base, path) : path);
+      if (pathname) {
+        cache[name] = pathname;
+      }
       return name;
     },
     get: (name: string, params: Params): string | void => {

--- a/packages/router/src/matchLocation.ts
+++ b/packages/router/src/matchLocation.ts
@@ -2,12 +2,12 @@ import { withLeadingSlash } from "./utils/path";
 import parseParams from "./utils/parseParams";
 
 import { HickoryLocation } from "@hickory/root";
-import { InternalRoute } from "./types/route";
+import { CompiledRoute } from "./types/route";
 import { PossibleMatch, Match, MatchingRoute } from "./types/match";
 import { Params, RawParams } from "./types/response";
 
 function matchRoute(
-  route: InternalRoute,
+  route: CompiledRoute,
   pathname: string
 ): Array<MatchingRoute> {
   const testPath: string = pathname;
@@ -87,7 +87,7 @@ function createMatch(
 
 export default function matchLocation(
   location: HickoryLocation,
-  routes: Array<InternalRoute>
+  routes: Array<CompiledRoute>
 ): PossibleMatch {
   // determine which route(s) match, then use the exact match
   // as the matched route and the rest as partial routes

--- a/packages/router/src/prepareRoutes.ts
+++ b/packages/router/src/prepareRoutes.ts
@@ -29,13 +29,6 @@ removed in the next major version. Instead, you should pass a compiled routes ar
 
 import { curi, prepareRoutes } from "@curi/router";
 
-const router = curi(
-  history,
-  prepareRoutes(routes)
-);
-
-or
-
 const routes = prepareRoutes([...]);
 const router = curi(history, routes);`);
         hasWarned = true;

--- a/packages/router/src/prepareRoutes.ts
+++ b/packages/router/src/prepareRoutes.ts
@@ -25,8 +25,8 @@ export function privatePrepareRoutes(
     }
     if (process.env.NODE_ENV !== "production") {
       if (_privateInternalCall && !hasWarned) {
-        console.warn(`Deprecation Warning: You passed a plain array to your curi() call. This will be
-removed in the next major version. Instead, you should pass a compiled routes array.
+        console.warn(`Deprecation Warning:
+You passed a plain array to your curi() call. This will be removed in the next major version. Instead, you should pass a compiled routes array.
 
 import { curi, prepareRoutes } from "@curi/router";
 
@@ -35,6 +35,6 @@ const router = curi(history, routes);`);
         hasWarned = true;
       }
     }
-    return createRoute(route as RouteDescriptor, usedNames);
+    return createRoute(route as RouteDescriptor, null, usedNames);
   });
 }

--- a/packages/router/src/prepareRoutes.ts
+++ b/packages/router/src/prepareRoutes.ts
@@ -7,13 +7,13 @@ import {
   CompiledRouteArray
 } from "./types/route";
 
-export default function buildRoutes(
+export default function prepareRoutes(
   userRoutes: UserRoutes
 ): CompiledRouteArray {
-  return privateBuildRoutes(userRoutes);
+  return privatePrepareRoutes(userRoutes);
 }
 
-export function privateBuildRoutes(
+export function privatePrepareRoutes(
   userRoutes: UserRoutes,
   _privateInternalCall: boolean = false
 ): CompiledRouteArray {
@@ -27,16 +27,16 @@ export function privateBuildRoutes(
         console.warn(`Deprecation Warning: You passed a plain array to your curi() call. This will be
 removed in the next major version. Instead, you should pass a compiled routes array.
 
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 const router = curi(
   history,
-  buildRoutes(routes)
+  prepareRoutes(routes)
 );
 
 or
 
-const routes = buildRoutes([...]);
+const routes = prepareRoutes([...]);
 const router = curi(history, routes);`);
         hasWarned = true;
       }

--- a/packages/router/src/prepareRoutes.ts
+++ b/packages/router/src/prepareRoutes.ts
@@ -18,6 +18,7 @@ export function privatePrepareRoutes(
   _privateInternalCall: boolean = false
 ): CompiledRouteArray {
   let hasWarned = false;
+  const usedNames: Set<string> = new Set();
   return userRoutes.map(route => {
     if ((route as CompiledRoute).public !== undefined) {
       return route as CompiledRoute;
@@ -34,6 +35,6 @@ const router = curi(history, routes);`);
         hasWarned = true;
       }
     }
-    return createRoute(route as RouteDescriptor);
+    return createRoute(route as RouteDescriptor, usedNames);
   });
 }

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -2,7 +2,7 @@ import { History, Action, NavType } from "@hickory/root";
 import { PathFunctionOptions } from "path-to-regexp";
 
 import { Interaction, Interactions } from "./interaction";
-import { RouteDescriptor } from "./route";
+import { UserRoutes } from "./route";
 import { Response, Params } from "./response";
 
 export interface Navigation {
@@ -48,7 +48,7 @@ export interface NavigationDetails {
 }
 
 export interface CuriRouter {
-  refresh: (routeArray?: Array<RouteDescriptor>) => void;
+  refresh: (routeArray?: UserRoutes) => void;
   observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
   once: (fn: Observer, options?: ResponseHandlerOptions) => void;
   route: Interactions;

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -13,7 +13,10 @@ export {
   AsyncMatchFn,
   AsyncGroup,
   Resolved,
-  ResolveResults
+  ResolveResults,
+  CompiledRoute,
+  CompiledRouteArray,
+  UserRoutes
 } from "./route";
 export {
   Response,

--- a/packages/router/src/types/match.ts
+++ b/packages/router/src/types/match.ts
@@ -1,8 +1,8 @@
-import { InternalRoute } from "./route";
+import { CompiledRoute } from "./route";
 import { Params, MatchResponseProperties } from "./response";
 
 export interface MatchingRoute {
-  route: InternalRoute;
+  route: CompiledRoute;
   params: Params;
 }
 
@@ -12,7 +12,7 @@ export interface MissMatch {
 }
 
 export interface Match {
-  route: InternalRoute;
+  route: CompiledRoute;
   match: MatchResponseProperties;
 }
 

--- a/packages/router/src/types/route.ts
+++ b/packages/router/src/types/route.ts
@@ -1,4 +1,4 @@
-import { RegExpOptions, Key } from "path-to-regexp";
+import { RegExpOptions, Key, PathFunction } from "path-to-regexp";
 
 import {
   MatchResponseProperties,
@@ -61,6 +61,7 @@ export interface Route {
   keys: Array<string | number>;
   resolve: AsyncGroup;
   extra?: { [key: string]: any };
+  pathname: PathFunction;
 }
 
 export interface PathMatching {

--- a/packages/router/src/types/route.ts
+++ b/packages/router/src/types/route.ts
@@ -42,6 +42,15 @@ export interface RouteDescriptor {
   extra?: { [key: string]: any };
 }
 
+export interface CompiledRoute {
+  public: Route;
+  sync: boolean;
+  children: Array<CompiledRoute>;
+  response?: ResponseFn;
+  pathMatching: PathMatching;
+  paramParsers?: ParamParsers;
+}
+
 /*
  * These are the route properties that will be available
  * to route interactions
@@ -60,11 +69,5 @@ export interface PathMatching {
   keys: Array<Key>;
 }
 
-export interface InternalRoute {
-  public: Route;
-  sync: boolean;
-  children: Array<InternalRoute>;
-  response?: ResponseFn;
-  pathMatching: PathMatching;
-  paramParsers?: ParamParsers;
-}
+export type CompiledRouteArray = Array<CompiledRoute>;
+export type UserRoutes = Array<CompiledRoute | RouteDescriptor>;

--- a/packages/router/src/utils/registerRoutes.ts
+++ b/packages/router/src/utils/registerRoutes.ts
@@ -1,8 +1,8 @@
-import { InternalRoute } from "../types/route";
+import { CompiledRoute } from "../types/route";
 import { Interaction } from "../types/interaction";
 
 export default function registerRoutes(
-  routes: Array<InternalRoute>,
+  routes: Array<CompiledRoute>,
   interaction: Interaction,
   parentData?: any
 ) {

--- a/packages/router/tests/addons-pathname.spec.ts
+++ b/packages/router/tests/addons-pathname.spec.ts
@@ -1,111 +1,76 @@
 import "jest";
+import InMemory from "@hickory/in-memory";
+import { Route } from "@curi/router";
 
 // @ts-ignore (resolved by jest)
-import { pathname } from "@curi/router";
+import { pathname, prepareRoutes, curi } from "@curi/router";
 
-describe("pathnameInteraction route interaction", () => {
-  let pathnameInteraction;
+describe("pathname route interaction", () => {
+  const history = InMemory();
 
-  beforeEach(() => {
-    pathnameInteraction = pathname();
-  });
+  describe("using directly", () => {
+    it("warns that using pathname directly is deprecated", () => {
+      const realWarn = console.warn;
+      const fakeWarn = jest.fn();
+      console.warn = fakeWarn;
 
-  describe("name", () => {
-    it("is pathname", () => {
-      expect(pathnameInteraction.name).toBe("pathname");
-    });
-  });
+      const pathnameInteraction = pathname();
 
-  describe("register", () => {
-    it("adds the path to the known paths", () => {
       const player = { name: "Player", path: "player" };
-      pathnameInteraction.register(player);
-      expect(pathnameInteraction.get("Player")).toBeDefined();
-    });
+      pathnameInteraction.register(player as Route);
 
-    it("merges path with parent path", () => {
-      const grandparent = { name: "Grandparent", path: "grandparent" };
-      const parent = { name: "Parent", path: "parent" };
-      const child = { name: "Child", path: "child" };
-      pathnameInteraction.register(grandparent);
-      pathnameInteraction.register(parent, "Grandparent");
-      pathnameInteraction.register(child, "Parent");
-      expect(pathnameInteraction.get("Child")).toBe(
-        "/grandparent/parent/child"
-      );
-    });
+      expect(fakeWarn.mock.calls.length).toBe(1);
 
-    it("merges when there is a trailing slash", () => {
-      const parent = { name: "Parent", path: "parent/" };
-      const child = { name: "Child", path: "child" };
-      pathnameInteraction.register(parent);
-      pathnameInteraction.register(child, "Parent");
-      expect(pathnameInteraction.get("Child")).toBe("/parent/child");
-    });
-
-    it("warns when registering the same name", () => {
-      const warn = console.warn;
-      const mockWarn = jest.fn();
-      console.warn = mockWarn;
-
-      const first = { name: "Test", path: "first" };
-      const second = { name: "Test", path: "second" };
-
-      pathnameInteraction.register(first);
-      expect(mockWarn.mock.calls.length).toBe(0);
-
-      pathnameInteraction.register(second);
-      expect(mockWarn.mock.calls.length).toBe(1);
-
-      console.warn = warn;
+      console.warn = realWarn;
     });
   });
 
-  describe("get", () => {
-    it("returns a pathnameInteraction using params", () => {
-      const player = { name: "Player", path: "player/:id" };
-      pathnameInteraction.register(player);
-      const output = pathnameInteraction.get("Player", { id: 17 });
+  describe("calling", () => {
+    it("it is accessed through route.name()", () => {
+      const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
+      const router = curi(history, routes);
+      expect(router.route.pathname).toBeDefined();
+    });
+  });
+
+  describe("generating pathnames", () => {
+    it("works when paths contain no params", () => {
+      // duh?
+      const routes = prepareRoutes([
+        { name: "Static", path: "this/has/no/params" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const output = router.route.pathname("Static");
+      expect(output).toBe("/this/has/no/params");
+    });
+
+    it("returns a pathname using params", () => {
+      const routes = prepareRoutes([
+        { name: "Player", path: "player/:id" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const output = router.route.pathname("Player", { id: 17 });
       expect(output).toBe("/player/17");
     });
 
-    it("returns undefined when path not found", () => {
+    it("returns undefined and logs error when path not found", () => {
       const error = console.error;
       const mockError = jest.fn();
       console.error = mockError;
 
-      const output = pathnameInteraction.get("Anonymous", { id: 123 });
+      const routes = prepareRoutes([
+        { name: "Player", path: "player/:id" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const output = router.route.pathname("Anonymous", { id: 123 });
+
       expect(output).toBe(undefined);
       expect(mockError.mock.calls.length).toBe(1);
 
       console.error = error;
-    });
-
-    it("works when paths contain no params", () => {
-      // duh?
-      const staticRoute = { name: "Static", path: "this/has/no/params" };
-      pathnameInteraction.register(staticRoute);
-      const output = pathnameInteraction.get("Static");
-      expect(output).toBe("/this/has/no/params");
-    });
-
-    it("re-uses compiled fn on subsequent calls", () => {
-      // this test is just added for coverage
-      const player = { name: "Player", path: "player/:id" };
-      pathnameInteraction.register(player);
-      const output = pathnameInteraction.get("Player", { id: 17 });
-      expect(output).toBe("/player/17");
-      const output2 = pathnameInteraction.get("Player", { id: 71 });
-      expect(output2).toBe("/player/71");
-    });
-
-    it("does not add extra leading slash if path begins with slash", () => {
-      // another code coverage test. There wasn't a "good" place to
-      // put this
-      const player = { name: "Player", path: "/player/:id" };
-      pathnameInteraction.register(player);
-      const output = pathnameInteraction.get("Player", { id: 17 });
-      expect(output).toBe("/player/17");
     });
   });
 });

--- a/packages/router/tests/buildRoutes.spec.ts
+++ b/packages/router/tests/buildRoutes.spec.ts
@@ -1,0 +1,35 @@
+import "jest";
+
+// @ts-ignore (resolved by jest)
+import { buildRoutes } from "@curi/router";
+
+describe("buildRoutes()", () => {
+  describe("paths beginning with forward slash", () => {
+    const realWarn = console.warn;
+    const fakeWarn = (console.warn = jest.fn());
+
+    afterEach(() => {
+      fakeWarn.mockReset();
+    });
+
+    afterAll(() => {
+      console.warn = realWarn;
+    });
+
+    it("removes the leading slash", () => {
+      const routes = buildRoutes([
+        { name: "Home", path: "/" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      expect(routes[0].public.path).toBe("");
+    });
+
+    it("warns", () => {
+      const routes = buildRoutes([
+        { name: "Home", path: "/" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      expect(fakeWarn.mock.calls.length).toBe(1);
+    });
+  });
+});

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -5,7 +5,7 @@ import { RemoveObserver } from "../src/types";
 import { NavType } from "@hickory/root";
 
 // @ts-ignore (resolved by jest)
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 describe("curi", () => {
   let history;
@@ -18,7 +18,7 @@ describe("curi", () => {
     // these tests rely on the fact that the pathname generator
     // is a default interaction
     it("registers routes", () => {
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "About", path: "about" },
         { name: "Contact", path: "contact" }
@@ -32,7 +32,7 @@ describe("curi", () => {
     });
 
     it("registers nested routes", () => {
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "About", path: "about" },
         {
@@ -73,7 +73,7 @@ describe("curi", () => {
     });
 
     it("makes interactions available through router.route", () => {
-      const routes = buildRoutes([{ name: "Home", path: "" }]);
+      const routes = prepareRoutes([{ name: "Home", path: "" }]);
       const createfakeInteraction = () => ({
         name: "fake",
         register: () => {},
@@ -89,7 +89,7 @@ describe("curi", () => {
     describe("options", () => {
       describe("interactions", () => {
         it("includes pathname interaction by default", () => {
-          const routes = buildRoutes([{ name: "Home", path: "" }]);
+          const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const router = curi(history, routes);
           expect(router.route.pathname).toBeDefined();
         });
@@ -107,7 +107,7 @@ describe("curi", () => {
             };
           };
 
-          const routes = buildRoutes([{ name: "Home", path: "" }]);
+          const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const router = curi(history, routes, {
             route: [createfirstInteraction()]
           });
@@ -144,7 +144,7 @@ describe("curi", () => {
             };
           };
 
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Grandparent",
               path: "grandparent",
@@ -193,7 +193,7 @@ describe("curi", () => {
 
       describe("sideEffects", () => {
         it("calls side effect methods AFTER a response is generated, passing response, navigation, and router", done => {
-          const routes = buildRoutes([{ name: "All", path: "(.*)" }]);
+          const routes = prepareRoutes([{ name: "All", path: "(.*)" }]);
           const sideEffect = jest.fn();
 
           const router = curi(history, routes, {
@@ -209,7 +209,7 @@ describe("curi", () => {
         });
 
         it("passes response, navigation, and router object to side effect", done => {
-          const routes = buildRoutes([{ name: "All", path: "(.*)" }]);
+          const routes = prepareRoutes([{ name: "All", path: "(.*)" }]);
           const sideEffect = function({ response, navigation, router }) {
             expect(response).toMatchObject({
               name: "All",
@@ -230,7 +230,7 @@ describe("curi", () => {
 
       describe("emitRedirects", () => {
         it("emits redirects by default", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Start",
               path: "",
@@ -260,7 +260,7 @@ describe("curi", () => {
         });
 
         it("does not emit redirects when emitRedirects = false", done => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Start",
               path: "",
@@ -291,7 +291,7 @@ describe("curi", () => {
 
       describe("automaticRedirects", () => {
         it("automatically redirects by default", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Start",
               path: "",
@@ -326,7 +326,7 @@ describe("curi", () => {
         });
 
         it("does not automatically redirect when automaticRedirects = false", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Start",
               path: "",
@@ -361,7 +361,7 @@ describe("curi", () => {
 
     describe("sync/async matching", () => {
       it("does synchronous matching by default", () => {
-        const routes = buildRoutes([{ name: "Home", path: "" }]);
+        const routes = prepareRoutes([{ name: "Home", path: "" }]);
         const router = curi(history, routes);
         const after = jest.fn();
         router.once(r => {
@@ -371,7 +371,7 @@ describe("curi", () => {
       });
 
       it("does asynchronous matching when route.resolve isn't empty", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Home",
             path: "",
@@ -389,7 +389,7 @@ describe("curi", () => {
       });
 
       it("still does synchronous matching when a different route is async", done => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Parent",
             path: "parent",
@@ -425,7 +425,7 @@ describe("curi", () => {
   describe("current", () => {
     describe("sync", () => {
       it("initial value is an object with resolved response and navigation properties", () => {
-        const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+        const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
         const router = curi(history, routes);
         expect(router.current()).toMatchObject({
           response: { name: "Catch All" },
@@ -436,7 +436,7 @@ describe("curi", () => {
 
     describe("async", () => {
       it("initial value is an object with null response and navigation properties", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Catch All",
             path: "(.*)",
@@ -454,7 +454,7 @@ describe("curi", () => {
     });
 
     it("response and navigation are the last resolved response and navigation", () => {
-      const routes = buildRoutes([{ name: "Home", path: "" }]);
+      const routes = prepareRoutes([{ name: "Home", path: "" }]);
       const router = curi(history, routes);
       router.once(({ response, navigation }) => {
         expect(router.current()).toMatchObject({
@@ -465,7 +465,7 @@ describe("curi", () => {
     });
 
     it("updates properties when a new response is resolved", done => {
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "About", path: "about" }
       ]);
@@ -498,12 +498,12 @@ describe("curi", () => {
     });
 
     it("resets and replaces registered routes", () => {
-      const englishRoutes = buildRoutes([
+      const englishRoutes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "About", path: "about" },
         { name: "Contact", path: "contact" }
       ]);
-      const spanishRoutes = buildRoutes([
+      const spanishRoutes = prepareRoutes([
         { name: "Casa", path: "" },
         { name: "Acerca De", path: "acerca-de" },
         { name: "Contacto", path: "contacto" }
@@ -528,11 +528,11 @@ describe("curi", () => {
       const history = InMemory({
         locations: ["/admin"]
       });
-      const nonAuthRoutes = buildRoutes([
+      const nonAuthRoutes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "Not Found", path: "(.*)" }
       ]);
-      const authRoutes = buildRoutes([
+      const authRoutes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "Admin", path: "admin" },
         { name: "Not Found", path: "(.*)" }
@@ -550,7 +550,7 @@ describe("curi", () => {
     });
 
     it("emits a response when called with no argument", done => {
-      const englishRoutes = buildRoutes([
+      const englishRoutes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "About", path: "about" },
         { name: "Contact", path: "contact" }
@@ -577,7 +577,7 @@ describe("curi", () => {
     });
 
     it("re-uses previously emitted navigation.previous", done => {
-      const englishRoutes = buildRoutes([
+      const englishRoutes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "About", path: "about" },
         { name: "Contact", path: "contact" }
@@ -609,7 +609,7 @@ describe("curi", () => {
     });
 
     it("returns a function to unsubscribe when called", () => {
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "Not Found", path: "(.*)" }
       ]);
@@ -634,7 +634,7 @@ describe("curi", () => {
 
     describe("response handler", () => {
       it("is passed object with response, navigation, and router", done => {
-        const routes = buildRoutes([{ name: "All", path: "(.*)" }]);
+        const routes = prepareRoutes([{ name: "All", path: "(.*)" }]);
         const responseHandler = function({ response, navigation, router }) {
           expect(response).toMatchObject({
             name: "All",
@@ -653,7 +653,7 @@ describe("curi", () => {
 
       it("is called when response is emitted", () => {
         const How = { name: "How", path: ":method" };
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Home", path: "" },
           { name: "About", path: "about" },
           { name: "Contact", path: "contact", children: [How] }
@@ -679,7 +679,7 @@ describe("curi", () => {
       });
 
       it("is re-called for new responses", done => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Home", path: "" },
           { name: "Contact", path: "contact" },
           { name: "Not Found", path: "(.*)" }
@@ -706,7 +706,7 @@ describe("curi", () => {
       it("is called BEFORE once() response handlers", done => {
         // need to use an async route so that handlers are registered before
         // the initial response is ready
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Home",
             path: "",
@@ -730,7 +730,7 @@ describe("curi", () => {
       describe("matched route is async", () => {
         it("is called AFTER promises have resolved", done => {
           let promiseResolved = false;
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             { name: "Home", path: "" },
             { name: "About", path: "about" },
             {
@@ -761,7 +761,7 @@ describe("curi", () => {
         });
 
         it("does not emit responses for cancelled navigation", done => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             { name: "Home", path: "" },
             { name: "About", path: "about" },
             {
@@ -794,7 +794,7 @@ describe("curi", () => {
     describe("response handler options", () => {
       describe("{ initial: true } (default)", () => {
         it("immediately called with most recent response/navigation", () => {
-          const routes = buildRoutes([{ name: "Home", path: "" }]);
+          const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const sub = jest.fn();
           const router = curi(history, routes);
           const { response, navigation } = router.current();
@@ -809,7 +809,7 @@ describe("curi", () => {
         });
 
         it("[async] immediately called if initial response has resolved", done => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Home",
               path: "",
@@ -828,7 +828,7 @@ describe("curi", () => {
         });
 
         it("[async] not immediately called if initial response hasn't resolved", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Home",
               path: "",
@@ -846,7 +846,7 @@ describe("curi", () => {
 
       describe("{ initial: false }", () => {
         it("has response, is not immediately called", done => {
-          const routes = buildRoutes([{ name: "Home", path: "" }]);
+          const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const everyTime = jest.fn();
           const router = curi(history, routes);
           router.once(() => {
@@ -857,7 +857,7 @@ describe("curi", () => {
         });
 
         it("is called AFTER next navigation", done => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             { name: "Home", path: "" },
             { name: "Catch All", path: "(.*)" }
           ]);
@@ -884,7 +884,7 @@ describe("curi", () => {
 
     describe("response handler", () => {
       it("is passed object with response, navigation, and router", done => {
-        const routes = buildRoutes([{ name: "All", path: "(.*)" }]);
+        const routes = prepareRoutes([{ name: "All", path: "(.*)" }]);
         const responseHandler = function({ response, navigation, router }) {
           expect(response).toMatchObject({
             name: "All",
@@ -902,7 +902,7 @@ describe("curi", () => {
       });
 
       it("is called when response is emitted", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Home", path: "" },
           { name: "Contact", path: "contact" },
           { name: "Not Found", path: "(.*)" }
@@ -915,7 +915,7 @@ describe("curi", () => {
 
       it("isn't re-called for new responses", () => {
         //
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Home", path: "" },
           { name: "Contact", path: "contact" },
           { name: "Not Found", path: "(.*)" }
@@ -944,7 +944,7 @@ describe("curi", () => {
       it("is called AFTER observe() response handlers", done => {
         // need to use an async route so that handlers are registered before
         // the initial response is ready
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Home",
             path: "",
@@ -968,7 +968,7 @@ describe("curi", () => {
       describe("matched route is async", () => {
         it("is called AFTER promises have resolved", done => {
           let promiseResolved = false;
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             { name: "Home", path: "" },
             { name: "About", path: "about" },
             {
@@ -999,7 +999,7 @@ describe("curi", () => {
         });
 
         it("does not emit responses for cancelled navigation", done => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             { name: "Home", path: "" },
             { name: "About", path: "about" },
             {
@@ -1032,7 +1032,7 @@ describe("curi", () => {
     describe("response handler options", () => {
       describe("{ initial: true } (default)", () => {
         it("immediately called with most recent response/navigation", () => {
-          const routes = buildRoutes([{ name: "Home", path: "" }]);
+          const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const sub = jest.fn();
           const router = curi(history, routes);
           const { response, navigation } = router.current();
@@ -1047,7 +1047,7 @@ describe("curi", () => {
         });
 
         it("[async] immediately called if initial response has resolved", done => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Home",
               path: "",
@@ -1066,7 +1066,7 @@ describe("curi", () => {
         });
 
         it("[async] not immediately called if initial response hasn't resolved", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Home",
               path: "",
@@ -1084,7 +1084,7 @@ describe("curi", () => {
 
       describe("{ initial: false }", () => {
         it("has response, is not immediately called", done => {
-          const routes = buildRoutes([{ name: "Home", path: "" }]);
+          const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const oneTime = jest.fn();
           const router = curi(history, routes);
           router.once(() => {
@@ -1095,7 +1095,7 @@ describe("curi", () => {
         });
 
         it("is called AFTER next navigation", done => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             { name: "Home", path: "" },
             { name: "Catch All", path: "(.*)" }
           ]);
@@ -1115,7 +1115,7 @@ describe("curi", () => {
   });
 
   describe("navigate()", () => {
-    const routes = buildRoutes([
+    const routes = prepareRoutes([
       { name: "Home", path: "" },
       {
         name: "Contact",
@@ -1209,7 +1209,7 @@ describe("curi", () => {
 
     describe("cancelling a navigation", () => {
       it("calls the navigation's cancelled function", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Home", path: "" },
           {
             name: "Slow",
@@ -1247,7 +1247,7 @@ describe("curi", () => {
       });
 
       it("does not call the previous navigation's cancelled function", done => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Home", path: "" },
           {
             name: "Loader",
@@ -1286,7 +1286,7 @@ describe("curi", () => {
 
     describe("finishing a navigation", () => {
       it("does not calls the navigation's finished function when the navigation is cancelled", () => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Home", path: "" },
           {
             name: "Slow",
@@ -1323,7 +1323,7 @@ describe("curi", () => {
       });
 
       it("calls the navigation's finished function", done => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           { name: "Home", path: "" },
           {
             name: "Loader",
@@ -1359,7 +1359,7 @@ describe("curi", () => {
   describe("response.redirectTo", () => {
     it("triggers a replace navigation AFTER emitting initial response", done => {
       let callPosition = 0;
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "A Route",
           path: "",

--- a/packages/router/tests/path.spec.ts
+++ b/packages/router/tests/path.spec.ts
@@ -2,13 +2,13 @@ import "jest";
 import InMemory from "@hickory/in-memory";
 
 // @ts-ignore (resolved by jest)
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 describe("route.pathOptions matching", () => {
   describe("default options", () => {
     it("sensitive = false", () => {
       const history = InMemory({ locations: ["/Here"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "here"
@@ -25,7 +25,7 @@ describe("route.pathOptions matching", () => {
 
     it("strict = false", () => {
       const history = InMemory({ locations: ["/here/"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "here"
@@ -42,7 +42,7 @@ describe("route.pathOptions matching", () => {
 
     it("end = true", () => {
       const history = InMemory({ locations: ["/here/again"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "here"
@@ -61,7 +61,7 @@ describe("route.pathOptions matching", () => {
   describe("user provided options", () => {
     it("sensitive = true", () => {
       const history = InMemory({ locations: ["/Here"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "here",
@@ -79,7 +79,7 @@ describe("route.pathOptions matching", () => {
 
     it("strict = true", () => {
       const history = InMemory({ locations: ["/here/"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "here",
@@ -97,7 +97,7 @@ describe("route.pathOptions matching", () => {
 
     it("end = false", () => {
       const history = InMemory({ locations: ["/here/again"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "here",

--- a/packages/router/tests/path.spec.ts
+++ b/packages/router/tests/path.spec.ts
@@ -2,13 +2,13 @@ import "jest";
 import InMemory from "@hickory/in-memory";
 
 // @ts-ignore (resolved by jest)
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 
 describe("route.pathOptions matching", () => {
   describe("default options", () => {
     it("sensitive = false", () => {
       const history = InMemory({ locations: ["/Here"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "here"
@@ -17,7 +17,7 @@ describe("route.pathOptions matching", () => {
           name: "Not Found",
           path: "(.*)"
         }
-      ];
+      ]);
       const router = curi(history, routes);
       const { response } = router.current();
       expect(response.name).toBe("Test");
@@ -25,7 +25,7 @@ describe("route.pathOptions matching", () => {
 
     it("strict = false", () => {
       const history = InMemory({ locations: ["/here/"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "here"
@@ -34,7 +34,7 @@ describe("route.pathOptions matching", () => {
           name: "Not Found",
           path: "(.*)"
         }
-      ];
+      ]);
       const router = curi(history, routes);
       const { response } = router.current();
       expect(response.name).toBe("Test");
@@ -42,7 +42,7 @@ describe("route.pathOptions matching", () => {
 
     it("end = true", () => {
       const history = InMemory({ locations: ["/here/again"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "here"
@@ -51,7 +51,7 @@ describe("route.pathOptions matching", () => {
           name: "Not Found",
           path: "(.*)"
         }
-      ];
+      ]);
       const router = curi(history, routes);
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
@@ -61,7 +61,7 @@ describe("route.pathOptions matching", () => {
   describe("user provided options", () => {
     it("sensitive = true", () => {
       const history = InMemory({ locations: ["/Here"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "here",
@@ -71,7 +71,7 @@ describe("route.pathOptions matching", () => {
           name: "Not Found",
           path: "(.*)"
         }
-      ];
+      ]);
       const router = curi(history, routes);
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
@@ -79,7 +79,7 @@ describe("route.pathOptions matching", () => {
 
     it("strict = true", () => {
       const history = InMemory({ locations: ["/here/"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "here",
@@ -89,7 +89,7 @@ describe("route.pathOptions matching", () => {
           name: "Not Found",
           path: "(.*)"
         }
-      ];
+      ]);
       const router = curi(history, routes);
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
@@ -97,7 +97,7 @@ describe("route.pathOptions matching", () => {
 
     it("end = false", () => {
       const history = InMemory({ locations: ["/here/again"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "here",
@@ -107,7 +107,7 @@ describe("route.pathOptions matching", () => {
           name: "Not Found",
           path: "(.*)"
         }
-      ];
+      ]);
       const router = curi(history, routes);
       const { response } = router.current();
       expect(response.name).toBe("Test");

--- a/packages/router/tests/prepareRoutes.spec.ts
+++ b/packages/router/tests/prepareRoutes.spec.ts
@@ -1,9 +1,9 @@
 import "jest";
 
 // @ts-ignore (resolved by jest)
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 
-describe("buildRoutes()", () => {
+describe("prepareRoutes()", () => {
   describe("paths beginning with forward slash", () => {
     const realWarn = console.warn;
     const fakeWarn = (console.warn = jest.fn());
@@ -17,7 +17,7 @@ describe("buildRoutes()", () => {
     });
 
     it("removes the leading slash", () => {
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Home", path: "/" },
         { name: "Catch All", path: "(.*)" }
       ]);
@@ -25,7 +25,7 @@ describe("buildRoutes()", () => {
     });
 
     it("warns", () => {
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Home", path: "/" },
         { name: "Catch All", path: "(.*)" }
       ]);

--- a/packages/router/tests/prepareRoutes.spec.ts
+++ b/packages/router/tests/prepareRoutes.spec.ts
@@ -32,4 +32,40 @@ describe("prepareRoutes()", () => {
       expect(fakeWarn.mock.calls.length).toBe(1);
     });
   });
+
+  describe("unique names", () => {
+    it("throws if multiple routes have the same name", () => {
+      const routes = [
+        { name: "Home", path: "" },
+        { name: "Home", path: "home" },
+        { name: "Catch All", path: "(.*)" }
+      ];
+      expect(() => {
+        prepareRoutes(routes);
+      }).toThrow(
+        `Multiple routes have the name "Home". Route names must be unique.`
+      );
+    });
+
+    it("throws with nested routes", () => {
+      const routes = [
+        {
+          name: "Home",
+          path: "",
+          children: [{ name: "Child", path: "child" }]
+        },
+        {
+          name: "About",
+          path: "about",
+          children: [{ name: "Child", path: "child" }]
+        },
+        { name: "Catch All", path: "(.*)" }
+      ];
+      expect(() => {
+        prepareRoutes(routes);
+      }).toThrow(
+        `Multiple routes have the name "Child". Route names must be unique.`
+      );
+    });
+  });
 });

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -2,18 +2,18 @@ import "jest";
 import InMemory from "@hickory/in-memory";
 
 // @ts-ignore (resolved by jest)
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 
 describe("route matching/response generation", () => {
   describe("route matching", () => {
     it("ignores leading slash on the pathname", () => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "test"
         }
-      ];
+      ]);
       const router = curi(history, routes);
       const { response } = router.current();
       expect(response.name).toBe("Test");
@@ -21,7 +21,7 @@ describe("route matching/response generation", () => {
 
     it("does exact matching", () => {
       const history = InMemory({ locations: ["/test/leftovers"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "test"
@@ -30,7 +30,7 @@ describe("route matching/response generation", () => {
           name: "Not Found",
           path: "(.*)"
         }
-      ];
+      ]);
       const router = curi(history, routes);
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
@@ -46,7 +46,7 @@ describe("route matching/response generation", () => {
 
       it("no response is emitted", () => {
         const history = InMemory({ locations: ["/test"] });
-        const routes = [];
+        const routes = buildRoutes([]);
         const router = curi(history, routes);
 
         const observer = jest.fn();
@@ -56,7 +56,7 @@ describe("route matching/response generation", () => {
 
       it("warns that no route matched", () => {
         const history = InMemory({ locations: ["/test"] });
-        const routes = [];
+        const routes = buildRoutes([]);
         const router = curi(history, routes);
         const observer = jest.fn();
 
@@ -70,7 +70,7 @@ describe("route matching/response generation", () => {
     describe("nested routes", () => {
       it("includes parent in partials if a child matches", () => {
         const history = InMemory({ locations: ["/ND/Fargo"] });
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "State",
             path: ":state",
@@ -81,7 +81,7 @@ describe("route matching/response generation", () => {
               }
             ]
           }
-        ];
+        ]);
         const router = curi(history, routes);
         const { response } = router.current();
         expect(response.name).toBe("City");
@@ -90,7 +90,7 @@ describe("route matching/response generation", () => {
 
       it("matches children when parent has trailing slash", () => {
         const history = InMemory({ locations: ["/ND/Fargo/"] });
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "State",
             path: ":state/",
@@ -105,7 +105,7 @@ describe("route matching/response generation", () => {
             name: "Not Found",
             path: "(.*)"
           }
-        ];
+        ]);
         const router = curi(history, routes);
         const { response } = router.current();
         expect(response.name).toBe("City");
@@ -113,7 +113,7 @@ describe("route matching/response generation", () => {
 
       it("does non-end parent matching when there are child routes, even if pathOptions.end=true", () => {
         const history = InMemory({ locations: ["/ND/Fargo"] });
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "State",
             path: ":state",
@@ -125,7 +125,7 @@ describe("route matching/response generation", () => {
               }
             ]
           }
-        ];
+        ]);
         const router = curi(history, routes);
         const { response } = router.current();
         expect(response.name).toBe("City");
@@ -134,7 +134,7 @@ describe("route matching/response generation", () => {
 
       it("skips parent match if no children match", () => {
         const history = InMemory({ locations: ["/MT/Bozeman"] });
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "State",
             path: ":state",
@@ -149,7 +149,7 @@ describe("route matching/response generation", () => {
             name: "Not Found",
             path: "(.*)"
           }
-        ];
+        ]);
         const router = curi(history, routes);
         const { response } = router.current();
         expect(response.name).toBe("Not Found");
@@ -159,7 +159,7 @@ describe("route matching/response generation", () => {
 
     it("matches partial routes if route.pathOptions.end=false", () => {
       const history = InMemory({ locations: ["/SD/Sioux City"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "State",
           path: ":state",
@@ -169,7 +169,7 @@ describe("route matching/response generation", () => {
           name: "Not Found",
           path: "(.*)"
         }
-      ];
+      ]);
       const router = curi(history, routes);
       const { response } = router.current();
       expect(response.name).toBe("State");
@@ -178,7 +178,7 @@ describe("route matching/response generation", () => {
     describe("optional path parameters", () => {
       it("works when optional param is included", () => {
         const history = InMemory({ locations: ["/NY/about"] });
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "State",
             path: ":state?/about",
@@ -188,7 +188,7 @@ describe("route matching/response generation", () => {
             name: "Not Found",
             path: "(.*)"
           }
-        ];
+        ]);
         const router = curi(history, routes);
         const { response } = router.current();
         expect(response.name).toBe("State");
@@ -196,7 +196,7 @@ describe("route matching/response generation", () => {
 
       it("works when optional param is NOT included", () => {
         const history = InMemory({ locations: ["/about"] });
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "State",
             path: ":state?/about",
@@ -206,7 +206,7 @@ describe("route matching/response generation", () => {
             name: "Not Found",
             path: "(.*)"
           }
-        ];
+        ]);
         const router = curi(history, routes);
         const { response } = router.current();
         expect(response.name).toBe("State");
@@ -218,7 +218,7 @@ describe("route matching/response generation", () => {
     describe("properties", () => {
       describe("location", () => {
         it("is the location used to match routes", () => {
-          const routes = [{ name: "Catch All", path: "(.*)" }];
+          const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
           const history = InMemory({ locations: ["/other-page"] });
           const router = curi(history, routes);
           const { response } = router.current();
@@ -229,12 +229,12 @@ describe("route matching/response generation", () => {
       describe("body", () => {
         it("is undefined if not set by route.response()", () => {
           const history = InMemory({ locations: ["/test"] });
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "Test",
               path: "test"
             }
-          ];
+          ]);
           const router = curi(history, routes);
           const { response } = router.current();
           expect(response.body).toBeUndefined();
@@ -243,7 +243,7 @@ describe("route matching/response generation", () => {
         it("is the body value of the object returned by route.response()", () => {
           const history = InMemory({ locations: ["/test"] });
           const body = () => "anybody out there?";
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "Test",
               path: "test",
@@ -253,7 +253,7 @@ describe("route matching/response generation", () => {
                 };
               }
             }
-          ];
+          ]);
           const router = curi(history, routes);
           const { response } = router.current();
           expect(response.body).toBe(body);
@@ -262,7 +262,7 @@ describe("route matching/response generation", () => {
 
       describe("status", () => {
         it("is undefined if not set by route.response()", () => {
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "Contact",
               path: "contact",
@@ -271,7 +271,7 @@ describe("route matching/response generation", () => {
                 { name: "Phone", path: "phone" }
               ]
             }
-          ];
+          ]);
           const history = InMemory({ locations: ["/contact"] });
           const router = curi(history, routes);
           const { response } = router.current();
@@ -279,7 +279,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is the status value of object returned by route.response()", () => {
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "A Route",
               path: "",
@@ -289,7 +289,7 @@ describe("route matching/response generation", () => {
                 };
               }
             }
-          ];
+          ]);
           const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
           const { response } = router.current();
@@ -299,12 +299,12 @@ describe("route matching/response generation", () => {
 
       describe("data", () => {
         it("is undefined if not set by route.response()", () => {
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "A Route",
               path: ""
             }
-          ];
+          ]);
           const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
           const { response } = router.current();
@@ -312,7 +312,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is the data value of the object returned by route.response()", () => {
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "A Route",
               path: "",
@@ -324,7 +324,7 @@ describe("route matching/response generation", () => {
                 };
               }
             }
-          ];
+          ]);
           const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
           const { response } = router.current();
@@ -334,12 +334,12 @@ describe("route matching/response generation", () => {
 
       describe("title", () => {
         it("is undefined if not set by route.response()", () => {
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "State",
               path: ":state"
             }
-          ];
+          ]);
           const history = InMemory({ locations: ["/AZ"] });
           const router = curi(history, routes);
 
@@ -348,7 +348,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is the title value of the object returned by route.response()", () => {
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "State",
               path: ":state",
@@ -358,7 +358,7 @@ describe("route matching/response generation", () => {
                 };
               }
             }
-          ];
+          ]);
           const history = InMemory({ locations: ["/VA"] });
           const router = curi(history, routes);
 
@@ -369,12 +369,14 @@ describe("route matching/response generation", () => {
 
       describe("name", () => {
         it("is the name of the best matching route", () => {
-          const Route = {
-            name: "A Route",
-            path: "a-route"
-          };
+          const routes = buildRoutes([
+            {
+              name: "A Route",
+              path: "a-route"
+            }
+          ]);
           const history = InMemory({ locations: ["/a-route"] });
-          const router = curi(history, [Route]);
+          const router = curi(history, routes);
           const { response } = router.current();
           expect(response.name).toBe("A Route");
         });
@@ -383,7 +385,7 @@ describe("route matching/response generation", () => {
       describe("partials", () => {
         it("is set using the names of all partially matching routes", () => {
           const history = InMemory({ locations: ["/TX/Austin"] });
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "State",
               path: ":state",
@@ -394,7 +396,7 @@ describe("route matching/response generation", () => {
                 }
               ]
             }
-          ];
+          ]);
           const router = curi(history, routes);
           const { response } = router.current();
           expect(response.partials).toEqual(["State"]);
@@ -404,7 +406,7 @@ describe("route matching/response generation", () => {
       describe("params", () => {
         it("includes params from partially matched routes", () => {
           const history = InMemory({ locations: ["/MT/Bozeman"] });
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "State",
               path: ":state",
@@ -415,7 +417,7 @@ describe("route matching/response generation", () => {
                 }
               ]
             }
-          ];
+          ]);
           const router = curi(history, routes);
           const { response } = router.current();
           expect(response.params).toEqual({
@@ -426,13 +428,13 @@ describe("route matching/response generation", () => {
 
         it("overwrites param name conflicts", () => {
           const history = InMemory({ locations: ["/1/2"] });
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "One",
               path: ":id",
               children: [{ name: "Two", path: ":id" }]
             }
-          ];
+          ]);
           const router = curi(history, routes);
           const { response } = router.current();
           expect(response.params["id"]).toBe("2");
@@ -441,7 +443,7 @@ describe("route matching/response generation", () => {
         describe("parsing params", () => {
           it("uses route.params to parse params", () => {
             const history = InMemory({ locations: ["/123"] });
-            const routes = [
+            const routes = buildRoutes([
               {
                 name: "number",
                 path: ":num",
@@ -449,7 +451,7 @@ describe("route matching/response generation", () => {
                   num: n => parseInt(n, 10)
                 }
               }
-            ];
+            ]);
             const router = curi(history, routes);
             const { response } = router.current();
             expect(response.params).toEqual({ num: 123 });
@@ -457,7 +459,7 @@ describe("route matching/response generation", () => {
 
           it("parses params from parent routes", () => {
             const history = InMemory({ locations: ["/123/456"] });
-            const routes = [
+            const routes = buildRoutes([
               {
                 name: "first",
                 path: ":first",
@@ -474,7 +476,7 @@ describe("route matching/response generation", () => {
                   first: n => parseInt(n, 10)
                 }
               }
-            ];
+            ]);
             const router = curi(history, routes);
             const { response } = router.current();
             expect(response.params).toEqual({
@@ -485,7 +487,7 @@ describe("route matching/response generation", () => {
 
           it("uses string for any params not in route.params", () => {
             const history = InMemory({ locations: ["/123/456"] });
-            const routes = [
+            const routes = buildRoutes([
               {
                 name: "combo",
                 path: ":first/:second",
@@ -493,7 +495,7 @@ describe("route matching/response generation", () => {
                   first: n => parseInt(n, 10)
                 }
               }
-            ];
+            ]);
             const router = curi(history, routes);
             const { response } = router.current();
             expect(response.params).toEqual({
@@ -508,7 +510,7 @@ describe("route matching/response generation", () => {
             console.error = errorMock;
 
             const history = InMemory({ locations: ["/123"] });
-            const routes = [
+            const routes = buildRoutes([
               {
                 name: "number",
                 path: ":num",
@@ -518,7 +520,7 @@ describe("route matching/response generation", () => {
                   }
                 }
               }
-            ];
+            ]);
             const router = curi(history, routes);
             const { response } = router.current();
             expect(response.params).toEqual({
@@ -533,7 +535,7 @@ describe("route matching/response generation", () => {
 
       describe("error", () => {
         it("is undefined for good responses", () => {
-          const routes = [{ name: "Contact", path: "contact" }];
+          const routes = buildRoutes([{ name: "Contact", path: "contact" }]);
           const history = InMemory({
             locations: ["/contact"]
           });
@@ -543,7 +545,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is the error value on the object returned by route.response()", () => {
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "A Route",
               path: "",
@@ -553,7 +555,7 @@ describe("route matching/response generation", () => {
                 };
               }
             }
-          ];
+          ]);
           const history = InMemory({ locations: ["/"] });
           const router = curi(history, routes);
           const { response } = router.current();
@@ -564,7 +566,7 @@ describe("route matching/response generation", () => {
       describe("redirectTo", () => {
         it("contains the expected properties", () => {
           const history = InMemory({ locations: ["/"] });
-          const routes = [
+          const routes = buildRoutes([
             {
               name: "A Route",
               path: "",
@@ -584,7 +586,7 @@ describe("route matching/response generation", () => {
               name: "B Route",
               path: "b/:id"
             }
-          ];
+          ]);
 
           let firstCall = true;
           const logger = ({ response }) => {
@@ -624,30 +626,34 @@ describe("route matching/response generation", () => {
           done();
         });
 
-        const CatchAll = {
-          name: "Catch All",
-          path: ":anything",
-          resolve: { spy }
-        };
+        const routes = buildRoutes([
+          {
+            name: "Catch All",
+            path: ":anything",
+            resolve: { spy }
+          }
+        ]);
 
         const history = InMemory({ locations: ["/hello?one=two"] });
-        curi(history, [CatchAll]);
+        curi(history, routes);
       });
 
       it("calls all resolve functions", done => {
         const one = jest.fn();
         const two = jest.fn();
-        const CatchAll = {
-          name: "Catch All",
-          path: ":anything",
-          resolve: {
-            one,
-            two
+        const routes = buildRoutes([
+          {
+            name: "Catch All",
+            path: ":anything",
+            resolve: {
+              one,
+              two
+            }
           }
-        };
+        ]);
 
         const history = InMemory({ locations: ["/hello?one=two"] });
-        const router = curi(history, [CatchAll]);
+        const router = curi(history, routes);
         router.once(() => {
           expect(one.mock.calls.length).toBe(1);
           expect(one.mock.calls.length).toBe(1);
@@ -669,7 +675,7 @@ describe("route matching/response generation", () => {
           });
         });
 
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "First",
             path: "first",
@@ -695,7 +701,7 @@ describe("route matching/response generation", () => {
               spy
             }
           }
-        ];
+        ]);
 
         const history = InMemory({ locations: ["/first"] });
         const router = curi(history, routes);
@@ -704,53 +710,59 @@ describe("route matching/response generation", () => {
 
       describe("resolved", () => {
         it("is null when route has no resolve functions", () => {
-          const CatchAll = {
-            name: "Catch All",
-            path: ":anything",
-            response: ({ resolved }) => {
-              expect(resolved).toBe(null);
-              return {};
+          const routes = buildRoutes([
+            {
+              name: "Catch All",
+              path: ":anything",
+              response: ({ resolved }) => {
+                expect(resolved).toBe(null);
+                return {};
+              }
             }
-          };
+          ]);
 
           const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, [CatchAll]);
+          const router = curi(history, routes);
         });
 
         it("is null when a resolve function throws", () => {
-          const CatchAll = {
-            name: "Catch All",
-            path: ":anything",
-            resolve: {
-              fails: () => Promise.reject("woops!")
-            },
-            response: ({ resolved }) => {
-              expect(resolved).toBe(null);
-              return {};
+          const routes = buildRoutes([
+            {
+              name: "Catch All",
+              path: ":anything",
+              resolve: {
+                fails: () => Promise.reject("woops!")
+              },
+              response: ({ resolved }) => {
+                expect(resolved).toBe(null);
+                return {};
+              }
             }
-          };
+          ]);
 
           const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, [CatchAll]);
+          const router = curi(history, routes);
         });
 
         it("is an object with named resolve function properties for async routes", () => {
-          const CatchAll = {
-            name: "Catch All",
-            path: ":anything",
-            response: ({ resolved }) => {
-              expect(resolved.test).toBe(1);
-              expect(resolved.yo).toBe("yo!");
-              return {};
-            },
-            resolve: {
-              test: () => Promise.resolve(1),
-              yo: () => Promise.resolve("yo!")
+          const routes = buildRoutes([
+            {
+              name: "Catch All",
+              path: ":anything",
+              response: ({ resolved }) => {
+                expect(resolved.test).toBe(1);
+                expect(resolved.yo).toBe("yo!");
+                return {};
+              },
+              resolve: {
+                test: () => Promise.resolve(1),
+                yo: () => Promise.resolve("yo!")
+              }
             }
-          };
+          ]);
 
           const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, [CatchAll]);
+          const router = curi(history, routes);
         });
       });
 
@@ -761,17 +773,19 @@ describe("route matching/response generation", () => {
             done();
           });
 
-          const CatchAll = {
-            name: "Catch All",
-            path: ":anything",
-            response: spy,
-            resolve: {
-              fails: () => Promise.reject("rejected")
+          const routes = buildRoutes([
+            {
+              name: "Catch All",
+              path: ":anything",
+              response: spy,
+              resolve: {
+                fails: () => Promise.reject("rejected")
+              }
             }
-          };
+          ]);
 
           const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, [CatchAll]);
+          const router = curi(history, routes);
         });
 
         it("is null when all resolve functions succeed", done => {
@@ -780,41 +794,45 @@ describe("route matching/response generation", () => {
             done();
           });
 
-          const CatchAll = {
-            name: "Catch All",
-            path: ":anything",
-            response: spy,
-            resolve: {
-              succeed: () => Promise.resolve("hurray!")
+          const routes = buildRoutes([
+            {
+              name: "Catch All",
+              path: ":anything",
+              response: spy,
+              resolve: {
+                succeed: () => Promise.resolve("hurray!")
+              }
             }
-          };
+          ]);
 
           const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, [CatchAll]);
+          const router = curi(history, routes);
         });
       });
 
       describe("match", () => {
         it("receives the response properties based on the matched route", () => {
-          const CatchAll = {
-            name: "Catch All",
-            path: ":anything",
-            response: props => {
-              expect(props.match).toMatchObject({
-                name: "Catch All",
-                params: { anything: "hello" },
-                partials: [],
-                location: {
-                  pathname: "/hello",
-                  query: "one=two"
-                }
-              });
-              return {};
+          const routes = buildRoutes([
+            {
+              name: "Catch All",
+              path: ":anything",
+              response: props => {
+                expect(props.match).toMatchObject({
+                  name: "Catch All",
+                  params: { anything: "hello" },
+                  partials: [],
+                  location: {
+                    pathname: "/hello",
+                    query: "one=two"
+                  }
+                });
+                return {};
+              }
             }
-          };
+          ]);
 
           const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, [CatchAll]);
+          const router = curi(history, routes);
         });
       });
     });

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -2,13 +2,13 @@ import "jest";
 import InMemory from "@hickory/in-memory";
 
 // @ts-ignore (resolved by jest)
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 describe("route matching/response generation", () => {
   describe("route matching", () => {
     it("ignores leading slash on the pathname", () => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "test"
@@ -21,7 +21,7 @@ describe("route matching/response generation", () => {
 
     it("does exact matching", () => {
       const history = InMemory({ locations: ["/test/leftovers"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "test"
@@ -46,7 +46,7 @@ describe("route matching/response generation", () => {
 
       it("no response is emitted", () => {
         const history = InMemory({ locations: ["/test"] });
-        const routes = buildRoutes([]);
+        const routes = prepareRoutes([]);
         const router = curi(history, routes);
 
         const observer = jest.fn();
@@ -56,7 +56,7 @@ describe("route matching/response generation", () => {
 
       it("warns that no route matched", () => {
         const history = InMemory({ locations: ["/test"] });
-        const routes = buildRoutes([]);
+        const routes = prepareRoutes([]);
         const router = curi(history, routes);
         const observer = jest.fn();
 
@@ -70,7 +70,7 @@ describe("route matching/response generation", () => {
     describe("nested routes", () => {
       it("includes parent in partials if a child matches", () => {
         const history = InMemory({ locations: ["/ND/Fargo"] });
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "State",
             path: ":state",
@@ -90,7 +90,7 @@ describe("route matching/response generation", () => {
 
       it("matches children when parent has trailing slash", () => {
         const history = InMemory({ locations: ["/ND/Fargo/"] });
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "State",
             path: ":state/",
@@ -113,7 +113,7 @@ describe("route matching/response generation", () => {
 
       it("does non-end parent matching when there are child routes, even if pathOptions.end=true", () => {
         const history = InMemory({ locations: ["/ND/Fargo"] });
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "State",
             path: ":state",
@@ -134,7 +134,7 @@ describe("route matching/response generation", () => {
 
       it("skips parent match if no children match", () => {
         const history = InMemory({ locations: ["/MT/Bozeman"] });
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "State",
             path: ":state",
@@ -159,7 +159,7 @@ describe("route matching/response generation", () => {
 
     it("matches partial routes if route.pathOptions.end=false", () => {
       const history = InMemory({ locations: ["/SD/Sioux City"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "State",
           path: ":state",
@@ -178,7 +178,7 @@ describe("route matching/response generation", () => {
     describe("optional path parameters", () => {
       it("works when optional param is included", () => {
         const history = InMemory({ locations: ["/NY/about"] });
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "State",
             path: ":state?/about",
@@ -196,7 +196,7 @@ describe("route matching/response generation", () => {
 
       it("works when optional param is NOT included", () => {
         const history = InMemory({ locations: ["/about"] });
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "State",
             path: ":state?/about",
@@ -218,7 +218,7 @@ describe("route matching/response generation", () => {
     describe("properties", () => {
       describe("location", () => {
         it("is the location used to match routes", () => {
-          const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+          const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
           const history = InMemory({ locations: ["/other-page"] });
           const router = curi(history, routes);
           const { response } = router.current();
@@ -229,7 +229,7 @@ describe("route matching/response generation", () => {
       describe("body", () => {
         it("is undefined if not set by route.response()", () => {
           const history = InMemory({ locations: ["/test"] });
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Test",
               path: "test"
@@ -243,7 +243,7 @@ describe("route matching/response generation", () => {
         it("is the body value of the object returned by route.response()", () => {
           const history = InMemory({ locations: ["/test"] });
           const body = () => "anybody out there?";
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Test",
               path: "test",
@@ -262,7 +262,7 @@ describe("route matching/response generation", () => {
 
       describe("status", () => {
         it("is undefined if not set by route.response()", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Contact",
               path: "contact",
@@ -279,7 +279,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is the status value of object returned by route.response()", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "A Route",
               path: "",
@@ -299,7 +299,7 @@ describe("route matching/response generation", () => {
 
       describe("data", () => {
         it("is undefined if not set by route.response()", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "A Route",
               path: ""
@@ -312,7 +312,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is the data value of the object returned by route.response()", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "A Route",
               path: "",
@@ -334,7 +334,7 @@ describe("route matching/response generation", () => {
 
       describe("title", () => {
         it("is undefined if not set by route.response()", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "State",
               path: ":state"
@@ -348,7 +348,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is the title value of the object returned by route.response()", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "State",
               path: ":state",
@@ -369,7 +369,7 @@ describe("route matching/response generation", () => {
 
       describe("name", () => {
         it("is the name of the best matching route", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "A Route",
               path: "a-route"
@@ -385,7 +385,7 @@ describe("route matching/response generation", () => {
       describe("partials", () => {
         it("is set using the names of all partially matching routes", () => {
           const history = InMemory({ locations: ["/TX/Austin"] });
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "State",
               path: ":state",
@@ -406,7 +406,7 @@ describe("route matching/response generation", () => {
       describe("params", () => {
         it("includes params from partially matched routes", () => {
           const history = InMemory({ locations: ["/MT/Bozeman"] });
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "State",
               path: ":state",
@@ -428,7 +428,7 @@ describe("route matching/response generation", () => {
 
         it("overwrites param name conflicts", () => {
           const history = InMemory({ locations: ["/1/2"] });
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "One",
               path: ":id",
@@ -443,7 +443,7 @@ describe("route matching/response generation", () => {
         describe("parsing params", () => {
           it("uses route.params to parse params", () => {
             const history = InMemory({ locations: ["/123"] });
-            const routes = buildRoutes([
+            const routes = prepareRoutes([
               {
                 name: "number",
                 path: ":num",
@@ -459,7 +459,7 @@ describe("route matching/response generation", () => {
 
           it("parses params from parent routes", () => {
             const history = InMemory({ locations: ["/123/456"] });
-            const routes = buildRoutes([
+            const routes = prepareRoutes([
               {
                 name: "first",
                 path: ":first",
@@ -487,7 +487,7 @@ describe("route matching/response generation", () => {
 
           it("uses string for any params not in route.params", () => {
             const history = InMemory({ locations: ["/123/456"] });
-            const routes = buildRoutes([
+            const routes = prepareRoutes([
               {
                 name: "combo",
                 path: ":first/:second",
@@ -510,7 +510,7 @@ describe("route matching/response generation", () => {
             console.error = errorMock;
 
             const history = InMemory({ locations: ["/123"] });
-            const routes = buildRoutes([
+            const routes = prepareRoutes([
               {
                 name: "number",
                 path: ":num",
@@ -535,7 +535,7 @@ describe("route matching/response generation", () => {
 
       describe("error", () => {
         it("is undefined for good responses", () => {
-          const routes = buildRoutes([{ name: "Contact", path: "contact" }]);
+          const routes = prepareRoutes([{ name: "Contact", path: "contact" }]);
           const history = InMemory({
             locations: ["/contact"]
           });
@@ -545,7 +545,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is the error value on the object returned by route.response()", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "A Route",
               path: "",
@@ -566,7 +566,7 @@ describe("route matching/response generation", () => {
       describe("redirectTo", () => {
         it("contains the expected properties", () => {
           const history = InMemory({ locations: ["/"] });
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "A Route",
               path: "",
@@ -626,7 +626,7 @@ describe("route matching/response generation", () => {
           done();
         });
 
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Catch All",
             path: ":anything",
@@ -641,7 +641,7 @@ describe("route matching/response generation", () => {
       it("calls all resolve functions", done => {
         const one = jest.fn();
         const two = jest.fn();
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Catch All",
             path: ":anything",
@@ -675,7 +675,7 @@ describe("route matching/response generation", () => {
           });
         });
 
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "First",
             path: "first",
@@ -710,7 +710,7 @@ describe("route matching/response generation", () => {
 
       describe("resolved", () => {
         it("is null when route has no resolve functions", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Catch All",
               path: ":anything",
@@ -726,7 +726,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is null when a resolve function throws", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Catch All",
               path: ":anything",
@@ -745,7 +745,7 @@ describe("route matching/response generation", () => {
         });
 
         it("is an object with named resolve function properties for async routes", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Catch All",
               path: ":anything",
@@ -773,7 +773,7 @@ describe("route matching/response generation", () => {
             done();
           });
 
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Catch All",
               path: ":anything",
@@ -794,7 +794,7 @@ describe("route matching/response generation", () => {
             done();
           });
 
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Catch All",
               path: ":anything",
@@ -812,7 +812,7 @@ describe("route matching/response generation", () => {
 
       describe("match", () => {
         it("receives the response properties based on the matched route", () => {
-          const routes = buildRoutes([
+          const routes = prepareRoutes([
             {
               name: "Catch All",
               path: ":anything",

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -3,7 +3,7 @@ import { Route, Interaction } from "../src/types";
 import InMemory from "@hickory/in-memory";
 
 // @ts-ignore (resolved by jest)
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 
 function PropertyReporter(): Interaction {
   let knownRoutes = {};
@@ -32,12 +32,12 @@ describe("public route properties", () => {
   describe("name", () => {
     it("is the provided value", () => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "test"
         }
-      ];
+      ]);
       const router = curi(history, routes, {
         route: [PropertyReporter()]
       });
@@ -49,12 +49,12 @@ describe("public route properties", () => {
   describe("path", () => {
     it("is the provided value", () => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "test"
         }
-      ];
+      ]);
       const router = curi(history, routes, {
         route: [PropertyReporter()]
       });
@@ -66,12 +66,12 @@ describe("public route properties", () => {
   describe("keys", () => {
     it("is the array of param names parsed from the path", () => {
       const history = InMemory({ locations: ["/four/five/six"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: ":one/:two/:three"
         }
-      ];
+      ]);
       const router = curi(history, routes, {
         route: [PropertyReporter()]
       });
@@ -81,12 +81,12 @@ describe("public route properties", () => {
 
     it("is an empty array when the path has no params", () => {
       const history = InMemory({ locations: ["/one/two/three"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "one/two/three"
         }
-      ];
+      ]);
       const router = curi(history, routes, {
         route: [PropertyReporter()]
       });
@@ -98,7 +98,7 @@ describe("public route properties", () => {
   describe("resolve", () => {
     it("is the resolve functions", done => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "test",
@@ -107,7 +107,7 @@ describe("public route properties", () => {
             eTest: () => Promise.resolve("eTest")
           }
         }
-      ];
+      ]);
       const router = curi(history, routes, {
         route: [PropertyReporter()]
       });
@@ -122,12 +122,12 @@ describe("public route properties", () => {
 
     it("is an empty object when route.resolve isn't provided", done => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "test"
         }
-      ];
+      ]);
       const router = curi(history, routes, {
         route: [PropertyReporter()]
       });
@@ -138,13 +138,13 @@ describe("public route properties", () => {
 
     it("is an empty object when route.resolve is an empty object", done => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "test",
           resolve: {}
         }
-      ];
+      ]);
       const router = curi(history, routes, {
         route: [PropertyReporter()]
       });
@@ -161,13 +161,13 @@ describe("public route properties", () => {
         unofficial: true,
         another: 1
       };
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "test",
           extra
         }
-      ];
+      ]);
       const router = curi(history, routes, {
         route: [PropertyReporter()]
       });

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -3,7 +3,7 @@ import { Route, Interaction } from "../src/types";
 import InMemory from "@hickory/in-memory";
 
 // @ts-ignore (resolved by jest)
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 function PropertyReporter(): Interaction {
   let knownRoutes = {};
@@ -32,7 +32,7 @@ describe("public route properties", () => {
   describe("name", () => {
     it("is the provided value", () => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "test"
@@ -49,7 +49,7 @@ describe("public route properties", () => {
   describe("path", () => {
     it("is the provided value", () => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "test"
@@ -66,7 +66,7 @@ describe("public route properties", () => {
   describe("keys", () => {
     it("is the array of param names parsed from the path", () => {
       const history = InMemory({ locations: ["/four/five/six"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: ":one/:two/:three"
@@ -81,7 +81,7 @@ describe("public route properties", () => {
 
     it("is an empty array when the path has no params", () => {
       const history = InMemory({ locations: ["/one/two/three"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "one/two/three"
@@ -98,7 +98,7 @@ describe("public route properties", () => {
   describe("resolve", () => {
     it("is the resolve functions", done => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "test",
@@ -122,7 +122,7 @@ describe("public route properties", () => {
 
     it("is an empty object when route.resolve isn't provided", done => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "test"
@@ -138,7 +138,7 @@ describe("public route properties", () => {
 
     it("is an empty object when route.resolve is an empty object", done => {
       const history = InMemory({ locations: ["/test"] });
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "test",
@@ -161,7 +161,7 @@ describe("public route properties", () => {
         unofficial: true,
         another: 1
       };
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "test",

--- a/packages/router/types/buildRoutes.d.ts
+++ b/packages/router/types/buildRoutes.d.ts
@@ -1,0 +1,3 @@
+import { UserRoutes, CompiledRouteArray } from "./types/route";
+export default function buildRoutes(userRoutes: UserRoutes): CompiledRouteArray;
+export declare function privateBuildRoutes(userRoutes: UserRoutes, _privateInternalCall?: boolean): CompiledRouteArray;

--- a/packages/router/types/buildRoutes.d.ts
+++ b/packages/router/types/buildRoutes.d.ts
@@ -1,3 +1,0 @@
-import { UserRoutes, CompiledRouteArray } from "./types/route";
-export default function buildRoutes(userRoutes: UserRoutes): CompiledRouteArray;
-export declare function privateBuildRoutes(userRoutes: UserRoutes, _privateInternalCall?: boolean): CompiledRouteArray;

--- a/packages/router/types/createRoute.d.ts
+++ b/packages/router/types/createRoute.d.ts
@@ -1,0 +1,3 @@
+import { RouteDescriptor, CompiledRoute } from "./types/route";
+declare const createRoute: (options: RouteDescriptor) => CompiledRoute;
+export default createRoute;

--- a/packages/router/types/createRoute.d.ts
+++ b/packages/router/types/createRoute.d.ts
@@ -1,3 +1,3 @@
 import { RouteDescriptor, CompiledRoute } from "./types/route";
-declare const createRoute: (options: RouteDescriptor) => CompiledRoute;
+declare const createRoute: (options: RouteDescriptor, usedNames: Set<string>) => CompiledRoute;
 export default createRoute;

--- a/packages/router/types/createRoute.d.ts
+++ b/packages/router/types/createRoute.d.ts
@@ -1,3 +1,3 @@
 import { RouteDescriptor, CompiledRoute } from "./types/route";
-declare const createRoute: (options: RouteDescriptor, usedNames: Set<string>) => CompiledRoute;
+declare const createRoute: (options: RouteDescriptor, parentPath: string | null, usedNames: Set<string>) => CompiledRoute;
 export default createRoute;

--- a/packages/router/types/curi.d.ts
+++ b/packages/router/types/curi.d.ts
@@ -1,4 +1,4 @@
 import { History } from "@hickory/root";
-import { RouteDescriptor } from "./types/route";
+import { UserRoutes } from "./types/route";
 import { CuriRouter, RouterOptions } from "./types/curi";
-export default function createRouter(history: History, routeArray: Array<RouteDescriptor>, options?: RouterOptions): CuriRouter;
+export default function createRouter(history: History, routeArray: UserRoutes, options?: RouterOptions): CuriRouter;

--- a/packages/router/types/index.d.ts
+++ b/packages/router/types/index.d.ts
@@ -2,5 +2,5 @@ export * from "./types";
 import curi from "./curi";
 import pathname from "./interactions/pathname";
 import once from "./deprecatedOnce";
-import buildRoutes from "./buildRoutes";
-export { curi, pathname, once, buildRoutes };
+import prepareRoutes from "./prepareRoutes";
+export { curi, pathname, once, prepareRoutes };

--- a/packages/router/types/index.d.ts
+++ b/packages/router/types/index.d.ts
@@ -2,4 +2,5 @@ export * from "./types";
 import curi from "./curi";
 import pathname from "./interactions/pathname";
 import once from "./deprecatedOnce";
-export { curi, pathname, once };
+import buildRoutes from "./buildRoutes";
+export { curi, pathname, once, buildRoutes };

--- a/packages/router/types/index.d.ts
+++ b/packages/router/types/index.d.ts
@@ -1,6 +1,6 @@
 export * from "./types";
 import curi from "./curi";
-import pathname from "./interactions/pathname";
+import pathname from "./interactions/deprecatedPathname";
 import once from "./deprecatedOnce";
 import prepareRoutes from "./prepareRoutes";
 export { curi, pathname, once, prepareRoutes };

--- a/packages/router/types/interactions/deprecatedPathname.d.ts
+++ b/packages/router/types/interactions/deprecatedPathname.d.ts
@@ -1,0 +1,3 @@
+import { PathFunctionOptions } from "path-to-regexp";
+import { Interaction } from "../types/interaction";
+export default function deprecatedPathname(options?: PathFunctionOptions): Interaction;

--- a/packages/router/types/matchLocation.d.ts
+++ b/packages/router/types/matchLocation.d.ts
@@ -1,4 +1,4 @@
 import { HickoryLocation } from "@hickory/root";
-import { InternalRoute } from "./types/route";
+import { CompiledRoute } from "./types/route";
 import { PossibleMatch } from "./types/match";
-export default function matchLocation(location: HickoryLocation, routes: Array<InternalRoute>): PossibleMatch;
+export default function matchLocation(location: HickoryLocation, routes: Array<CompiledRoute>): PossibleMatch;

--- a/packages/router/types/prepareRoutes.d.ts
+++ b/packages/router/types/prepareRoutes.d.ts
@@ -1,0 +1,3 @@
+import { UserRoutes, CompiledRouteArray } from "./types/route";
+export default function prepareRoutes(userRoutes: UserRoutes): CompiledRouteArray;
+export declare function privatePrepareRoutes(userRoutes: UserRoutes, _privateInternalCall?: boolean): CompiledRouteArray;

--- a/packages/router/types/route.d.ts
+++ b/packages/router/types/route.d.ts
@@ -1,3 +1,0 @@
-import { RouteDescriptor, InternalRoute } from "./types/route";
-declare const createRoute: (options: RouteDescriptor) => InternalRoute;
-export default createRoute;

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -1,7 +1,7 @@
 import { History, Action, NavType } from "@hickory/root";
 import { PathFunctionOptions } from "path-to-regexp";
 import { Interaction, Interactions } from "./interaction";
-import { RouteDescriptor } from "./route";
+import { UserRoutes } from "./route";
 import { Response, Params } from "./response";
 export interface Navigation {
     action: Action;
@@ -39,7 +39,7 @@ export interface NavigationDetails {
     finished?: () => void;
 }
 export interface CuriRouter {
-    refresh: (routeArray?: Array<RouteDescriptor>) => void;
+    refresh: (routeArray?: UserRoutes) => void;
     observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
     once: (fn: Observer, options?: ResponseHandlerOptions) => void;
     route: Interactions;

--- a/packages/router/types/types/index.d.ts
+++ b/packages/router/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
-export { Route, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, AsyncGroup, Resolved, ResolveResults } from "./route";
+export { Route, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, AsyncGroup, Resolved, ResolveResults, CompiledRoute, CompiledRouteArray, UserRoutes } from "./route";
 export { Response, RawParams, Params, RedirectLocation, MatchResponseProperties, SettableResponseProperties } from "./response";
 export { CuriRouter, RouterOptions, Observer, Emitted, ResponseHandlerOptions, RemoveObserver, Navigation, CurrentResponse } from "./curi";

--- a/packages/router/types/types/match.d.ts
+++ b/packages/router/types/types/match.d.ts
@@ -1,7 +1,7 @@
-import { InternalRoute } from "./route";
+import { CompiledRoute } from "./route";
 import { Params, MatchResponseProperties } from "./response";
 export interface MatchingRoute {
-    route: InternalRoute;
+    route: CompiledRoute;
     params: Params;
 }
 export interface MissMatch {
@@ -9,7 +9,7 @@ export interface MissMatch {
     match: undefined;
 }
 export interface Match {
-    route: InternalRoute;
+    route: CompiledRoute;
     match: MatchResponseProperties;
 }
 export declare type PossibleMatch = Match | MissMatch;

--- a/packages/router/types/types/route.d.ts
+++ b/packages/router/types/types/route.d.ts
@@ -1,4 +1,4 @@
-import { RegExpOptions, Key } from "path-to-regexp";
+import { RegExpOptions, Key, PathFunction } from "path-to-regexp";
 import { MatchResponseProperties, SettableResponseProperties } from "./response";
 export interface Resolved {
     [key: string]: any;
@@ -49,6 +49,7 @@ export interface Route {
     extra?: {
         [key: string]: any;
     };
+    pathname: PathFunction;
 }
 export interface PathMatching {
     mustBeExact: boolean;

--- a/packages/router/types/types/route.d.ts
+++ b/packages/router/types/types/route.d.ts
@@ -33,6 +33,14 @@ export interface RouteDescriptor {
         [key: string]: any;
     };
 }
+export interface CompiledRoute {
+    public: Route;
+    sync: boolean;
+    children: Array<CompiledRoute>;
+    response?: ResponseFn;
+    pathMatching: PathMatching;
+    paramParsers?: ParamParsers;
+}
 export interface Route {
     name: string;
     path: string;
@@ -47,11 +55,5 @@ export interface PathMatching {
     re: RegExp;
     keys: Array<Key>;
 }
-export interface InternalRoute {
-    public: Route;
-    sync: boolean;
-    children: Array<InternalRoute>;
-    response?: ResponseFn;
-    pathMatching: PathMatching;
-    paramParsers?: ParamParsers;
-}
+export declare type CompiledRouteArray = Array<CompiledRoute>;
+export declare type UserRoutes = Array<CompiledRoute | RouteDescriptor>;

--- a/packages/router/types/utils/registerRoutes.d.ts
+++ b/packages/router/types/utils/registerRoutes.d.ts
@@ -1,3 +1,3 @@
-import { InternalRoute } from "../types/route";
+import { CompiledRoute } from "../types/route";
 import { Interaction } from "../types/interaction";
-export default function registerRoutes(routes: Array<InternalRoute>, interaction: Interaction, parentData?: any): void;
+export default function registerRoutes(routes: Array<CompiledRoute>, interaction: Interaction, parentData?: any): void;

--- a/packages/vue/tests/Block.spec.ts
+++ b/packages/vue/tests/Block.spec.ts
@@ -1,9 +1,9 @@
 import "jest";
 import { createLocalVue } from "@vue/test-utils";
 import InMemory from "@hickory/in-memory";
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("<curi-block>", () => {
@@ -13,10 +13,10 @@ describe("<curi-block>", () => {
   history.confirmWith = mockConfirmWith;
   history.removeConfirmation = mockRemoveConfirmation;
 
-  const routes = [
+  const routes = buildRoutes([
     { name: "Place", path: "place/:name" },
     { name: "Catch All", path: "(.*)" }
-  ];
+  ]);
   const router = curi(history, routes);
 
   const Vue = createLocalVue();

--- a/packages/vue/tests/Block.spec.ts
+++ b/packages/vue/tests/Block.spec.ts
@@ -1,7 +1,7 @@
 import "jest";
 import { createLocalVue } from "@vue/test-utils";
 import InMemory from "@hickory/in-memory";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 // @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
@@ -13,7 +13,7 @@ describe("<curi-block>", () => {
   history.confirmWith = mockConfirmWith;
   history.removeConfirmation = mockRemoveConfirmation;
 
-  const routes = buildRoutes([
+  const routes = prepareRoutes([
     { name: "Place", path: "place/:name" },
     { name: "Catch All", path: "(.*)" }
   ]);

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -1,14 +1,14 @@
 import "jest";
 import { createLocalVue } from "@vue/test-utils";
 import InMemory from "@hickory/in-memory";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 // @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("<curi-link>", () => {
   let Vue, node, history, router, wrapper;
-  const routes = buildRoutes([
+  const routes = prepareRoutes([
     { name: "Place", path: "place/:name" },
     { name: "Catch All", path: "(.*)" }
   ]);
@@ -146,7 +146,7 @@ describe("<curi-link>", () => {
 
     describe("scoped slot", () => {
       let history;
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         {
           name: "Test",
           path: "test",
@@ -249,7 +249,7 @@ describe("<curi-link>", () => {
       });
 
       it("navigating = false after navigation is cancelled", done => {
-        const routes = buildRoutes([
+        const routes = prepareRoutes([
           {
             name: "Slow",
             path: "slow",

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -1,17 +1,17 @@
 import "jest";
 import { createLocalVue } from "@vue/test-utils";
 import InMemory from "@hickory/in-memory";
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("<curi-link>", () => {
   let Vue, node, history, router, wrapper;
-  const routes = [
+  const routes = buildRoutes([
     { name: "Place", path: "place/:name" },
     { name: "Catch All", path: "(.*)" }
-  ];
+  ]);
 
   beforeEach(() => {
     node = document.createElement("div");
@@ -146,7 +146,7 @@ describe("<curi-link>", () => {
 
     describe("scoped slot", () => {
       let history;
-      const routes = [
+      const routes = buildRoutes([
         {
           name: "Test",
           path: "test",
@@ -161,7 +161,7 @@ describe("<curi-link>", () => {
           }
         },
         { name: "Catch All", path: "(.*)" }
-      ];
+      ]);
 
       beforeEach(() => {
         history = InMemory();
@@ -249,7 +249,7 @@ describe("<curi-link>", () => {
       });
 
       it("navigating = false after navigation is cancelled", done => {
-        const routes = [
+        const routes = buildRoutes([
           {
             name: "Slow",
             path: "slow",
@@ -271,7 +271,7 @@ describe("<curi-link>", () => {
             }
           },
           { name: "Catch All", path: "(.*)" }
-        ];
+        ]);
         const router = curi(history, routes);
         const Vue = createLocalVue();
         Vue.use(CuriPlugin, { router });

--- a/packages/vue/tests/focus.spec.ts
+++ b/packages/vue/tests/focus.spec.ts
@@ -1,7 +1,7 @@
 import "jest";
 import { createLocalVue } from "@vue/test-utils";
 import InMemory from "@hickory/in-memory";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 // @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";

--- a/packages/vue/tests/focus.spec.ts
+++ b/packages/vue/tests/focus.spec.ts
@@ -1,9 +1,9 @@
 import "jest";
 import { createLocalVue } from "@vue/test-utils";
 import InMemory from "@hickory/in-memory";
-import { curi } from "@curi/router";
+import { curi, buildRoutes } from "@curi/router";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("curi-focus directive", () => {

--- a/packages/vue/tests/plugin.spec.ts
+++ b/packages/vue/tests/plugin.spec.ts
@@ -1,14 +1,14 @@
 import "jest";
 import { createLocalVue } from "@vue/test-utils";
 import InMemory from "@hickory/in-memory";
-import { curi, buildRoutes } from "@curi/router";
+import { curi, prepareRoutes } from "@curi/router";
 
 // @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("CuriPlugin", () => {
   const history = InMemory();
-  const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
+  const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
   const router = curi(history, routes);
 
   describe("$router", () => {
@@ -59,7 +59,7 @@ describe("CuriPlugin", () => {
       }
 
       let history, router;
-      const routes = buildRoutes([
+      const routes = prepareRoutes([
         { name: "Contact", path: "contact" },
         { name: "Catch All", path: "(.*)" }
       ]);

--- a/packages/vue/tests/plugin.spec.ts
+++ b/packages/vue/tests/plugin.spec.ts
@@ -1,14 +1,14 @@
 import "jest";
 import { createLocalVue } from "@vue/test-utils";
-import { curi } from "@curi/router";
 import InMemory from "@hickory/in-memory";
+import { curi, buildRoutes } from "@curi/router";
 
-// resolved by jest
+// @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("CuriPlugin", () => {
   const history = InMemory();
-  const routes = [{ name: "Catch All", path: "(.*)" }];
+  const routes = buildRoutes([{ name: "Catch All", path: "(.*)" }]);
   const router = curi(history, routes);
 
   describe("$router", () => {
@@ -59,10 +59,10 @@ describe("CuriPlugin", () => {
       }
 
       let history, router;
-      const routes = [
+      const routes = buildRoutes([
         { name: "Contact", path: "contact" },
         { name: "Catch All", path: "(.*)" }
-      ];
+      ]);
 
       beforeEach(() => {
         history = InMemory();

--- a/website/src/pages/Examples/react/authentication.js
+++ b/website/src/pages/Examples/react/authentication.js
@@ -30,26 +30,26 @@ export default function AuthenticationExample() {
         </p>
 
         <CodeBlock lang="javascript">
-          {`const routes = [
-    // ...,
-    {
-      name: 'Protected',
-      path: 'super-secret',
-      response: () => {
-        if (!store.userIsAuthenticated) {
-          return {
-            redirectTo: { name: "Login" },
-            status: 302
-          };
-        }
+          {`const routes = prepareRoutes([
+  // ...,
+  {
+    name: 'Protected',
+    path: 'super-secret',
+    response: () => {
+      if (!store.userIsAuthenticated) {
+        return {
+          redirectTo: { name: "Login" },
+          status: 302
+        };
       }
-    },
-    {
-      name: 'Login',
-      path: 'login',
-      ...
     }
-  ];`}
+  },
+  {
+    name: 'Login',
+    path: 'login',
+    ...
+  }
+]);`}
         </CodeBlock>
       </Section>
 

--- a/website/src/pages/Examples/react/multi-body.js
+++ b/website/src/pages/Examples/react/multi-body.js
@@ -26,19 +26,19 @@ export default function MultiBodyExample() {
           components.
         </p>
         <CodeBlock lang="javascript">
-          {`const routes = [
-    {
-      ...,
-      response() {
-        return {
-          body: {
-            main: MainComponent,
-            menu: MenuComponent
-          }
-        };
-      }
+          {`const routes = prepareRoutes([
+  {
+    ...,
+    response() {
+      return {
+        body: {
+          main: MainComponent,
+          menu: MenuComponent
+        }
+      };
     }
-  ];`}
+  }
+]);`}
         </CodeBlock>
         <Note>
           One thing to remember when attaching multiple components to a route is
@@ -48,25 +48,25 @@ export default function MultiBodyExample() {
         </Note>
         <CodeBlock lang="javascript">
           {`// be consistent, don't use
-  // different body types
-  const routes = [
-    {
-      ...,
-      response() {
-        return {
-          body: OneLayout
-        };
-      }
-    },
-    {
-      ...,
-      response() {
-        return {
-          body: { another: Layout }
-        };
-      }
+// different body types
+const routes = prepareRoutes([
+  {
+    ...,
+    response() {
+      return {
+        body: OneLayout
+      };
     }
-  ];`}
+  },
+  {
+    ...,
+    response() {
+      return {
+        body: { another: Layout }
+      };
+    }
+  }
+]);`}
         </CodeBlock>
       </Section>
 

--- a/website/src/pages/Examples/vue/authentication.js
+++ b/website/src/pages/Examples/vue/authentication.js
@@ -30,26 +30,26 @@ export default function AuthenticationExample() {
         </p>
 
         <CodeBlock lang="javascript">
-          {`const routes = [
-    // ...,
-    {
-      name: 'Protected',
-      path: 'super-secret',
-      response: () => {
-        if (!store.userIsAuthenticated) {
-          return {
-            name: "Login",
-            status: 302
-          };
-        }
+          {`const routes = prepareRoutes([
+  // ...,
+  {
+    name: 'Protected',
+    path: 'super-secret',
+    response: () => {
+      if (!store.userIsAuthenticated) {
+        return {
+          name: "Login",
+          status: 302
+        };
       }
-    },
-    {
-      name: 'Login',
-      path: 'login',
-      ...
     }
-  ];`}
+  },
+  {
+    name: 'Login',
+    path: 'login',
+    ...
+  }
+]);`}
         </CodeBlock>
       </Section>
 

--- a/website/src/pages/Guides/accessibility.js
+++ b/website/src/pages/Guides/accessibility.js
@@ -62,7 +62,7 @@ const announcer = ariaLive(
   ({ response }) => \`Navigated to \${response.title}\`
 );
 
-const routes = [
+const routes = prepareRoutes([
   {
     name: "Home",
     path: "",
@@ -72,7 +72,7 @@ const routes = [
       };
     }
   }
-]
+]);
 
 const router = curi(history, routes, {
   sideEffects: [announcer]

--- a/website/src/pages/Guides/apollo.js
+++ b/website/src/pages/Guides/apollo.js
@@ -97,7 +97,7 @@ ReactDOM.render((
 import Noun from "./pages/Noun";
 
 // nothing Apollo related in here
-const routes = [
+const routes = prepareRoutes([
   {
     name: 'Noun',
     path: 'noun/:word',
@@ -107,7 +107,7 @@ const routes = [
       };
     }
   }
-];`}
+]);`}
         </CodeBlock>
 
         <Explanation>
@@ -196,7 +196,7 @@ const Noun = ({ response }) => (
           {`import client from "./apollo";
 import { EXAMPLE_QUERY } from "./queries";
 
-const routes = [
+const routes = prepareRoutes([
   {
     name: "Example",
     path: "example/:id",
@@ -209,7 +209,7 @@ const routes = [
       }
     }
   }
-];`}
+]);`}
         </CodeBlock>
 
         <Explanation>
@@ -383,7 +383,7 @@ const Verb = ({ response }) => (
             {`// index.js
 import prefetch from "@curi/route-prefetch";
 
-const routes = [
+const routes = prepareRoutes([
   {
     name: "Example",
     path: "example/:id",
@@ -396,7 +396,7 @@ const routes = [
       }
     }
   }
-]
+]);
 
 const router = curi(history, routes, {
   route: [prefetch()]

--- a/website/src/pages/Guides/code-splitting.js
+++ b/website/src/pages/Guides/code-splitting.js
@@ -44,7 +44,7 @@ export default function CodeSplittingGuide() {
 import Contact from './components/Contact';
 import ContactMethod from './components/ContactMethod';
 
-const routes = [
+const routes = prepareRoutes([
   {
     name: 'Home',
     path: '',
@@ -74,7 +74,7 @@ const routes = [
       }
     ]
   }
-];`}
+]);`}
         </CodeBlock>
       </Section>
 
@@ -113,7 +113,7 @@ const routes = [
           </p>
         </Explanation>
         <CodeBlock>
-          {`const routes = [
+          {`const routes = prepareRoutes([
   {
     name: 'Home',
     path: '',
@@ -161,7 +161,7 @@ const routes = [
       }
     ]
   }
-];`}
+]);`}
         </CodeBlock>
       </Section>
 

--- a/website/src/pages/Guides/creating-a-router.js
+++ b/website/src/pages/Guides/creating-a-router.js
@@ -27,10 +27,10 @@ export default function CreatingARouterGuide() {
           </p>
         </Explanation>
         <CodeBlock>
-          {`import { curi } from '@curi/router';
+          {`import { curi, prepareRoutes } from '@curi/router';
 
 const history = Browser();
-const routes = [...];
+const routes = prepareRoutes([...]);
 const router = curi(history, routes);`}
         </CodeBlock>
         <Explanation>

--- a/website/src/pages/Guides/loading.js
+++ b/website/src/pages/Guides/loading.js
@@ -40,12 +40,12 @@ export default function LoadingGuide() {
           </p>
         </Explanation>
         <CodeBlock>
-          {`const routes = [
+          {`const routes = prepareRoutes([
   {
     name: 'Recipe',
     path: 'recipe/:id'
   }
-];`}
+]);`}
         </CodeBlock>
 
         <Explanation>

--- a/website/src/pages/Guides/migrate-rrv3.js
+++ b/website/src/pages/Guides/migrate-rrv3.js
@@ -139,7 +139,7 @@ export default function MigrateReactRouterv3Guide() {
             </p>
           </Explanation>
           <CodeBlock>
-            {`const routes = [
+            {`const routes = prepareRoutes([
   {
     name: 'Home',
     path: ''
@@ -154,7 +154,7 @@ export default function MigrateReactRouterv3Guide() {
       }
     ]
   }
-];`}
+]);`}
           </CodeBlock>
 
           <Explanation>
@@ -177,11 +177,13 @@ export default function MigrateReactRouterv3Guide() {
             <Note>Only known properties will be merged onto the response.</Note>
           </Explanation>
           <CodeBlock>
-            {`import Home from './pages/Home';
+            {`import { prepareRoutes } from "@curi/router";
+            
+import Home from './pages/Home';
 import Inbox from './pages/Inbox';
 import Mesage from './pages/Message';
 
-const routes = [
+const routes = prepareRoutes([
   {
     name: 'Home',
     path: '',
@@ -211,7 +213,7 @@ const routes = [
       }
     ]
   }
-];`}
+]);`}
           </CodeBlock>
 
           <Explanation>
@@ -256,7 +258,7 @@ const routes = [
             </p>
           </Explanation>
           <CodeBlock>
-            {`const routes = [
+            {`const routes = prepareRoutes([
   {
     name: 'Home',
     path: '',
@@ -289,7 +291,7 @@ const routes = [
       }
     ]
   }
-];`}
+]);`}
           </CodeBlock>
         </Section>
         <p>
@@ -311,7 +313,7 @@ const routes = [
         </Explanation>
         <CodeBlock lang="jsx">
           {`import { Router, browserHistory } from 'react-router';
-const routes = [...];
+const routes = prepareRoutes([...]);
 ReactDOM.render((
   <Router history={browserHistory} routes={routes} />
 ), holder);`}
@@ -330,10 +332,10 @@ ReactDOM.render((
           </p>
         </Explanation>
         <CodeBlock>
-          {`import { curi } from '@curi/router';
+          {`import { curi, prepareRoutes } from '@curi/router';
 import Browser from '@hickory/browser';
 const history = Browser();
-const routes = [...];
+const routes = prepareRoutes([...]);
 const router = curi(history, routes);`}
         </CodeBlock>
       </Section>
@@ -473,7 +475,7 @@ ReactDOM.render((
             </Note>
           </Explanation>
           <CodeBlock>
-            {`const routes = [
+            {`const routes = prepareRoutes([
   // ...,
   {
     name: "Not Found",
@@ -482,7 +484,7 @@ ReactDOM.render((
       return { body: NotFound };
     }
   }
-];`}
+]);`}
           </CodeBlock>
 
           <Explanation>

--- a/website/src/pages/Guides/migrate-rrv4.js
+++ b/website/src/pages/Guides/migrate-rrv4.js
@@ -94,7 +94,7 @@ const Inbox = ({ match }) => (
             </p>
           </Explanation>
           <CodeBlock>
-            {`const routes = [
+            {`const routes = prepareRoutes([
   {
     name: 'Home',
     path: ''
@@ -109,7 +109,7 @@ const Inbox = ({ match }) => (
       }
     ]
   }
-];`}
+]);`}
           </CodeBlock>
 
           <Explanation>
@@ -123,11 +123,13 @@ const Inbox = ({ match }) => (
             </p>
           </Explanation>
           <CodeBlock>
-            {`import Home from './pages/Home';
+            {`import { prepareRoutes } from "@curi/router";
+            
+import Home from './pages/Home';
 import Inbox from './pages/Inbox';
 import Mesage from './pages/Message';
 
-const routes = [
+const routes = prepareRoutes([
   {
     name: 'Home',
     path: '',
@@ -157,7 +159,7 @@ const routes = [
       }
     ]
   }
-];`}
+]);`}
           </CodeBlock>
 
           <Explanation>
@@ -182,7 +184,7 @@ const routes = [
             </p>
           </Explanation>
           <CodeBlock>
-            {`const routes = [
+            {`const routes = prepareRoutes([
   {
     path: '',
     response: () => {
@@ -212,7 +214,7 @@ const routes = [
       }
     ]
   }
-];`}
+]);`}
           </CodeBlock>
         </Section>
         <p>
@@ -255,10 +257,10 @@ ReactDOM.render((
           </p>
         </Explanation>
         <CodeBlock>
-          {`import { curi } from '@curi/router';
+          {`import { curi, prepareRoutes } from '@curi/router';
 import Browser from '@hickory/browser';
 const history = Browser();
-const routes = [...];
+const routes = prepareRoutes([...]);
 const router = curi(history, routes);`}
         </CodeBlock>
       </Section>
@@ -426,7 +428,7 @@ ReactDOM.render((
             </Note>
           </Explanation>
           <CodeBlock>
-            {`const routes = [
+            {`const routes = prepareRoutes([
   // ...,
   {
     name: "Not Found",
@@ -435,7 +437,7 @@ ReactDOM.render((
       return { body: NotFound };
     }
   }
-];`}
+]);`}
           </CodeBlock>
 
           <Explanation>

--- a/website/src/pages/Guides/react-dom.js
+++ b/website/src/pages/Guides/react-dom.js
@@ -137,7 +137,7 @@ router.once(() => {
             </p>
           </Explanation>
           <CodeBlock lang="jsx" data-line="20,24,27">
-            {`const routes = [
+            {`const routes = prepareRoutes([
   {
     name: "Home",
     path: "",
@@ -151,7 +151,7 @@ router.once(() => {
     }
   },
   // ...
-];
+]);
 
 ReactDOM.render((
   <Router>

--- a/website/src/pages/Guides/react-native.js
+++ b/website/src/pages/Guides/react-native.js
@@ -141,7 +141,7 @@ const App = () => (
             </p>
           </Explanation>
           <CodeBlock lang="jsx" data-line="20,24,27">
-            {`const routes = [
+            {`const routes = prepareRoutes([
   {
     name: "Home",
     path: "",
@@ -155,7 +155,7 @@ const App = () => (
     }
   },
   // ...
-];
+]);
 
 const App = () => (
   <Router>

--- a/website/src/pages/Guides/responses.js
+++ b/website/src/pages/Guides/responses.js
@@ -167,7 +167,7 @@ export default function RoutesAndResponsesGuide() {
         <CodeBlock>
           {`// do NOT do this
 // mixing body shapes complicates rendering
-const routes = [
+const routes = prepareRoutes([
   {
     response() {
       return { body: One }
@@ -183,7 +183,7 @@ const routes = [
       }
     }
   }
-];`}
+]);`}
         </CodeBlock>
       </Section>
 

--- a/website/src/pages/Guides/route-interactions.js
+++ b/website/src/pages/Guides/route-interactions.js
@@ -188,10 +188,10 @@ export default function confirmInteraction() {
           </p>
         </Explanation>
         <CodeBlock>
-          {`import { curi } from '@curi/router';
+          {`import { curi, prepareRoutes } from '@curi/router';
 import confirmFactory from './interactions/confirm'
 
-const routes = [{ name: 'Home', path: '' }];
+const routes = prepareRoutes([{ name: 'Home', path: '' }]);
 
 const router = curi(history, routes, {
   route: [confirmFactory()]

--- a/website/src/pages/Guides/routes.js
+++ b/website/src/pages/Guides/routes.js
@@ -44,7 +44,7 @@ export default function RoutesGuide() {
         </Note>
       </Explanation>
       <CodeBlock>
-        {`const routes = [
+        {`const routes = prepareRoutes([
   {
     name: "Home",
     path: ""
@@ -54,8 +54,26 @@ export default function RoutesGuide() {
     // the "id" segment can be any value
     path: "a/:id"
   }
-];`}
+]);`}
       </CodeBlock>
+
+      <Section title="Preparing Routes" id="prepareRoutes" tag="h3">
+        <Explanation>
+          <p>
+            The routes array should be wrapped in a <IJS>prepareRoutes()</IJS>{" "}
+            call. This will pre-build the routes for the router.
+          </p>
+        </Explanation>
+        <CodeBlock>
+          {`import { prepareRoutes } from "@curi/router";
+
+// plain routes
+const routes = [...]
+
+// prepared routes
+export default prepareRoutes(routes);`}
+        </CodeBlock>
+      </Section>
 
       <Section title="Route names" id="route-names" tag="h3">
         <Explanation>
@@ -140,7 +158,7 @@ export default function RoutesGuide() {
         <CodeBlock>
           {`import User from "./components/User";
 
-const routes = [
+const routes = prepareRoutes([
   {
     name: "User",
     path: "u/:id",
@@ -158,7 +176,7 @@ const routes = [
       };
     }
   }
-];`}
+]);`}
         </CodeBlock>
         <Explanation>
           <p>
@@ -223,7 +241,7 @@ const routes = [
           tag="h3"
         >
           <CodeBlock>
-            {`const routes = [
+            {`const routes = prepareRoutes([
   {
     name: 'Home',
     path: '',
@@ -236,7 +254,7 @@ const routes = [
     name: 'Not Found',
     path: '(.*)' // this matches EVERY pathname
   }
-];`}
+]);`}
           </CodeBlock>
 
           <Explanation>

--- a/website/src/pages/Guides/svelte.js
+++ b/website/src/pages/Guides/svelte.js
@@ -98,7 +98,7 @@ curiStore(router, store);`}
           </Explanation>
           <CodeBlock lang="html">
             {`<script>
-const routes = [
+const routes = prepareRoutes([
   {
     name: "Home",
     path: "",
@@ -112,7 +112,7 @@ const routes = [
     }
   },
   // ...
-];
+]);
 </script>
 
 <template>

--- a/website/src/pages/Guides/vue.js
+++ b/website/src/pages/Guides/vue.js
@@ -95,7 +95,7 @@ Vue.use(CuriPlugin, { router });`}
           </Explanation>
           <CodeBlock lang="html">
             {`<script>
-const routes = [
+const routes = prepareRoutes([
   {
     name: "Home",
     path: "",
@@ -109,7 +109,7 @@ const routes = [
     }
   },
   // ...
-];
+]);
 </script>
 
 <template>

--- a/website/src/pages/Home/index.js
+++ b/website/src/pages/Home/index.js
@@ -12,16 +12,16 @@ export default function HomePage() {
     <React.Fragment>
       <h1>Curi is a JavaScript router for single-page applications</h1>
       <CodeBlock>
-        {`import { curi } from '@curi/router';
+        {`import { curi, prepareRoutes } from '@curi/router';
 import Browser from '@hickory/browser';
 
 const history = Browser();
-const routes = [
+const routes = prepareRoutes([
   { name: 'Home', path: '', ... },
   { name: 'User', path: 'u/:userID', ... },
   // more routes...
   { name: 'Not Found', path: '(.*)', ... }
-];
+]);
 
 const router = curi(history, routes);`}
       </CodeBlock>

--- a/website/src/pages/Packages/helpers.js
+++ b/website/src/pages/Packages/helpers.js
@@ -41,7 +41,7 @@ export default class RouteActivePkg extends React.PureComponent {
             <CodeBlock>
               {`import { once } from "@curi/helpers";
             
-const routes = [
+const routes = prepareRoutes([
   {
     name: "Menu",
     path: "menu",
@@ -54,7 +54,7 @@ const routes = [
       cached: once(() => api.getItems)
     }
   }
-];`}
+]);`}
             </CodeBlock>
           </Section>
           <Section title="preferDefault" id="preferDefault">
@@ -74,7 +74,7 @@ const routes = [
             <CodeBlock>
               {`import { preferDefault } from "@curi/helpers";
 
-const routes = [
+const routes = prepareRoutes([
   {
     name: "Menu",
     path: "menu",
@@ -86,7 +86,7 @@ const routes = [
       return { body: resolved.body }
     }
   }
-]`}
+]);`}
             </CodeBlock>
           </Section>
         </APIBlock>

--- a/website/src/pages/Packages/route-ancestors.js
+++ b/website/src/pages/Packages/route-ancestors.js
@@ -39,7 +39,7 @@ export default class RouteAncestorsPkg extends React.PureComponent {
               {`import { curi } from '@curi/router';
 import ancestors from '@curi/route-ancestors';
 
-const routes = [
+const routes = prepareRoutes([
   {
     name: 'Grandparent', path: 'g',
     children: [
@@ -51,7 +51,7 @@ const routes = [
       }
     ]
   }
-];
+]);
 
 const router = curi(history,routes, {
   route: [ancestors()]

--- a/website/src/pages/Packages/router.js
+++ b/website/src/pages/Packages/router.js
@@ -64,18 +64,18 @@ const router = curi(history, routes);`}
               <Section tag="h5" title="routes" id="routes">
                 <Explanation>
                   <p>
-                    An array of{" "}
+                    An array of prepared{" "}
                     <Link to="Guide" params={{ slug: "routes" }}>
                       route
                     </Link>{" "}
-                    objects for all valid routes in the application.
+                    objects describing all valid routes in the application.
                   </p>
                 </Explanation>
                 <CodeBlock lang="jsx">
-                  {`const routes = [
+                  {`const routes = prepareRoutes([
   { name: "Home", path: "" },
   { name: "About", path: "about" }
-];
+]);
 
 const router = curi(history, routes);`}
                 </CodeBlock>
@@ -109,7 +109,7 @@ const router = curi(history, routes);`}
                       {`import active from "@curi/route-active";
 import ancestors from "@curi/route-ancestors";
 
-const routes = [{ name: "Home", path: "" }];
+const routes = prepareRoutes([{ name: "Home", path: "" }]);
 
 const router = curi(history, routes, {
   route: [active(), ancestors()]
@@ -185,7 +185,7 @@ const router = curi(history, routes, {
                       </p>
                     </Explanation>
                     <CodeBlock>
-                      {`const routes = [
+                      {`const routes = prepareRoutes([
   {
     name: "Old",
     path: "old/:id",
@@ -203,7 +203,7 @@ const router = curi(history, routes, {
     name: "New",
     path: "new/:id"
   }
-];
+]);
 
 const router = curi(history, routes, {
   emitRedirects: false                 
@@ -233,7 +233,7 @@ const router = curi(history, routes, {
                       </p>
                     </Explanation>
                     <CodeBlock>
-                      {`const routes = [
+                      {`const routes = prepareRoutes([
   {
     name: "Old",
     path: "old/:id",
@@ -251,7 +251,7 @@ const router = curi(history, routes, {
     name: "New",
     path: "new/:id"
   }
-];
+]);
 const history = InMemory({ locations: ["old/1" ]});
 const router = curi(history, routes, {
   automaticRedirects: false                 
@@ -367,7 +367,7 @@ router.once(({ response }) => {
                   </table>
                 </Explanation>
                 <CodeBlock>
-                  {`const routes = [
+                  {`const routes = prepareRoutes([
   {
     name: "Album",
     path: "photos/:albumID",
@@ -376,7 +376,7 @@ router.once(({ response }) => {
     ]
   },
   // ...
-];
+]);
 const router = curi(history, routes);
 
 router.navigate({
@@ -612,9 +612,9 @@ router.once(({ response, navigation }) => {
                     </p>
                   </Explanation>
                   <CodeBlock>
-                    {`const routes = [
+                    {`const routes = prepareRoutes([
   { name: 'User', path: 'user/:id' }
-];
+]);
 const router = curi(history, routes);
 const userPathname = router.route.pathname(
   'User',
@@ -638,8 +638,8 @@ const userPathname = router.route.pathname(
                   </p>
                 </Explanation>
                 <CodeBlock>
-                  {`const oldRoutes = [...];
-const newRoutes = [...];
+                  {`const oldRoutes = prepareRoutes([...]);
+const newRoutes = prepareRoutes([...]);
 
 const router = curi(history, oldRoutes);
 // generates responses using old routes
@@ -659,25 +659,32 @@ router.refresh(newRoutes);
               </Section>
             </Section>
           </Section>
-          <Section title="pathname" id="pathname">
+
+          <Section title="prepareRoutes" id="prepareRoutes">
             <Explanation>
               <p>
-                Curi automatically includes a <IJS>pathname</IJS> route
-                interaction for you to generate URL pathnames for routes. If you
-                need to access this same ability outside of a router, you can
-                import the <IJS>pathname</IJS> route interaction.
+                The <IJS>prepareRoutes()</IJS> export is used to build the
+                routes for Curi. This will pre-compile paths for location
+                matching and pathname building, which is particularly useful for
+                server rendering.
               </p>
             </Explanation>
             <CodeBlock>
-              {`import { pathname } from "@curi/router";
+              {`import { prepareRoutes } from '@curi/router';
 
-const pathnameGenerator = pathname();
-// register routes
-pathnameGenerator.register({ name: "Yo", path: "yo/:name" });
-// generate pathname
-const path = pathnameGenerator.get("Yo", { name: "joey" })
-// path = "/yo/joey"`}
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  // ...
+  { name: "Not Found", path: "(.*)" }
+]);`}
             </CodeBlock>
+            <Explanation>
+              <Warning>
+                Passing a non-prepared routes array to <IJS>curi()</IJS> is
+                still supported, but deprecated and will be removed in the next
+                major version.
+              </Warning>
+            </Explanation>
           </Section>
 
           <Section title="Route properties" id="route-properties">
@@ -804,7 +811,7 @@ const path = pathnameGenerator.get("Yo", { name: "joey" })
                   </Explanation>
                   <CodeBlock>
                     {`import Home from "./components/Home";
-const routes = [
+const routes = prepareRoutes([
   {
     name: "Home",
     path: "",
@@ -813,7 +820,7 @@ const routes = [
     }
   },
   // ...
-];
+]);
 // response = { body: Home, ... }`}
                   </CodeBlock>
                 </li>
@@ -1110,7 +1117,7 @@ const user = {
                 </p>
               </Explanation>
               <CodeBlock>
-                {`const routes = [
+                {`const routes = prepareRoutes([
   {
     name: 'Number',
     path: 'number/:num',
@@ -1118,7 +1125,8 @@ const user = {
       num: n => parseInt(n, 10)
     }
   }
-]
+]);
+
 // when the user visits /number/1,
 // response.params will be { num: 1 }
 // instead of { num: "1" }`}
@@ -1153,7 +1161,7 @@ const user = {
                 </p>
               </Explanation>
               <CodeBlock>
-                {`const routes = [
+                {`const routes = prepareRoutes([
   {
     name: 'A Route',
     path: 'a-route',
@@ -1168,7 +1176,7 @@ const user = {
       enter: 'slide-right'
     }
   }
-];`}
+]);`}
               </CodeBlock>
             </Section>
           </Section>

--- a/website/src/pages/Packages/static.js
+++ b/website/src/pages/Packages/static.js
@@ -90,7 +90,7 @@ staticFiles({
                   </p>
                 </Explanation>
                 <CodeBlock>
-                  {`routes = [
+                  {`routes = prepareRoutes([
   {
     name: "Home",
     path: "",
@@ -99,7 +99,7 @@ staticFiles({
     name: "User",
     path: "u/:id"
   }
-];
+]);
 
 
 staticFiles({
@@ -304,7 +304,7 @@ staticFiles({
                   </p>
                 </Explanation>
                 <CodeBlock>
-                  {`routes = [
+                  {`routes = prepareRoutes([
   {
     name: "Home",
     path: "",
@@ -313,7 +313,7 @@ staticFiles({
     name: "User",
     path: "u/:id"
   }
-];
+]);
 
 
 const paths = pathnames({

--- a/website/src/pages/Tutorials/react-advanced.js
+++ b/website/src/pages/Tutorials/react-advanced.js
@@ -100,7 +100,7 @@ npm run start`}
           </p>
         </Explanation>
         <CodeBlock>
-          {`const routes = [
+          {`const routes = prepareRoutes([
   {
     name: "A Route",
     path: "route/:id",
@@ -119,7 +119,7 @@ npm run start`}
       }
     }
   }
-];`}
+]);`}
         </CodeBlock>
 
         <Explanation>
@@ -228,7 +228,7 @@ import(/* webpackChunkName: "Test" */ "./components/Test.js")`}
           </p>
         </Explanation>
         <CodeBlock>
-          {`const routes = [
+          {`const routes = prepareRoutes([
   {
     name: "Test",
     path: "test",
@@ -236,7 +236,7 @@ import(/* webpackChunkName: "Test" */ "./components/Test.js")`}
       body: () => import(/* webpackChunkName: "Test" */ "./components/Test.js")
     }
   }
-];`}
+]);`}
         </CodeBlock>
 
         <Note>
@@ -262,7 +262,7 @@ import(/* webpackChunkName: "Test" */ "./components/Test.js")`}
             <p>Which you choose is mostly a matter of personal preference.</p>
           </Explanation>
           <CodeBlock>
-            {`const routes = [
+            {`const routes = prepareRoutes([
   {
     name: "One",
     path: "one",
@@ -288,7 +288,7 @@ import(/* webpackChunkName: "Test" */ "./components/Test.js")`}
       };
     }
   }
-];`}
+]);`}
           </CodeBlock>
         </Note>
 
@@ -305,7 +305,7 @@ import(/* webpackChunkName: "Test" */ "./components/Test.js")`}
         <CodeBlock>
           {`import displayLoadError from "./components/LoadError";
         
-const routes = [
+const routes = prepareRoutes([
   {
     name: "One",
     path: "one",
@@ -320,7 +320,7 @@ const routes = [
       };
     }
   }
-];`}
+]);`}
         </CodeBlock>
 
         <Explanation>

--- a/website/src/routes.js
+++ b/website/src/routes.js
@@ -1,4 +1,4 @@
-import { buildRoutes } from "@curi/router";
+import { prepareRoutes } from "@curi/router";
 import { preferDefault } from "@curi/helpers";
 
 // components that are not code split
@@ -16,7 +16,7 @@ import EXAMPLE_API from "./constants/examples";
 
 import catchImportError from "./catchImportError";
 
-export default buildRoutes([
+export default prepareRoutes([
   {
     name: "Home",
     path: "",

--- a/website/src/routes.js
+++ b/website/src/routes.js
@@ -1,3 +1,4 @@
+import { buildRoutes } from "@curi/router";
 import { preferDefault } from "@curi/helpers";
 
 // components that are not code split
@@ -15,7 +16,7 @@ import EXAMPLE_API from "./constants/examples";
 
 import catchImportError from "./catchImportError";
 
-export default [
+export default buildRoutes([
   {
     name: "Home",
     path: "",
@@ -229,4 +230,4 @@ export default [
       };
     }
   }
-];
+]);


### PR DESCRIPTION
This introduces a new function to the `@curi/router` package: `prepareRoutes()`. This function does externally what Curi previously did internally: transform the `route` objects in the `routes` array to what Curi knows how to work with. The most expensive bit of this is compiling the route `path`s using `path-to-regexp`.

Why? This is primarily a server side optimization. Instead of having to re-build the routes for every single request, they can be built ahead of time and re-used for every render.

```js
import { curi, prepareRoutes } from "@curi/router";
import routes from "./routes";

// build the routes ahead of time instead of for every request
const preppedRoutes = prepareRoutes(routes);

function renderHandler(req, res) {
  const history = InMemory(...);
  const router = curi(history, preppedRoutes);
  // ...
}
```
Routes can even be prepared in the module where they are defined.
```js
import { prepareRoutes } from "@curi/router";

export default prepareRoutes([
 { name: "Home", path: "" },
 // ...
]);
```
A deprecation warning has been added to encourage users to switch to the new style, but passing a plain routes array will be supported until `@curi/router` v2 is released (which isn't happening any time soon).

#### Downsides

* Instead of routes "just" being an array, the user has to take the extra step of wrapping it in a `prepareRoutes()` call. While minimal, this is still extra work.

#### Upsides

* More efficient server renders because we aren't wasting time re-parsing paths.