### PR TITLE
Provide external values when creating router

### DIFF
--- a/packages/interactions/route-active/package-lock.json
+++ b/packages/interactions/route-active/package-lock.json
@@ -2,6 +2,29 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@hickory/in-memory": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-1.0.2.tgz",
+      "integrity": "sha512-qDE0MluMoFgZcKj5yMjzOBAMv8Luq1uBCKV1BUKc/W9afwhtNOaNzzPv2d9MaMCiyZYsM7kiDW+EWqSAI+x+ZQ==",
+      "requires": {
+        "@hickory/root": "^1.0.2"
+      },
+      "dependencies": {
+        "@hickory/location-utils": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-1.0.2.tgz",
+          "integrity": "sha512-6aFLOGADMu3u7M2KTOp2UzteR+WG+rAf+B2qeUkGpT1LvFuCUC/1NiQJqG098sL3A2OlOAweJic9PmayemuQ4Q=="
+        },
+        "@hickory/root": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@hickory/root/-/root-1.0.2.tgz",
+          "integrity": "sha512-YL0JT/kd0Bj3wBqXOVT4eDYXFFrBxU0xsbigFTTJL//+eIKjB95gXvx4CEzV9FCLGvEsOcemZqHuxdr8PNN2yA==",
+          "requires": {
+            "@hickory/location-utils": "^1.0.2"
+          }
+        }
+      }
+    },
     "ts-jest": {
       "version": "23.10.4",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.4.tgz",

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 20218,
-    "minified": 7683,
-    "gzipped": 3053,
+    "bundled": 20225,
+    "minified": 7685,
+    "gzipped": 3054,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 20477,
-    "minified": 7888,
-    "gzipped": 3130
+    "bundled": 20484,
+    "minified": 7890,
+    "gzipped": 3131
   },
   "dist/curi-router.umd.js": {
-    "bundled": 33697,
-    "minified": 10110,
-    "gzipped": 4226
+    "bundled": 33704,
+    "minified": 10112,
+    "gzipped": 4225
   },
   "dist/curi-router.min.js": {
-    "bundled": 31903,
-    "minified": 8956,
-    "gzipped": 3740
+    "bundled": 31910,
+    "minified": 8958,
+    "gzipped": 3739
   }
 }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 20121,
