### PR TITLE
Tweak @curi/react-dom & @curi/react-native Link components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -792,11 +792,17 @@
 				"@curi/router": "^1.0.0-beta.37"
 			}
 		},
+		"@curi/helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@curi/helpers/-/helpers-1.0.0.tgz",
+			"integrity": "sha512-Hk3O+f5K7eDYm8LKoiMfjqMszUZvpa0GvSd3vyCev5AdlunyXmLrZrK+nhliqhTLxIyLbnvQZroRHHQ5XOA6JQ=="
+		},
 		"@curi/router": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@curi/router/-/router-1.0.3.tgz",
-			"integrity": "sha512-UyIlsRSfA5ZPcyylW6Qyob1yS9z1YRYdgdXvjKLvkuywDK8NNhSLVWhtrRWM56SoZ/qUCt1cZYDFhnKU28Aazw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@curi/router/-/router-1.0.4.tgz",
+			"integrity": "sha512-soeBlMKZVvDsv8g1n03L0M2mCIORV1XrBZlxeBmw/NSgVkwdZQzDyFmLXG2R+MhPp6nzm1NZ266dBEen28ZtFg==",
 			"requires": {
+				"@curi/helpers": "^1.0.0",
 				"@hickory/root": "^1.0.0",
 				"path-to-regexp": "^2.1.0"
 			}
@@ -969,6 +975,11 @@
 				"@types/express-serve-static-core": "*",
 				"@types/mime": "*"
 			}
+		},
+		"@types/shallowequal": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@types/shallowequal/-/shallowequal-0.2.3.tgz",
+			"integrity": "sha512-Dj0AAVyoclTZnm2QiK+6mqs65yO5b7RFQtlUS0ZgUqTVvCTXFVVwNhZQ5m27ICF/tr7Mt/jGaqwRRyOPX2zZxQ=="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.5.13",
@@ -2737,13 +2748,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.2.0.tgz",
-			"integrity": "sha512-Berls1CHL7qfQz8Lct6QxYA5d2Tvt4doDWHcjvAISybpd+EKZVppNtXgXhaN6SdrPKo7YLTSZuYBs5cYrSWN8w==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
+			"integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000889",
-				"electron-to-chromium": "^1.3.73",
-				"node-releases": "^1.0.0-alpha.12"
+				"caniuse-lite": "^1.0.30000899",
+				"electron-to-chromium": "^1.3.82",
+				"node-releases": "^1.0.1"
 			}
 		},
 		"bser": {
@@ -2873,9 +2884,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000890",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000890.tgz",
-			"integrity": "sha512-4NI3s4Y6ROm+SgZN5sLUG4k7nVWQnedis3c/RWkynV5G6cHSY7+a8fwFyn2yoBDE3E6VswhTNNwR3PvzGqlTkg=="
+			"version": "1.0.30000902",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000902.tgz",
+			"integrity": "sha512-EZG6qrRHkW715hOFjOrshH2JygbLfhaC8NjjkE5EdGJZhCYbtnJMaRdicB+2AP8xKX3QzW9g3mkDUTHUoBG5rQ=="
 		},
 		"capture-exit": {
 			"version": "1.2.0",
@@ -3731,15 +3742,15 @@
 			}
 		},
 		"css-loader": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
-			"integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
+			"integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"css-selector-tokenizer": "^0.7.0",
 				"icss-utils": "^2.1.0",
 				"loader-utils": "^1.0.2",
-				"lodash.camelcase": "^4.3.0",
+				"lodash": "^4.17.11",
 				"postcss": "^6.0.23",
 				"postcss-modules-extract-imports": "^1.2.0",
 				"postcss-modules-local-by-default": "^1.2.0",
