### PR TITLE
Remove unnecessary type exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4750,13 +4750,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4773,8 +4771,7 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
@@ -4903,7 +4900,6 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -26,12 +26,12 @@ export interface LinkProps
   children: NavigatingChildren | React.ReactNode;
 }
 
-export interface BaseLinkProps extends LinkProps {
+interface BaseLinkProps extends LinkProps {
   router: CuriRouter;
   forwardedRef: React.Ref<any> | undefined;
 }
 
-export interface LinkState {
+interface LinkState {
   navigating: boolean;
 }
 

--- a/packages/react-dom/types/Link.d.ts
+++ b/packages/react-dom/types/Link.d.ts
@@ -1,5 +1,4 @@
 import React from "react";
-import { CuriRouter } from "@curi/router";
 export declare type NavigatingChildren = (navigating: boolean) => React.ReactNode;
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     to?: string;
@@ -10,13 +9,6 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>
     onClick?: (e: React.MouseEvent<HTMLElement>) => void;
     anchor?: React.ReactType;
     children: NavigatingChildren | React.ReactNode;
-}
-export interface BaseLinkProps extends LinkProps {
-    router: CuriRouter;
-    forwardedRef: React.Ref<any> | undefined;
-}
-export interface LinkState {
-    navigating: boolean;
 }
 declare const Link: React.ComponentType<LinkProps & React.ClassAttributes<{}>>;
 export default Link;

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -23,12 +23,12 @@ export interface LinkProps {
   children: NavigatingChildren | React.ReactNode;
 }
 
-export interface BaseLinkProps extends LinkProps {
+interface BaseLinkProps extends LinkProps {
   router: CuriRouter;
   forwardedRef: React.Ref<any> | undefined;
 }
 
-export interface LinkState {
+interface LinkState {
   navigating: boolean;
 }
 

--- a/packages/react-native/types/Link.d.ts
+++ b/packages/react-native/types/Link.d.ts
@@ -1,6 +1,5 @@
 import React from "react";
 import { GestureResponderEvent } from "react-native";
-import { CuriRouter } from "@curi/router";
 import { NavType } from "@hickory/root";
 export declare type NavigatingChildren = (navigating: boolean) => React.ReactNode;
 export interface LinkProps {
@@ -15,13 +14,6 @@ export interface LinkProps {
     style?: any;
     method?: NavType;
     children: NavigatingChildren | React.ReactNode;
-}
-export interface BaseLinkProps extends LinkProps {
-    router: CuriRouter;
-    forwardedRef: React.Ref<any> | undefined;
-}
-export interface LinkState {
-    navigating: boolean;
 }
 declare const Link: React.ComponentType<LinkProps & React.ClassAttributes<{}>>;
 export default Link;

--- a/packages/react-universal/src/Block.tsx
+++ b/packages/react-universal/src/Block.tsx
@@ -9,7 +9,7 @@ export interface BlockProps {
   confirm: ConfirmationFunction;
 }
 
-export interface BaseBlockProps extends BlockProps {
+interface BaseBlockProps extends BlockProps {
   router: CuriRouter;
 }
 

--- a/packages/react-universal/src/curiProvider.tsx
+++ b/packages/react-universal/src/curiProvider.tsx
@@ -9,11 +9,13 @@ export interface RouterProps {
   children: CuriRenderFn;
 }
 
-export interface RouterState {
+interface RouterState {
   emitted: Emitted;
 }
 
-export default function curiProvider(router: CuriRouter) {
+export default function curiProvider(
+  router: CuriRouter
+): React.ComponentType<RouterProps> {
   return class Router extends React.Component<RouterProps, RouterState> {
     stopResponding: () => void;
     removed: boolean;

--- a/packages/react-universal/types/Block.d.ts
+++ b/packages/react-universal/types/Block.d.ts
@@ -1,12 +1,8 @@
 import React from "react";
 import { ConfirmationFunction } from "@hickory/root";
-import { CuriRouter } from "@curi/router";
 export interface BlockProps {
     active?: boolean;
     confirm: ConfirmationFunction;
-}
-export interface BaseBlockProps extends BlockProps {
-    router: CuriRouter;
 }
 declare const Block: (props: BlockProps) => React.ReactElement<any>;
 export default Block;

--- a/packages/react-universal/types/curiProvider.d.ts
+++ b/packages/react-universal/types/curiProvider.d.ts
@@ -4,36 +4,4 @@ export declare type CuriRenderFn = (props: Emitted) => React.ReactNode;
 export interface RouterProps {
     children: CuriRenderFn;
 }
-export interface RouterState {
-    emitted: Emitted;
-}
-export default function curiProvider(router: CuriRouter): {
-    new (props: RouterProps): {
-        stopResponding: () => void;
-        removed: boolean;
-        componentDidMount(): void;
-        setupRespond(router: CuriRouter): void;
-        componentWillUnmount(): void;
-        render(): JSX.Element;
-        setState<K extends "emitted">(state: RouterState | ((prevState: Readonly<RouterState>, props: Readonly<RouterProps>) => RouterState | Pick<RouterState, K>) | Pick<RouterState, K>, callback?: () => void): void;
-        forceUpdate(callBack?: () => void): void;
-        readonly props: Readonly<{
-            children?: React.ReactNode;
-        }> & Readonly<RouterProps>;
-        state: Readonly<RouterState>;
-        context: any;
-        refs: {
-            [key: string]: React.ReactInstance;
-        };
-        shouldComponentUpdate?(nextProps: Readonly<RouterProps>, nextState: Readonly<RouterState>, nextContext: any): boolean;
-        componentDidCatch?(error: Error, errorInfo: React.ErrorInfo): void;
-        getSnapshotBeforeUpdate?(prevProps: Readonly<RouterProps>, prevState: Readonly<RouterState>): any;
-        componentDidUpdate?(prevProps: Readonly<RouterProps>, prevState: Readonly<RouterState>, snapshot?: any): void;
-        componentWillMount?(): void;
-        UNSAFE_componentWillMount?(): void;
-        componentWillReceiveProps?(nextProps: Readonly<RouterProps>, nextContext: any): void;
-        UNSAFE_componentWillReceiveProps?(nextProps: Readonly<RouterProps>, nextContext: any): void;
-        componentWillUpdate?(nextProps: Readonly<RouterProps>, nextState: Readonly<RouterState>, nextContext: any): void;
-        UNSAFE_componentWillUpdate?(nextProps: Readonly<RouterProps>, nextState: Readonly<RouterState>, nextContext: any): void;
-    };
-};
+export default function curiProvider(router: CuriRouter): React.ComponentType<RouterProps>;


### PR DESCRIPTION
* Don't need to expose private interfaces.
* Set a return type for `curiProvider()`.