-    "minified": 7651,
-    "gzipped": 3045,
+    "bundled": 20218,
+    "minified": 7683,
+    "gzipped": 3053,
     "treeshaked": {
       "rollup": {
         "code": 45,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 20380,
-    "minified": 7856,
-    "gzipped": 3122
+    "bundled": 20477,
+    "minified": 7888,
+    "gzipped": 3130
   },
   "dist/curi-router.umd.js": {
-    "bundled": 33596,
-    "minified": 10078,
-    "gzipped": 4205
+    "bundled": 33697,
+    "minified": 10110,
+    "gzipped": 4226
   },
   "dist/curi-router.min.js": {
-    "bundled": 31802,
-    "minified": 8924,
-    "gzipped": 3719
+    "bundled": 31903,
+    "minified": 8956,
+    "gzipped": 3740
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Add `global` option when creating router. This value will be available to `route.resolve` functions and `route.response()`.
+* Add `globals` option when creating router. This value will be available to `route.resolve` functions and `route.response()`.
 * Export `prepareRoutes()` function to pre-build routes. Pre-building routes is encouraged and a warning message will be displayed to users who do not pre-build. In `@curi/router` v2, pre-building routes will be required.
 * Throw if routes have duplicate names.
 * Deprecate `pathname()` export.

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Add `global` option when creating router. This value will be available to `route.resolve` functions and `route.response()`.
 * Export `prepareRoutes()` function to pre-build routes. Pre-building routes is encouraged and a warning message will be displayed to users who do not pre-build. In `@curi/router` v2, pre-building routes will be required.
 * Throw if routes have duplicate names.
 * Deprecate `pathname()` export.

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -37,7 +37,8 @@ export default function createRouter(
     route: userInteractions = [],
     sideEffects = [],
     emitRedirects = true,
-    automaticRedirects = true
+    automaticRedirects = true,
+    globals
   } = options;
 
   let routes: CompiledRouteArray;
@@ -125,17 +126,19 @@ export default function createRouter(
     if (match.route.sync) {
       finalizeResponseAndEmit(match as Match, pendingNav, navigation, null);
     } else {
-      resolveMatchedRoute(match as Match).then((resolved: ResolveResults) => {
-        if (pendingNav.cancelled) {
-          return;
+      resolveMatchedRoute(match as Match, globals).then(
+        (resolved: ResolveResults) => {
+          if (pendingNav.cancelled) {
+            return;
+          }
+          finalizeResponseAndEmit(
+            match as Match,
+            pendingNav,
+            navigation,
+            resolved
+          );
         }
-        finalizeResponseAndEmit(
-          match as Match,
-          pendingNav,
-          navigation,
-          resolved
-        );
-      });
+      );
     }
   }
 
@@ -149,7 +152,8 @@ export default function createRouter(
       match,
       routeInteractions,
       resolved,
-      history
+      history,
+      globals
     );
     pending.finish();
     emitImmediate(response, navigation);

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -38,7 +38,7 @@ export default function createRouter(
     sideEffects = [],
     emitRedirects = true,
     automaticRedirects = true,
-    globals
+    external
   } = options;
 
   let routes: CompiledRouteArray;
@@ -126,7 +126,7 @@ export default function createRouter(
     if (match.route.sync) {
       finalizeResponseAndEmit(match as Match, pendingNav, navigation, null);
     } else {
-      resolveMatchedRoute(match as Match, globals).then(
+      resolveMatchedRoute(match as Match, external).then(
         (resolved: ResolveResults) => {
           if (pendingNav.cancelled) {
             return;
@@ -153,7 +153,7 @@ export default function createRouter(
       routeInteractions,
       resolved,
       history,
-      globals
+      external
     );
     pending.finish();
     emitImmediate(response, navigation);

--- a/packages/router/src/finishResponse.ts
+++ b/packages/router/src/finishResponse.ts
@@ -28,7 +28,8 @@ export default function finishResponse(
   routeMatch: Match,
   interactions: Interactions,
   resolvedResults: ResolveResults | null,
-  history: History
+  history: History,
+  globals: any
 ): Response {
   const { route, match } = routeMatch;
   const response: Response = match;
@@ -41,7 +42,8 @@ export default function finishResponse(
   const responseModifiers = route.response({
     resolved,
     error,
-    match
+    match,
+    globals
   });
 
   if (!responseModifiers) {

--- a/packages/router/src/finishResponse.ts
+++ b/packages/router/src/finishResponse.ts
@@ -29,7 +29,7 @@ export default function finishResponse(
   interactions: Interactions,
   resolvedResults: ResolveResults | null,
   history: History,
-  globals: any
+  external: any
 ): Response {
   const { route, match } = routeMatch;
   const response: Response = match;
@@ -43,7 +43,7 @@ export default function finishResponse(
     resolved,
     error,
     match,
-    globals
+    external
   });
 
   if (!responseModifiers) {

--- a/packages/router/src/resolveMatchedRoute.ts
+++ b/packages/router/src/resolveMatchedRoute.ts
@@ -8,13 +8,16 @@ export interface KeyPromiseGroup {
 /*
  * This will call any initial/every match functions for the matching route
  */
-export default function resolveRoute(match: Match): Promise<ResolveResults> {
+export default function resolveRoute(
+  match: Match,
+  global: any
+): Promise<ResolveResults> {
   const { resolve } = match.route.public;
 
   const { keys, promises } = Object.keys(resolve).reduce(
     (acc, key) => {
       acc.keys.push(key);
-      acc.promises.push(resolve[key](match.match));
+      acc.promises.push(resolve[key](match.match, global));
       return acc;
     },
     { keys: [], promises: [] } as KeyPromiseGroup

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -29,7 +29,7 @@ export interface RouterOptions {
   pathnameOptions?: PathFunctionOptions;
   emitRedirects?: boolean;
   automaticRedirects?: boolean;
-  globals?: any;
+  external?: any;
 }
 
 export interface CurrentResponse {

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -29,6 +29,7 @@ export interface RouterOptions {
   pathnameOptions?: PathFunctionOptions;
   emitRedirects?: boolean;
   automaticRedirects?: boolean;
+  globals?: any;
 }
 
 export interface CurrentResponse {

--- a/packages/router/src/types/route.ts
+++ b/packages/router/src/types/route.ts
@@ -22,11 +22,15 @@ export interface ResponseBuilder {
   resolved: Resolved | null;
   error: any;
   match: MatchResponseProperties;
+  globals: any;
 }
 
 export type ResponseFn = (props: ResponseBuilder) => SettableResponseProperties;
 
-export type AsyncMatchFn = (matched?: MatchResponseProperties) => Promise<any>;
+export type AsyncMatchFn = (
+  matched?: MatchResponseProperties,
+  globals?: any
+) => Promise<any>;
 export interface AsyncGroup {
   [key: string]: AsyncMatchFn;
 }

--- a/packages/router/src/types/route.ts
+++ b/packages/router/src/types/route.ts
@@ -22,14 +22,14 @@ export interface ResponseBuilder {
   resolved: Resolved | null;
   error: any;
   match: MatchResponseProperties;
-  globals: any;
+  external: any;
 }
 
 export type ResponseFn = (props: ResponseBuilder) => SettableResponseProperties;
 
 export type AsyncMatchFn = (
   matched?: MatchResponseProperties,
-  globals?: any
+  external?: any
 ) => Promise<any>;
 export interface AsyncGroup {
   [key: string]: AsyncMatchFn;

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -357,6 +357,55 @@ describe("curi", () => {
           });
         });
       });
+
+      describe("globals", () => {
+        it("gets passed to resolve functions", done => {
+          const history = InMemory();
+          const globals = "hey!";
+          const routes = prepareRoutes([
+            {
+              name: "Start",
+              path: "",
+              resolve: {
+                test(match, a) {
+                  expect(a).toBe(globals);
+                  done();
+                  return Promise.resolve(true);
+                }
+              }
+            },
+            {
+              name: "Other",
+              path: "other"
+            },
+            {
+              name: "Not Found",
+              path: "(.*)"
+            }
+          ]);
+          const router = curi(history, routes, { globals });
+        });
+
+        it("gets passed to response function", () => {
+          const history = InMemory();
+          const globals = "hey!";
+          const routes = prepareRoutes([
+            {
+              name: "Start",
+              path: "",
+              response({ globals: a }) {
+                expect(a).toBe(globals);
+                return {};
+              }
+            },
+            {
+              name: "Not Found",
+              path: "(.*)"
+            }
+          ]);
+          const router = curi(history, routes, { globals });
+        });
+      });
     });
 
     describe("sync/async matching", () => {

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -358,17 +358,17 @@ describe("curi", () => {
         });
       });
 
-      describe("globals", () => {
+      describe("external", () => {
         it("gets passed to resolve functions", done => {
           const history = InMemory();
-          const globals = "hey!";
+          const external = "hey!";
           const routes = prepareRoutes([
             {
               name: "Start",
               path: "",
               resolve: {
-                test(match, a) {
-                  expect(a).toBe(globals);
+                test(match, e) {
+                  expect(e).toBe(external);
                   done();
                   return Promise.resolve(true);
                 }
@@ -383,18 +383,18 @@ describe("curi", () => {
               path: "(.*)"
             }
           ]);
-          const router = curi(history, routes, { globals });
+          const router = curi(history, routes, { external });
         });
 
         it("gets passed to response function", () => {
           const history = InMemory();
-          const globals = "hey!";
+          const external = "hey!";
           const routes = prepareRoutes([
             {
               name: "Start",
               path: "",
-              response({ globals: a }) {
-                expect(a).toBe(globals);
+              response({ external: e }) {
+                expect(e).toBe(external);
                 return {};
               }
             },
@@ -403,7 +403,7 @@ describe("curi", () => {
               path: "(.*)"
             }
           ]);
-          const router = curi(history, routes, { globals });
+          const router = curi(history, routes, { external });
         });
       });
     });

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -638,6 +638,25 @@ describe("route matching/response generation", () => {
         curi(history, routes);
       });
 
+      it("is called with globals provided to router", done => {
+        const globals = "test";
+        const spy = jest.fn((_, a) => {
+          expect(a).toBe(globals);
+          done();
+        });
+
+        const routes = prepareRoutes([
+          {
+            name: "Catch All",
+            path: ":anything",
+            resolve: { spy }
+          }
+        ]);
+
+        const history = InMemory({ locations: ["/hello?one=two"] });
+        curi(history, routes, { globals });
+      });
+
       it("calls all resolve functions", done => {
         const one = jest.fn();
         const two = jest.fn();

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -638,10 +638,10 @@ describe("route matching/response generation", () => {
         curi(history, routes);
       });
 
-      it("is called with globals provided to router", done => {
-        const globals = "test";
-        const spy = jest.fn((_, a) => {
-          expect(a).toBe(globals);
+      it("is called with external provided to router", done => {
+        const external = "test";
+        const spy = jest.fn((_, e) => {
+          expect(e).toBe(external);
           done();
         });
 
@@ -654,7 +654,7 @@ describe("route matching/response generation", () => {
         ]);
 
         const history = InMemory({ locations: ["/hello?one=two"] });
-        curi(history, routes, { globals });
+        curi(history, routes, { external });
       });
 
       it("calls all resolve functions", done => {

--- a/packages/router/types/finishResponse.d.ts
+++ b/packages/router/types/finishResponse.d.ts
@@ -3,4 +3,4 @@ import { Interactions } from "./types/interaction";
 import { Response } from "./types/response";
 import { ResolveResults } from "./types/route";
 import { Match } from "./types/match";
-export default function finishResponse(routeMatch: Match, interactions: Interactions, resolvedResults: ResolveResults | null, history: History, globals: any): Response;
+export default function finishResponse(routeMatch: Match, interactions: Interactions, resolvedResults: ResolveResults | null, history: History, external: any): Response;

--- a/packages/router/types/finishResponse.d.ts
+++ b/packages/router/types/finishResponse.d.ts
@@ -3,4 +3,4 @@ import { Interactions } from "./types/interaction";
 import { Response } from "./types/response";
 import { ResolveResults } from "./types/route";
 import { Match } from "./types/match";
-export default function finishResponse(routeMatch: Match, interactions: Interactions, resolvedResults: ResolveResults | null, history: History): Response;
+export default function finishResponse(routeMatch: Match, interactions: Interactions, resolvedResults: ResolveResults | null, history: History, globals: any): Response;

--- a/packages/router/types/resolveMatchedRoute.d.ts
+++ b/packages/router/types/resolveMatchedRoute.d.ts
@@ -4,4 +4,4 @@ export interface KeyPromiseGroup {
     keys: Array<string>;
     promises: Array<Promise<any>>;
 }
-export default function resolveRoute(match: Match): Promise<ResolveResults>;
+export default function resolveRoute(match: Match, global: any): Promise<ResolveResults>;

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -23,6 +23,7 @@ export interface RouterOptions {
     pathnameOptions?: PathFunctionOptions;
     emitRedirects?: boolean;
     automaticRedirects?: boolean;
+    globals?: any;
 }
 export interface CurrentResponse {
     response: Response | null;

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -23,7 +23,7 @@ export interface RouterOptions {
     pathnameOptions?: PathFunctionOptions;
     emitRedirects?: boolean;
     automaticRedirects?: boolean;
-    globals?: any;
+    external?: any;
 }
 export interface CurrentResponse {
     response: Response | null;

--- a/packages/router/types/types/route.d.ts
+++ b/packages/router/types/types/route.d.ts
@@ -15,10 +15,10 @@ export interface ResponseBuilder {
     resolved: Resolved | null;
     error: any;
     match: MatchResponseProperties;
-    globals: any;
+    external: any;
 }
 export declare type ResponseFn = (props: ResponseBuilder) => SettableResponseProperties;
-export declare type AsyncMatchFn = (matched?: MatchResponseProperties, globals?: any) => Promise<any>;
+export declare type AsyncMatchFn = (matched?: MatchResponseProperties, external?: any) => Promise<any>;
 export interface AsyncGroup {
     [key: string]: AsyncMatchFn;
 }

--- a/packages/router/types/types/route.d.ts
+++ b/packages/router/types/types/route.d.ts
@@ -15,9 +15,10 @@ export interface ResponseBuilder {
     resolved: Resolved | null;
     error: any;
     match: MatchResponseProperties;
+    globals: any;
 }
 export declare type ResponseFn = (props: ResponseBuilder) => SettableResponseProperties;
-export declare type AsyncMatchFn = (matched?: MatchResponseProperties) => Promise<any>;
+export declare type AsyncMatchFn = (matched?: MatchResponseProperties, globals?: any) => Promise<any>;
 export interface AsyncGroup {
     [key: string]: AsyncMatchFn;
 }

--- a/website/src/pages/Guides/apollo.js
+++ b/website/src/pages/Guides/apollo.js
@@ -176,7 +176,7 @@ const Noun = ({ response }) => (
             until after a route's GraphQL data has been loaded by Apollo.
           </p>
           <p>
-            The <IJS>globals</IJS> option can be used when creating the router
+            The <IJS>external</IJS> option can be used when creating the router
             to make the Apollo client accessible from routes.
           </p>
         </Explanation>
@@ -184,7 +184,7 @@ const Noun = ({ response }) => (
           {`import client from "./apollo";
           
 const router = curi(history, routes, {
-  globals: { client }
+  external: { client }
 });`}
         </CodeBlock>
         <CodeBlock>
@@ -195,8 +195,8 @@ const routes = prepareRoutes([
     name: "Example",
     path: "example/:id",
     resolve: {
-      data({ params }, globals) {
-        return globals.client.query({
+      data({ params }, external) {
+        return external.client.query({
           query: EXAMPLE_QUERY,
           variables: { id: params.id }
         });
@@ -231,8 +231,8 @@ export default [
     name: "Verb",
     path: "verb/:word",
     resolve: {
-      verb({ params }, globals) {
-        return globals.client.query({
+      verb({ params }, external) {
+        return external.client.query({
           query: GET_VERB,
           variables: { word: params.word }
         })
@@ -287,10 +287,10 @@ export default [
     name: "Verb",
     path: "verb/:word",
     resolve: {
-      data({ params, globals }) {
+      data({ params, external }) {
         // load the data so it is cached by
         // your Apollo client
-        return globals.client.query({
+        return external.client.query({
           query: GET_VERB,
           variables: { word: params.word }
         })
@@ -356,8 +356,8 @@ const routes = prepareRoutes([
     name: "Example",
     path: "example/:id",
     resolve: {
-      examples({ params }, globals) {
-        return globals.client.query({
+      examples({ params }, external) {
+        return external.client.query({
           query: GET_EXAMPLES,
           variables: { id: params.id }
         })

--- a/website/src/pages/Guides/apollo.js
+++ b/website/src/pages/Guides/apollo.js
@@ -45,21 +45,6 @@ export default function ApolloGuide() {
       <Section title="Setup" id="setup">
         <Explanation>
           <p>
-            Your application's Apollo client instance should be defined in its
-            own module so that it can be imported throughout the application.
-          </p>
-        </Explanation>
-        <CodeBlock>
-          {`// apollo.js
-import ApolloClient from "apollo-boost";
-
-export default ApolloClient({
-  uri: "https://example.com/graphql"
-});`}
-        </CodeBlock>
-
-        <Explanation>
-          <p>
             Apollo's React package provides an <Cmp>ApolloProvider</Cmp>{" "}
             component for accessing your Apollo client throughout the
             application. The <Cmp>Router</Cmp> (or whatever you name the root
@@ -185,24 +170,33 @@ const Noun = ({ response }) => (
             You can use your Apollo client instance to call queries in a route's{" "}
             <IJS>resolve</IJS> functions. <IJS>resolve</IJS> functions are
             expected to return a Promise, which is exactly what{" "}
-            <IJS>client.query()</IJS> returns, so tightly pairing Curi and
-            Apollo is mostly center around using a <IJS>resolve</IJS> function
-            to return a <IJS>client.query()</IJS> call. This will delay
-            navigation until after a route's GraphQL data has been loaded by
-            Apollo.
+            <IJS>client.query()</IJS> returns. Tightly pairing Curi and Apollo
+            is mostly center around using a <IJS>resolve</IJS> function to
+            return a <IJS>client.query()</IJS> call. This will delay navigation
+            until after a route's GraphQL data has been loaded by Apollo.
+          </p>
+          <p>
+            The <IJS>globals</IJS> option can be used when creating the router
+            to make the Apollo client accessible from routes.
           </p>
         </Explanation>
         <CodeBlock>
           {`import client from "./apollo";
-import { EXAMPLE_QUERY } from "./queries";
+          
+const router = curi(history, routes, {
+  globals: { client }
+});`}
+        </CodeBlock>
+        <CodeBlock>
+          {`import { EXAMPLE_QUERY } from "./queries";
 
 const routes = prepareRoutes([
   {
     name: "Example",
     path: "example/:id",
     resolve: {
-      data({ params }) {
-        return client.query({
+      data({ params }, globals) {
+        return globals.client.query({
           query: EXAMPLE_QUERY,
           variables: { id: params.id }
         });
@@ -213,30 +207,7 @@ const routes = prepareRoutes([
         </CodeBlock>
 
         <Explanation>
-          <p>
-            There are two strategies for doing this. Both approaches require you
-            to be able to import your Apollo client in the module where you
-            define your routes, which is why we created client in its own module
-            in the <Link hash="setup">setup</Link> section.
-          </p>
-        </Explanation>
-        <CodeBlock>
-          {`// index.js
-import client from "./apollo";
-
-ReactDOM.render((
-  <ApolloProvider client={client}>
-    /*...*/
-  </ApolloProvider>
-), holder);
-
-// routes.js
-import client from "./apollo";
-
-// ...`}
-        </CodeBlock>
-
-        <Explanation>
+          <p>There are two strategies for doing this.</p>
           <p>
             The first approach is to avoid the <Cmp>Query</Cmp> altogether.
             Instead, you can use a route's <IJS>response()</IJS> property to
@@ -245,13 +216,12 @@ import client from "./apollo";
           </p>
           <p>
             While we know at this point that the query has executed, we should
-            also check <IJS>resolved.error</IJS> in the <IJS>response()</IJS>{" "}
-            function to ensure that the query was executed successfully.
+            also check <IJS>error</IJS> in the <IJS>response()</IJS> function to
+            ensure that the query was executed successfully.
           </p>
         </Explanation>
         <CodeBlock>
           {`// routes.js
-import client from "./apollo";
 import GET_VERB from "./queries";
 
 import Verb from "./pages/Verb";
@@ -261,8 +231,8 @@ export default [
     name: "Verb",
     path: "verb/:word",
     resolve: {
-      verb({ params }) {
-        return client.query({
+      verb({ params }, globals) {
+        return globals.client.query({
           query: GET_VERB,
           variables: { word: params.word }
         })
@@ -283,9 +253,8 @@ export default [
 
         <Explanation>
           <p>
-            In the response's <IJS>body</IJS> component, you would access the
-            query data through the <IJS>response</IJS>'s <IJS>data</IJS>{" "}
-            property.
+            When rendering, you can access the query data through the{" "}
+            <IJS>response</IJS>'s <IJS>data</IJS> property.
           </p>
         </Explanation>
         <CodeBlock lang="jsx">
@@ -311,7 +280,6 @@ const Verb = ({ response }) => (
         </Explanation>
         <CodeBlock>
           {`// routes.js
-import client from "./apollo";
 import { GET_VERB } from "./queries";
 
 export default [
@@ -319,10 +287,10 @@ export default [
     name: "Verb",
     path: "verb/:word",
     resolve: {
-      data({ params }) {
+      data({ params, globals }) {
         // load the data so it is cached by
         // your Apollo client
-        return client.query({
+        return globals.client.query({
           query: GET_VERB,
           variables: { word: params.word }
         })
@@ -388,8 +356,8 @@ const routes = prepareRoutes([
     name: "Example",
     path: "example/:id",
     resolve: {
-      examples({ params }) {
-        client.query({
+      examples({ params }, globals) {
+        return globals.client.query({
           query: GET_EXAMPLES,
           variables: { id: params.id }
         })

--- a/website/src/pages/Packages/router.js
+++ b/website/src/pages/Packages/router.js
@@ -176,12 +176,12 @@ const router = curi(history, routes, {
                   <li>
                     <Explanation>
                       <p>
-                        <IJS>globals</IJS> - Values that should be accessible to
-                        a route's <IJS>resolve</IJS> functions and{" "}
+                        <IJS>external</IJS> - Values that should be accessible
+                        to a route's <IJS>resolve</IJS> functions and{" "}
                         <IJS>response()</IJS> function.
                       </p>
                       <p>
-                        Using <IJS>globals</IJS> allows you to access APIs,
+                        Using <IJS>external</IJS> allows you to access APIs,
                         data, etc. without having to be able to import it in the
                         module where the routes are defined.
                       </p>
@@ -189,7 +189,7 @@ const router = curi(history, routes, {
                     <CodeBlock>
                       {`const client = new ApolloClient();
 const router = curi(history, routes, {
-  globals: { client, greeting: "Hi!" }
+  external: { client, greeting: "Hi!" }
 });`}
                     </CodeBlock>
                     <CodeBlock>
@@ -198,9 +198,9 @@ const router = curi(history, routes, {
     name: "User",
     path: "user/:id",
     resolve: {
-      data(match, globals) {
-        // use the globals object to make a query
-        return globals.client.query()
+      data(match, external) {
+        // use the external object to make a query
+        return external.client.query()
       }
     }
   }

--- a/website/src/pages/Packages/router.js
+++ b/website/src/pages/Packages/router.js
@@ -176,6 +176,40 @@ const router = curi(history, routes, {
                   <li>
                     <Explanation>
                       <p>
+                        <IJS>globals</IJS> - Values that should be accessible to
+                        a route's <IJS>resolve</IJS> functions and{" "}
+                        <IJS>response()</IJS> function.
+                      </p>
+                      <p>
+                        Using <IJS>globals</IJS> allows you to access APIs,
+                        data, etc. without having to be able to import it in the
+                        module where the routes are defined.
+                      </p>
+                    </Explanation>
+                    <CodeBlock>
+                      {`const client = new ApolloClient();
+const router = curi(history, routes, {
+  globals: { client, greeting: "Hi!" }
+});`}
+                    </CodeBlock>
+                    <CodeBlock>
+                      {`const routes = prepareRoutes([
+  {
+    name: "User",
+    path: "user/:id",
+    resolve: {
+      data(match, globals) {
+        // use the globals object to make a query
+        return globals.client.query()
+      }
+    }
+  }
+]);`}
+                    </CodeBlock>
+                  </li>
+                  <li>
+                    <Explanation>
+                      <p>
                         <IJS>emitRedirects</IJS> - When <IJS>false</IJS>{" "}
                         (default is <IJS>true</IJS>), response objects with the{" "}
                         <IJS>redirectTo</IJS> property{" "}


### PR DESCRIPTION
Currently, there isn't a good way to access some types of values in routes, especially runtime ones.

For example, if you are using a store (Apollo, Redux), you _could_ import it in the module where the routes are defined, but this requires the store to be created in its own module. If the store is dynamically initialized, this breaks down quickly.

Rendering on the server can also be painful. If the route wants to know about a request's cookies or the authenticated user, how does it access this information?

This PR introduces a `external` option when creating a router.

```js
const client = new ApolloClient({...});
const router = curi(history, routes, {
  external: {
    apollo: client
  }
});
```
The `external` value will be available to a route's `resolve` functions through their second argument.

```js
{
  name: "User",
  path: "u/:id",
  resolve: {
    data(match, external) {
      external.apollo.readQuery(...);
    }
  }
}
```
The `external` value is also available in a route's `response()` function as a property of its argument object.

```js
{
  name: "User",
  path: "u/:id",
  response({ match, external }) {}
}
```