### PR TITLE
Support <Link name>, deprecate <Link to>

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 8308,
-    "minified": 3919,
-    "gzipped": 1593,
+    "bundled": 8853,
+    "minified": 4242,
+    "gzipped": 1746,
     "treeshaked": {
       "rollup": {
-        "code": 2401,
+        "code": 2440,
         "import_statements": 97
       },
       "webpack": {
-        "code": 3504
+        "code": 3547
       }
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 8653,
-    "minified": 4199,
-    "gzipped": 1692
+    "bundled": 9198,
+    "minified": 4522,
+    "gzipped": 1842
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 17914,
-    "minified": 7295,
-    "gzipped": 2398
+    "bundled": 18452,
+    "minified": 7549,
+    "gzipped": 2533
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 16916,
-    "minified": 6648,
-    "gzipped": 2077
+    "bundled": 17063,
+    "minified": 6687,
+    "gzipped": 2097
   }
 }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* `<Link>` takes `name` prop, preferable over `to`.
 * Only export public TypeScript types.
 * `<Link>` with no `to` prop outputs anchor with relative `href`.
 * `<Link>` is no longer a pure component.

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -28,10 +28,41 @@ describe("<Link>", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
+  describe("to", () => {
+    it('warns about using "to" instead of "name"', () => {
+      // this test needs to be called first in order to catch the warning
+      const realWarn = console.warn;
+      const fakeWarn = jest.fn();
+      console.warn = fakeWarn;
+
+      ReactDOM.render(
+        <Router>{() => <Link to="Test">Test</Link>}</Router>,
+        node
+      );
+
+      expect(fakeWarn.mock.calls.length).toBe(1);
+      expect(fakeWarn.mock.calls[0][0]).toBe(`Deprecation warning:
+The "to" prop should be replaced with the "name" prop. The "to" prop will be removed in @curi/react-dom v2.
+
+<Link name="Route Name">...</Link>`);
+
+      console.warn = realWarn;
+    });
+
+    it("sets the href attribute using the named route's path", () => {
+      ReactDOM.render(
+        <Router>{() => <Link to="Test">Test</Link>}</Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      expect(a.getAttribute("href")).toBe("/");
+    });
+  });
+
   describe("anchor", () => {
     it("renders an <a> by default", () => {
       ReactDOM.render(
-        <Router>{() => <Link to="Test">Test</Link>}</Router>,
+        <Router>{() => <Link name="Test">Test</Link>}</Router>,
         node
       );
       const a = node.querySelector("a");
@@ -45,7 +76,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link anchor={StyledAnchor} to="Test">
+            <Link anchor={StyledAnchor} name="Test">
               Test
             </Link>
           )}
@@ -68,7 +99,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link anchor={StyledAnchor} to="Test">
+            <Link anchor={StyledAnchor} name="Test">
               {renderCounter}
             </Link>
           )}
@@ -81,7 +112,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link anchor={StyledAnchor} to="Test">
+            <Link anchor={StyledAnchor} name="Test">
               {renderCounter}
             </Link>
           )}
@@ -94,7 +125,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link anchor="a" to="Test">
+            <Link anchor="a" name="Test">
               {renderCounter}
             </Link>
           )}
@@ -106,10 +137,10 @@ describe("<Link>", () => {
     });
   });
 