@@ -3747,6 +3758,13 @@
 				"postcss-modules-values": "^1.3.0",
 				"postcss-value-parser": "^3.3.0",
 				"source-list-map": "^2.0.0"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				}
 			}
 		},
 		"css-mqpacker": {
@@ -3766,9 +3784,9 @@
 			}
 		},
 		"css-selector-tokenizer": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+			"integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
 			"requires": {
 				"cssesc": "^0.1.0",
 				"fastparse": "^1.1.1",
@@ -3792,7 +3810,7 @@
 				},
 				"regjsgen": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
 					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 				},
 				"regjsparser": {
@@ -4146,9 +4164,9 @@
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.77",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.77.tgz",
-			"integrity": "sha512-XIfQcdU9L4qUte31fFATwptHodMH0Otf53N8y1AKxd1+79vR+2UYpLq+Z1Zbtbuy+w0xd7KwIUrvlnje/htiOg=="
+			"version": "1.3.82",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz",
+			"integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -4193,12 +4211,9 @@
 			}
 		},
 		"epic-spinners": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/epic-spinners/-/epic-spinners-1.0.3.tgz",
-			"integrity": "sha512-xtBBuQeUSAc2dioKTdn2cBFoqAOPpD/ggQLiszGsHsnHfIT3z2b7hxGpQu6s7VHoJLhCQgdXDOU9R4rjnKPaxw==",
-			"requires": {
-				"vue": "2.5.16"
-			}
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/epic-spinners/-/epic-spinners-1.0.4.tgz",
+			"integrity": "sha512-oCcAN0/GrAlERMYBaMpjEQCfaqUyyAGZnHv8jad9W2EwKrxeGCRp4sjKezGB/m+quJ8ZWGNQZKHiCAA1GSUWJw=="
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -4507,9 +4522,9 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fastparse": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
@@ -4735,11 +4750,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4756,7 +4773,8 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
@@ -4885,6 +4903,7 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -7060,11 +7079,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
 			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
 		},
-		"lodash.camelcase": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -7211,7 +7225,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
@@ -7649,17 +7663,17 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.0.0-alpha.12",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.12.tgz",
-			"integrity": "sha512-VPB4rTPqpVyWKBHbSa4YPFme3+8WHsOSpvbp0Mfj0bWsC8TEjt4HQrLl1hsBDELlp1nB4lflSgSuGTYiuyaP7Q==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.2.tgz",
+			"integrity": "sha512-zP8Asfg13lG9KDAW85rylSxXBYvaSdtjMIYKHUk8c1fM8drmFwRqbSYKYD+UlNVPUvrceSvgLUKHMOWR5jPWQg==",
 			"requires": {
 				"semver": "^5.3.0"
 			}
 		},
 		"node-sass": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
-			"integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
+			"version": "4.9.4",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.4.tgz",
+			"integrity": "sha512-MXyurANsUoE4/6KmfMkwGcBzAnJQ5xJBGW7Ei6ea8KnUKuzHr/SguVBIi3uaUAHtZCPUYkvlJ3Ef5T5VAwVpaA==",
 			"requires": {
 				"async-foreach": "^0.1.3",
 				"chalk": "^1.1.1",
@@ -7676,7 +7690,7 @@
 				"nan": "^2.10.0",
 				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
-				"request": "2.87.0",
+				"request": "^2.88.0",
 				"sass-graph": "^2.2.4",
 				"stdout-stream": "^1.4.0",
 				"true-case-path": "^1.0.2"
@@ -7694,7 +7708,7 @@
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"requires": {
 						"camelcase": "^2.0.0",
@@ -7722,15 +7736,6 @@
 						"which": "^1.2.9"
 					}
 				},