-  describe("to", () => {
+  describe("name", () => {
     it("sets the href attribute using the named route's path", () => {
       ReactDOM.render(
-        <Router>{() => <Link to="Test">Test</Link>}</Router>,
+        <Router>{() => <Link name="Test">Test</Link>}</Router>,
         node
       );
       const a = node.querySelector("a");
@@ -124,7 +155,7 @@ describe("<Link>", () => {
       const router = curi(history, routes);
       const Router = curiProvider(router);
       ReactDOM.render(
-        <Router>{() => <Link to={null}>Test</Link>}</Router>,
+        <Router>{() => <Link name={null}>Test</Link>}</Router>,
         node
       );
       const a = node.querySelector("a");
@@ -137,21 +168,21 @@ describe("<Link>", () => {
         return <div>{count++}</div>;
       }
       ReactDOM.render(
-        <Router>{() => <Link to="Test">{renderCounter}</Link>}</Router>,
+        <Router>{() => <Link name="Test">{renderCounter}</Link>}</Router>,
         node
       );
       const a0 = node.querySelector("a");
       expect(a0.textContent).toBe("0");
 
       ReactDOM.render(
-        <Router>{() => <Link to="Test">{renderCounter}</Link>}</Router>,
+        <Router>{() => <Link name="Test">{renderCounter}</Link>}</Router>,
         node
       );
       const a1 = node.querySelector("a");
       expect(a1.textContent).toBe("0");
 
       ReactDOM.render(
-        <Router>{() => <Link to="Best">{renderCounter}</Link>}</Router>,
+        <Router>{() => <Link name="Best">{renderCounter}</Link>}</Router>,
         node
       );
       const a2 = node.querySelector("a");
@@ -177,7 +208,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link to="Park" params={params}>
+            <Link name="Park" params={params}>
               Test
             </Link>
           )}
@@ -193,7 +224,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link to="Park" params={params}>
+            <Link name="Park" params={params}>
               Test
             </Link>
           )}
@@ -207,7 +238,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link to="Park" params={newParams}>
+            <Link name="Park" params={newParams}>
               Test
             </Link>
           )}
@@ -226,7 +257,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link to="Park" params={{ name: "Yosemite" }}>
+            <Link name="Park" params={{ name: "Yosemite" }}>
               {renderCounter}
             </Link>
           )}
@@ -240,7 +271,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link to="Park" params={{ name: "Yosemite" }}>
+            <Link name="Park" params={{ name: "Yosemite" }}>
               {renderCounter}
             </Link>
           )}
@@ -264,7 +295,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link to="Test" query="one=two" hash="hashtag">
+            <Link name="Test" query="one=two" hash="hashtag">
               Test
             </Link>
           )}
@@ -289,7 +320,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link to="Test" ref={ref}>
+            <Link name="Test" ref={ref}>
               Test
             </Link>
           )}