-				"har-validator": {
-					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-					"requires": {
-						"ajv": "^5.1.0",
-						"har-schema": "^2.0.0"
-					}
-				},
 				"indent-string": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -7746,7 +7751,7 @@
 				},
 				"meow": {
 					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+					"resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"requires": {
 						"camelcase-keys": "^2.0.0",
@@ -7766,16 +7771,6 @@
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-				},
 				"redent": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -7783,33 +7778,6 @@
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
-					}
-				},
-				"request": {
-					"version": "2.87.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-					"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.6.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.1",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.1",
-						"har-validator": "~5.0.3",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.17",
-						"oauth-sign": "~0.8.2",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.1",
-						"safe-buffer": "^5.1.1",
-						"tough-cookie": "~2.3.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.1.0"
 					}
 				},
 				"strip-indent": {
@@ -7825,23 +7793,10 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				},
-				"tough-cookie": {
-					"version": "2.3.4",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-					"requires": {
-						"punycode": "^1.4.1"
-					}
-				},
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-				},
-				"uuid": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 				}
 			}
 		},
@@ -8371,9 +8326,9 @@
 			}
 		},
 		"postcss-modules-extract-imports": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
-			"integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+			"integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
 			"requires": {
 				"postcss": "^6.0.1"
 			}
@@ -8406,9 +8361,9 @@
 			}
 		},
 		"postcss-value-parser": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -9916,6 +9871,11 @@
 				}
 			}
 		},
+		"shallowequal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -11054,11 +11014,6 @@
 				"indexof": "0.0.1"
 			}
 		},
-		"vue": {
-			"version": "2.5.16",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-2.5.16.tgz",
-			"integrity": "sha512-/ffmsiVuPC8PsWcFkZngdpas19ABm5mh2wA7iDqcltyCTwlgZjHGeJYOXkBMo422iPwIcviOtrTCUpSfXmToLQ=="
-		},
 		"vuex": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/vuex/-/vuex-3.0.1.tgz",
@@ -11431,9 +11386,9 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.2.tgz",
-			"integrity": "sha512-cZG4wSQtKrSpk5RJ33dxiaAyo8bP0V+JvycAyIDFEiDIhw4LHhhVKhn40YT1w6TR9E4scHA00LnIoBtTA13Mow==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.3.tgz",
+			"integrity": "sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==",
 			"requires": {
 				"acorn": "^5.7.3",
 				"bfj": "^6.1.1",

--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 7830,
-    "minified": 3672,
-    "gzipped": 1516,
+    "bundled": 8308,
+    "minified": 3919,
+    "gzipped": 1593,
     "treeshaked": {
       "rollup": {
-        "code": 2205,
-        "import_statements": 69
+        "code": 2401,
+        "import_statements": 97
       },
       "webpack": {
-        "code": 3265
+        "code": 3504
       }
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 8155,
-    "minified": 3937,
-    "gzipped": 1616
+    "bundled": 8653,
+    "minified": 4199,
+    "gzipped": 1692
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 16335,
-    "minified": 6715,
-    "gzipped": 2201
+    "bundled": 17914,
+    "minified": 7295,
+    "gzipped": 2398
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 15337,
-    "minified": 6068,
-    "gzipped": 1878
+    "bundled": 16916,
+    "minified": 6648,
+    "gzipped": 2077
   }
 }

--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 7972,
-    "minified": 3741,
-    "gzipped": 1545,
+    "bundled": 7830,
+    "minified": 3672,
+    "gzipped": 1516,
     "treeshaked": {
       "rollup": {
-        "code": 2274,
+        "code": 2205,
         "import_statements": 69
       },
       "webpack": {
-        "code": 3334
+        "code": 3265
       }
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 8297,
-    "minified": 4006,
-    "gzipped": 1645
+    "bundled": 8155,
+    "minified": 3937,
+    "gzipped": 1616
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 16485,
-    "minified": 6784,
-    "gzipped": 2228
+    "bundled": 16335,
+    "minified": 6715,
+    "gzipped": 2201
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 15487,
-    "minified": 6137,
-    "gzipped": 1902
+    "bundled": 15337,
+    "minified": 6068,
+    "gzipped": 1878
   }
 }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* `<Link>` with no `to` prop outputs anchor with relative `href`.
+* `<Link>` is no longer a pure component.
 * Add `<Navigation>` component, which lets the user know when asynchronous routes are navigating and cancel the navigation.
 
 ## 1.1.2

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -39,7 +39,9 @@
   "dependencies": {
     "@curi/react-universal": "^1.0.1",
     "@curi/router": "^1.0.4",
-    "@types/react": "^16.3.11"
+    "@types/react": "^16.3.11",
+    "@types/shallowequal": "^0.2.3",
+    "shallowequal": "^1.1.0"
   },
   "devDependencies": {
     "@hickory/in-memory": "^1.0.0",

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Curious } from "@curi/react-universal";
+import shallowEqual from "shallowequal";
 
 import { CuriRouter } from "@curi/router";
 
@@ -40,6 +41,16 @@ class BaseLink extends React.Component<BaseLinkProps, LinkState> {
   state = {
     navigating: false
   };
+
+  shouldComponentUpdate(nextProps: BaseLinkProps, nextState: LinkState) {
+    const { params: nextParams, ...nextRest } = nextProps;
+    const { params: currentParams, ...currentRest } = this.props;
+    return (
+      !shallowEqual(nextState, this.state) ||
+      !shallowEqual(nextParams, currentParams) ||
+      !shallowEqual(nextRest, currentRest)
+    );
+  }
 
   clickHandler = (event: React.MouseEvent<HTMLElement>) => {
     const { onClick, router, target } = this.props;

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Curious } from "@curi/react-universal";
 
-import { CuriRouter, Response } from "@curi/router";
+import { CuriRouter } from "@curi/router";
 
 const canNavigate = (event: React.MouseEvent<HTMLElement>) => {
   return (
@@ -27,7 +27,6 @@ export interface LinkProps
 
 export interface BaseLinkProps extends LinkProps {
   router: CuriRouter;
-  response: Response;
   forwardedRef: React.Ref<any> | undefined;
 }
 
@@ -35,7 +34,7 @@ export interface LinkState {
   navigating: boolean;
 }
 
-class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
+class BaseLink extends React.Component<BaseLinkProps, LinkState> {
   removed: boolean;
 
   state = {
@@ -85,7 +84,6 @@ class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
       onClick,
       anchor,
       router,
-      response,
       forwardedRef,
       children,
       ...rest
@@ -95,9 +93,7 @@ class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
       hash,
       query,
       state,
-      pathname: to
-        ? router.route.pathname(to, params)
-        : response.location.pathname
+      pathname: to ? router.route.pathname(to, params) : ""
     });
 
     return (
@@ -122,13 +118,8 @@ class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
 const Link = React.forwardRef(
   (props: LinkProps, ref): React.ReactElement<any> => (
     <Curious>
-      {({ router, response }) => (
-        <BaseLink
-          {...props}
-          router={router}
-          response={response}
-          forwardedRef={ref}
-        />
+      {({ router }) => (
+        <BaseLink {...props} router={router} forwardedRef={ref} />
       )}
     </Curious>
   )

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -64,7 +64,7 @@ describe("<Link>", () => {
       expect(a.getAttribute("href")).toBe("/");
     });
 
-    it("uses the pathname from current response's location if 'to' is not provided", () => {
+    it("creates a relative link if 'to' is undefined", () => {
       const history = InMemory({
         locations: ["/the-initial-location"]
       });
@@ -76,7 +76,7 @@ describe("<Link>", () => {
         node
       );
       const a = node.querySelector("a");
-      expect(a.getAttribute("href")).toBe("/the-initial-location");
+      expect(a.getAttribute("href")).toBe("");
     });
   });
 

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -11,7 +11,11 @@ import { curiProvider, Link } from "@curi/react-dom";
 describe("<Link>", () => {
   let node;
   let history, router, Router;
-  const routes = prepareRoutes([{ name: "Test", path: "" }]);
+  const routes = prepareRoutes([
+    { name: "Test", path: "" },
+    { name: "Best", path: "best" },
+    { name: "Catch All", path: "(.*)" }
+  ]);
 
   beforeEach(() => {
     node = document.createElement("div");
@@ -52,6 +56,54 @@ describe("<Link>", () => {
       expect(a).toBeDefined();
       expect(getComputedStyle(a).color).toBe("orange");
     });
+
+    it("re-renders if the anchor changes", () => {
+      let count = 0;
+      function renderCounter() {
+        return <div>{count++}</div>;
+      }
+      const StyledAnchor = props => (
+        <a style={{ color: "orange" }} {...props} />
+      );
+      ReactDOM.render(
+        <Router>
+          {() => (
+            <Link anchor={StyledAnchor} to="Test">
+              {renderCounter}
+            </Link>
+          )}
+        </Router>,
+        node
+      );
+      const a0 = node.querySelector("a");
+      expect(a0.textContent).toBe("0");
+
+      ReactDOM.render(
+        <Router>
+          {() => (
+            <Link anchor={StyledAnchor} to="Test">
+              {renderCounter}
+            </Link>
+          )}
+        </Router>,
+        node
+      );
+      const a1 = node.querySelector("a");
+      expect(a1.textContent).toBe("0");
+
+      ReactDOM.render(
+        <Router>
+          {() => (
+            <Link anchor="a" to="Test">
+              {renderCounter}
+            </Link>
+          )}
+        </Router>,
+        node
+      );
+      const a2 = node.querySelector("a");
+      expect(a2.textContent).toBe("1");
+    });
   });
 
   describe("to", () => {
@@ -77,6 +129,33 @@ describe("<Link>", () => {
       );
       const a = node.querySelector("a");
       expect(a.getAttribute("href")).toBe("");
+    });
+
+    it("re-renders if to changes", () => {
+      let count = 0;
+      function renderCounter() {
+        return <div>{count++}</div>;
+      }
+      ReactDOM.render(
+        <Router>{() => <Link to="Test">{renderCounter}</Link>}</Router>,
+        node
+      );
+      const a0 = node.querySelector("a");
+      expect(a0.textContent).toBe("0");
+
+      ReactDOM.render(
+        <Router>{() => <Link to="Test">{renderCounter}</Link>}</Router>,
+        node
+      );
+      const a1 = node.querySelector("a");
+      expect(a1.textContent).toBe("0");
+
+      ReactDOM.render(
+        <Router>{() => <Link to="Best">{renderCounter}</Link>}</Router>,
+        node
+      );
+      const a2 = node.querySelector("a");
+      expect(a2.textContent).toBe("1");
     });
   });
 
@@ -137,6 +216,39 @@ describe("<Link>", () => {
       );
       a = node.querySelector("a");
       expect(a.getAttribute("href")).toBe("/park/Yellowstone");
+    });
+
+    it("does not re-render if new params object is shallowly equal to current", () => {
+      let count = 0;
+      function renderCounter() {
+        return <div>{count++}</div>;
+      }
+      ReactDOM.render(
+        <Router>
+          {() => (
+            <Link to="Park" params={{ name: "Yosemite" }}>
+              {renderCounter}
+            </Link>
+          )}
+        </Router>,
+        node
+      );
+      const a0 = node.querySelector("a");
+      expect(a0.textContent).toBe("0");
+
+      // same params, but new object
+      ReactDOM.render(
+        <Router>
+          {() => (
+            <Link to="Park" params={{ name: "Yosemite" }}>
+              {renderCounter}
+            </Link>
+          )}
+        </Router>,
+        node
+      );
+      const a1 = node.querySelector("a");
+      expect(a1.textContent).toBe("0");
     });
   });
 

--- a/packages/react-dom/types/Link.d.ts
+++ b/packages/react-dom/types/Link.d.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { CuriRouter, Response } from "@curi/router";
+import { CuriRouter } from "@curi/router";
 export declare type NavigatingChildren = (navigating: boolean) => React.ReactNode;
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     to?: string;
@@ -13,7 +13,6 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>
 }
 export interface BaseLinkProps extends LinkProps {
     router: CuriRouter;
-    response: Response;
     forwardedRef: React.Ref<any> | undefined;
 }
 export interface LinkState {

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 5295,
-    "minified": 2422,
-    "gzipped": 1077,
+    "bundled": 5291,
+    "minified": 2418,
+    "gzipped": 1074,
     "treeshaked": {
       "rollup": {
-        "code": 2222,
+        "code": 2218,
         "import_statements": 119
       },
       "webpack": {
-        "code": 3305
+        "code": 3301
       }
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 5593,
-    "minified": 2661,
-    "gzipped": 1175
+    "bundled": 5589,
+    "minified": 2657,
+    "gzipped": 1172
   }
 }

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 5291,
-    "minified": 2418,
-    "gzipped": 1074,
+    "bundled": 5689,
+    "minified": 2619,
+    "gzipped": 1136,
     "treeshaked": {
       "rollup": {
-        "code": 2218,
-        "import_statements": 119
+        "code": 2368,
+        "import_statements": 147
       },
       "webpack": {
-        "code": 3301
+        "code": 3494
       }
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 5589,
-    "minified": 2657,
-    "gzipped": 1172
+    "bundled": 6007,
+    "minified": 2873,
+    "gzipped": 1230
   }
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* `<Link>` is no longer a pure component.
 * Add `<Navigation>` component, which lets the user know when asynchronous routes are navigating and cancel the navigation.
 
 ## 1.0.2

--- a/packages/react-native/package-lock.json
+++ b/packages/react-native/package-lock.json
@@ -2768,6 +2768,7 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -2790,7 +2791,8 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -2804,7 +2806,8 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -2821,15 +2824,18 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -2892,7 +2898,8 @@
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -3001,6 +3008,7 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -3042,6 +3050,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -3053,7 +3062,8 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -3241,7 +3251,8 @@
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -3274,6 +3285,7 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -3322,7 +3334,8 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -3342,6 +3355,7 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -3372,6 +3386,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3381,6 +3396,7 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -3405,6 +3421,7 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -3454,7 +3471,8 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -44,7 +44,9 @@
     "@hickory/root": "^1.0.0",
     "@types/invariant": "^2.2.29",
     "@types/react": "^16.3.11",
-    "invariant": "^2.2.2"
+    "@types/shallowequal": "^0.2.3",
+    "invariant": "^2.2.2",
+    "shallowequal": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -3,7 +3,7 @@ import { TouchableHighlight } from "react-native";
 import { Curious } from "@curi/react-universal";
 
 import { GestureResponderEvent } from "react-native";
-import { Emitted, CuriRouter, Response } from "@curi/router";
+import { Emitted, CuriRouter } from "@curi/router";
 import { NavType } from "@hickory/root";
 
 export type NavigatingChildren = (navigating: boolean) => React.ReactNode;
@@ -24,7 +24,6 @@ export interface LinkProps {
 
 export interface BaseLinkProps extends LinkProps {
   router: CuriRouter;
-  response: Response;
   forwardedRef: React.Ref<any> | undefined;
 }
 
@@ -32,7 +31,7 @@ export interface LinkState {
   navigating: boolean;
 }
 
-class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
+class BaseLink extends React.Component<BaseLinkProps, LinkState> {
   removed: boolean;
 
   state = {
@@ -86,7 +85,6 @@ class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
       onPress,
       anchor: Anchor = TouchableHighlight,
       router,
-      response,
       method,
       forwardedRef,
       children,
@@ -109,13 +107,8 @@ class BaseLink extends React.PureComponent<BaseLinkProps, LinkState> {
 
 const Link = React.forwardRef((props: LinkProps, ref) => (
   <Curious>
-    {({ router, response }: Emitted) => (
-      <BaseLink
-        {...props}
-        router={router}
-        response={response}
-        forwardedRef={ref}
-      />
+    {({ router }: Emitted) => (
+      <BaseLink {...props} router={router} forwardedRef={ref} />
     )}
   </Curious>
 ));

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TouchableHighlight } from "react-native";
 import { Curious } from "@curi/react-universal";
+import shallowEqual from "shallowequal";
 
 import { GestureResponderEvent } from "react-native";
 import { Emitted, CuriRouter } from "@curi/router";
@@ -37,6 +38,16 @@ class BaseLink extends React.Component<BaseLinkProps, LinkState> {
   state = {
     navigating: false
   };
+
+  shouldComponentUpdate(nextProps: BaseLinkProps, nextState: LinkState) {
+    const { params: nextParams, ...nextRest } = nextProps;
+    const { params: currentParams, ...currentRest } = this.props;
+    return (
+      !shallowEqual(nextState, this.state) ||
+      !shallowEqual(nextParams, currentParams) ||
+      !shallowEqual(nextRest, currentRest)
+    );
+  }
 
   pressHandler = (event: GestureResponderEvent) => {
     const { onPress, router } = this.props;

--- a/packages/react-native/types/Link.d.ts
+++ b/packages/react-native/types/Link.d.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import { GestureResponderEvent } from "react-native";
-import { CuriRouter, Response } from "@curi/router";
+import { CuriRouter } from "@curi/router";
 import { NavType } from "@hickory/root";
 export declare type NavigatingChildren = (navigating: boolean) => React.ReactNode;
 export interface LinkProps {
@@ -18,7 +18,6 @@ export interface LinkProps {
 }
 export interface BaseLinkProps extends LinkProps {
     router: CuriRouter;
-    response: Response;
     forwardedRef: React.Ref<any> | undefined;
 }
 export interface LinkState {

--- a/website/src/pages/Packages/react-dom.js
+++ b/website/src/pages/Packages/react-dom.js
@@ -597,7 +597,7 @@ const router = curi(history, routes, {
 </Navigating>`}
             </CodeBlock>
             <Section tag="h3" title="Props" id="Navigating-props">
-              <Subsection tag="h4" title="children()" id="Navigating-children">
+              <Section tag="h4" title="children()" id="Navigating-children">
                 <Explanation>
                   <p>
                     A function that returns a React node. The function will be
@@ -610,7 +610,7 @@ const router = curi(history, routes, {
                     is finished has no effect.
                   </p>
                 </Explanation>
-              </Subsection>
+              </Section>
             </Section>
           </Section>
 

--- a/website/src/pages/Packages/react-native.js
+++ b/website/src/pages/Packages/react-native.js
@@ -484,7 +484,7 @@ const router = curi(history, routes, {
 </Navigating>`}
             </CodeBlock>
             <Section tag="h3" title="Props" id="Navigating-props">
-              <Subsection tag="h4" title="children()" id="Navigating-children">
+              <Section tag="h4" title="children()" id="Navigating-children">
                 <Explanation>
                   <p>
                     A function that returns a React node. The function will be
@@ -497,7 +497,7 @@ const router = curi(history, routes, {
                     is finished has no effect.
                   </p>
                 </Explanation>
-              </Subsection>
+              </Section>
             </Section>
           </Section>
 


### PR DESCRIPTION
The first change this makes is that `Link` is no longer a "pure" component (`React.PureComponent`). Instead, a more refined `shouldComponentUpdate` check is used so that re-using params objects does not cause unnecessary re-renders.

The second change is only for `@curi/react-dom`. The generated `href` is now relative (no `pathname`) when the `to` prop is not provided. Previously, the `location.pathname` of the current response was used. The new `href` is functionally equivalent to the old approach, but the `Link` no longer requires knowledge of the current `response`. (The `href` isn't even used when navigating within the application.)

```jsx
<Link hash="#test">Test</Link>
// old
<a href="/current-location#test">Test</a>
// new
<a href="#test">Test</a>
```