@@ -313,7 +344,7 @@ describe("<Link>", () => {
         const Router = curiProvider(router);
         const children = "Test Value";
         ReactDOM.render(
-          <Router>{() => <Link to="Test">{children}</Link>}</Router>,
+          <Router>{() => <Link name="Test">{children}</Link>}</Router>,
           node
         );
         const a = node.querySelector("a");
@@ -333,7 +364,7 @@ describe("<Link>", () => {
         ReactDOM.render(
           <Router>
             {() => (
-              <Link to="Test">
+              <Link name="Test">
                 {navigating => {
                   expect(navigating).toBe(false);
                   return null;
@@ -360,7 +391,7 @@ describe("<Link>", () => {
       const router = curi(history, routes);
       const Router = curiProvider(router);
       ReactDOM.render(
-        <Router>{() => <Link to="Test">Test</Link>}</Router>,
+        <Router>{() => <Link name="Test">Test</Link>}</Router>,
         node
       );
       const a = node.querySelector("a");
@@ -407,7 +438,7 @@ describe("<Link>", () => {
         ReactDOM.render(
           <Router>
             {() => (
-              <Link to="Test">
+              <Link name="Test">
                 {navigating => {
                   return <div>{navigating.toString()}</div>;
                 }}
@@ -464,12 +495,12 @@ describe("<Link>", () => {
           <Router>
             {() => (
               <React.Fragment>
-                <Link to="Slow">
+                <Link name="Slow">
                   {navigating => {
                     return <div>Slow {navigating.toString()}</div>;
                   }}
                 </Link>
-                <Link to="Fast">
+                <Link name="Fast">
                   {navigating => {
                     return <div>Fast {navigating.toString()}</div>;
                   }}
@@ -518,7 +549,7 @@ describe("<Link>", () => {
         ReactDOM.render(
           <Router>
             {() => (
-              <Link to="Loader">
+              <Link name="Loader">
                 {navigating => {
                   return <div>{navigating.toString()}</div>;
                 }}
@@ -586,7 +617,7 @@ describe("<Link>", () => {
         ReactDOM.render(
           <Router>
             {() => (
-              <Link to="Slow">
+              <Link name="Slow">
                 {navigating => {
                   return <div>{navigating.toString()}</div>;
                 }}
@@ -629,7 +660,7 @@ describe("<Link>", () => {
       ReactDOM.render(
         <Router>
           {() => (
-            <Link to="Test" hash="thing" query="one=1" state="yo">
+            <Link name="Test" hash="thing" query="one=1" state="yo">
               Test
             </Link>
           )}
@@ -674,7 +705,7 @@ describe("<Link>", () => {
         ReactDOM.render(
           <Router>
             {() => (
-              <Link to="Test" onClick={onClick}>
+              <Link name="Test" onClick={onClick}>
                 Test
               </Link>
             )}
@@ -715,7 +746,7 @@ describe("<Link>", () => {
         ReactDOM.render(
           <Router>
             {() => (
-              <Link to="Test" onClick={onClick}>
+              <Link name="Test" onClick={onClick}>
                 Test
               </Link>
             )}
@@ -753,7 +784,7 @@ describe("<Link>", () => {
       const Router = curiProvider(router);
 
       ReactDOM.render(
-        <Router>{() => <Link to="Test">Test</Link>}</Router>,
+        <Router>{() => <Link name="Test">Test</Link>}</Router>,
         node
       );
       const a = node.querySelector("a");
@@ -790,7 +821,7 @@ describe("<Link>", () => {
       const Router = curiProvider(router);
 
       ReactDOM.render(
-        <Router>{() => <Link to="Test">Test</Link>}</Router>,
+        <Router>{() => <Link name="Test">Test</Link>}</Router>,
         node
       );
       const a = node.querySelector("a");

--- a/packages/react-dom/types/Link.d.ts
+++ b/packages/react-dom/types/Link.d.ts
@@ -2,6 +2,7 @@ import React from "react";
 export declare type NavigatingChildren = (navigating: boolean) => React.ReactNode;
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     to?: string;
+    name?: string;
     params?: object;
     hash?: string;
     query?: any;

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 5689,
-    "minified": 2619,
-    "gzipped": 1136,
+    "bundled": 6133,
+    "minified": 2923,
+    "gzipped": 1306,
     "treeshaked": {
       "rollup": {
-        "code": 2368,
+        "code": 2391,
         "import_statements": 147
       },
       "webpack": {
-        "code": 3494
+        "code": 3517
       }
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 6007,
-    "minified": 2873,
-    "gzipped": 1230
+    "bundled": 6451,
+    "minified": 3177,
+    "gzipped": 1402
   }
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* `<Link>` takes `name` prop, preferable over `to`.
 * Only export public TypeScript types.
 * `<Link>` is no longer a pure component.
 * Add `<Navigation>` component, which lets the user know when asynchronous routes are navigating and cancel the navigation.

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -11,6 +11,7 @@ export type NavigatingChildren = (navigating: boolean) => React.ReactNode;
 
 export interface LinkProps {
   to?: string;
+  name?: string;
   params?: object;
   hash?: string;
   query?: any;
@@ -31,6 +32,8 @@ interface BaseLinkProps extends LinkProps {
 interface LinkState {
   navigating: boolean;
 }
+
+let hasWarnedTo = false;
 
 class BaseLink extends React.Component<BaseLinkProps, LinkState> {
   removed: boolean;
@@ -57,7 +60,8 @@ class BaseLink extends React.Component<BaseLinkProps, LinkState> {
 
     if (!event.defaultPrevented) {
       event.preventDefault();
-      const { to: name, params, hash, query, state, children } = this.props;
+      const { to, name, params, hash, query, state, children } = this.props;
+      const routeName = name || to;
       let { method = "ANCHOR" } = this.props;
       if (method !== "ANCHOR" && method !== "PUSH" && method !== "REPLACE") {
         method = "ANCHOR";
@@ -89,6 +93,7 @@ class BaseLink extends React.Component<BaseLinkProps, LinkState> {
   render(): React.ReactElement<any> {
     const {
       to,
+      name,
       params,
       hash,
       query,
@@ -101,7 +106,16 @@ class BaseLink extends React.Component<BaseLinkProps, LinkState> {
       children,
       ...rest
     } = this.props;
+    if (process.env.NODE_ENV !== "production") {
+      if (!hasWarnedTo && to !== undefined) {
+        hasWarnedTo = true;
+        console.warn(`Deprecation warning:
+The "to" prop should be replaced with the "name" prop. The "to" prop will be removed in @curi/react-dom v2.
 
+<Link name="Route Name">...</Link>`);
+      }
+    }
+    const routeName = name || to;
     return (
       <Anchor {...rest} onPress={this.pressHandler} ref={forwardedRef}>
         {typeof children === "function"

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -23,6 +23,67 @@ function fakeEvent(props = {}) {
 }
 
 describe("<Link>", () => {
+  describe("to", () => {
+    it('warns when using "to" instead of "name"', () => {
+      // this test needs to be called first in order to catch the warning
+      const realWarn = console.warn;
+      const fakeWarn = jest.fn();
+      console.warn = fakeWarn;
+
+      const history = InMemory();
+      const routes = prepareRoutes([
+        { name: "Test", path: "" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      const tree = renderer.create(
+        <Router>
+          {() => (
+            <Link to="Test">
+              <Text>Test</Text>
+            </Link>
+          )}
+        </Router>
+      );
+
+      expect(fakeWarn.mock.calls.length).toBe(1);
+      expect(fakeWarn.mock.calls[0][0]).toBe(`Deprecation warning:
+The "to" prop should be replaced with the "name" prop. The "to" prop will be removed in @curi/react-dom v2.
+
+<Link name="Route Name">...</Link>`);
+
+      console.warn = realWarn;
+    });
+
+    it('works the same as "name"', () => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+      const routes = prepareRoutes([
+        { name: "Test", path: "" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      const tree = renderer.create(
+        <Router>
+          {() => (
+            <Link to="Test">
+              <Text>Test</Text>
+            </Link>
+          )}
+        </Router>
+      );
+
+      const anchor = tree.root.findByType(TouchableHighlight);
+      anchor.props.onPress(fakeEvent());
+      expect(mockNavigate.mock.calls[0][0].pathname).toBe("/");
+    });
+  });
+
   describe("anchor", () => {
     it("renders a <TouchableHighlight> by default", () => {
       const history = InMemory();
@@ -35,7 +96,7 @@ describe("<Link>", () => {
       const tree = renderer.create(
         <Router>
           {() => (
-            <Link to="Test">
+            <Link name="Test">
               <Text>Test</Text>
             </Link>
           )}
@@ -61,7 +122,7 @@ describe("<Link>", () => {
       const tree = renderer.create(
         <Router>
           {() => (
-            <Link to="Test" anchor={StyledAnchor}>
+            <Link name="Test" anchor={StyledAnchor}>
               <Text>Test</Text>
             </Link>
           )}
@@ -72,8 +133,8 @@ describe("<Link>", () => {
     });
   });
 
-  describe("to", () => {
-    it("uses the pathname from current response's location if 'to' is not provided", () => {
+  describe("name", () => {
+    it("uses the pathname from current response's location if 'name' is not provided", () => {
       const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
       history.navigate = mockNavigate;
@@ -84,7 +145,7 @@ describe("<Link>", () => {
       const tree = renderer.create(
         <Router>
           {() => (
-            <Link to={null}>
+            <Link name={null}>
               <Text>Test</Text>
             </Link>
           )}
@@ -116,7 +177,7 @@ describe("<Link>", () => {
       const tree = renderer.create(
         <Router>
           {() => (
-            <Link to="Park" params={params}>
+            <Link name="Park" params={params}>
               <Text>Test</Text>
             </Link>
           )}
@@ -139,7 +200,7 @@ describe("<Link>", () => {
       const tree = renderer.create(
         <Router>
           {() => (
-            <Link to="Park" params={params}>
+            <Link name="Park" params={params}>
               <Text>Test</Text>
             </Link>
           )}
@@ -153,7 +214,7 @@ describe("<Link>", () => {
       tree.update(
         <Router>
           {() => (
-            <Link to="Park" params={newParams}>
+            <Link name="Park" params={newParams}>
               <Text>Test</Text>
             </Link>
           )}
@@ -180,7 +241,7 @@ describe("<Link>", () => {
       const tree = renderer.create(
         <Router>
           {() => (
-            <Link to="Parks" ref={ref}>
+            <Link name="Parks" ref={ref}>
               <Text>Test</Text>
             </Link>
           )}
@@ -206,7 +267,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test">
+              <Link name="Test">
                 <Text>{children}</Text>
               </Link>
             )}
@@ -232,7 +293,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test">
+              <Link name="Test">
                 {navigating => {
                   expect(navigating).toBe(false);
                   return <Text>Test</Text>;
@@ -265,7 +326,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test">
+              <Link name="Test">
                 <Text>Test</Text>
               </Link>
             )}
@@ -287,7 +348,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test" method="ANCHOR">
+              <Link name="Test" method="ANCHOR">
                 <Text>Test</Text>
               </Link>
             )}
@@ -309,7 +370,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test" method="PUSH">
+              <Link name="Test" method="PUSH">
                 <Text>Test</Text>
               </Link>
             )}
@@ -331,7 +392,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test" method="REPLACE">
+              <Link name="Test" method="REPLACE">
                 <Text>Test</Text>
               </Link>
             )}
@@ -353,7 +414,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test" method={"whatchamacallit" as NavType}>
+              <Link name="Test" method={"whatchamacallit" as NavType}>
                 <Text>Test</Text>
               </Link>
             )}
@@ -393,7 +454,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test">
+              <Link name="Test">
                 {navigating => {
                   return <Text>{navigating.toString()}</Text>;
                 }}
@@ -441,12 +502,12 @@ describe("<Link>", () => {
           <Router>
             {() => (
               <React.Fragment>
-                <Link to="Slow">
+                <Link name="Slow">
                   {navigating => {
                     return <Text>{`Slow ${navigating.toString()}`}</Text>;
                   }}
                 </Link>
-                <Link to="Fast">
+                <Link name="Fast">
                   {navigating => {
                     return <Text>{`Fast ${navigating.toString()}`}</Text>;
                   }}
@@ -489,7 +550,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Loader">
+              <Link name="Loader">
                 {navigating => {
                   return <Text>{navigating.toString()}</Text>;
                 }}
@@ -549,7 +610,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Blork">
+              <Link name="Blork">
                 {navigating => {
                   return <Text>{navigating.toString()}</Text>;
                 }}
@@ -580,7 +641,7 @@ describe("<Link>", () => {
       const tree = renderer.create(
         <Router>
           {() => (
-            <Link to="Test" hash="thing" query="one=1" state="yo">
+            <Link name="Test" hash="thing" query="one=1" state="yo">
               <Text>Test</Text>
             </Link>
           )}
@@ -614,7 +675,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test" onPress={onPress}>
+              <Link name="Test" onPress={onPress}>
                 <Text>Test</Text>
               </Link>
             )}
@@ -645,7 +706,7 @@ describe("<Link>", () => {
         const tree = renderer.create(
           <Router>
             {() => (
-              <Link to="Test" onPress={onPress}>
+              <Link name="Test" onPress={onPress}>
                 <Text>Test</Text>
               </Link>
             )}
@@ -673,7 +734,7 @@ describe("<Link>", () => {
       const tree = renderer.create(
         <Router>
           {() => (
-            <Link to="Test">
+            <Link name="Test">
               <Text>Test</Text>
             </Link>
           )}

--- a/packages/react-native/types/Link.d.ts
+++ b/packages/react-native/types/Link.d.ts
@@ -4,6 +4,7 @@ import { NavType } from "@hickory/root";
 export declare type NavigatingChildren = (navigating: boolean) => React.ReactNode;
 export interface LinkProps {
     to?: string;
+    name?: string;
     params?: object;
     hash?: string;
     query?: any;


### PR DESCRIPTION
`to` has always been an alias for a route's `name`. `<Link to>` was used because it was  familiar (e.g. used in React Router),  but it was the only place that the `to` alias was used (`<Active>` uses a route's `name`)

A new `name` prop is added to the `Link` components to specify the name of the route to link to. This applies to both the `@curi/react-dom` and `@curi/react-native` packages.

`to` will continue to be supported in `@curi/react-dom` and `@curi/react-native` v1, but will be removed in v2. If you use `<Link to>` in v1, a warning will show up in the console letting you know to switch to the `name` prop.

```jsx
// deprecated in v1, will be removed in v2
<Link to="Greeting">Hi!</Link>

// v1/v2
<Link name="Greeting">Hi!</Link>
```