### PR TITLE
(svelte) Pass wrapper to Link for use while navigating

### DIFF
--- a/packages/svelte/src/Link.html
+++ b/packages/svelte/src/Link.html
@@ -1,5 +1,11 @@
-<a href="{href}" on:click="handleClick(event, location, $router)">
-	<slot></slot>
+<a href="{href}" on:click="handleClick(event)">
+	{#if wrapper}
+		<svelte:component this={wrapper} navigating={navigating}>
+			<slot></slot>
+		</svelte:component>
+	{:else}
+		<slot></slot>
+	{/if}
 </a>
 
 <script>
@@ -18,7 +24,8 @@
 				params: {},
 				hash: '',
 				query: '',
-				state: null
+				state: null,
+				navigating: false
 			};
 		},
 		computed: {
@@ -37,8 +44,16 @@
 		methods: {
 			handleClick(event, location, $router) {
 				if (canNavigate(event)) {
+					const { $router, name, params, hash, query, state, wrapper } = this.get();
 					event.preventDefault();
-					$router.history.navigate(location);
+					let cancelled, finished;
+					if (wrapper) {
+						cancelled = finished = () => {
+							this.set({ navigating: false });
+						}
+						this.set({ navigating: true });
+					}
+					$router.navigate({ name, params, hash, query, state, cancelled, finished });
 				}
 			}
 		}

--- a/packages/svelte/tests/cases/link/basic-pathname/app.html
+++ b/packages/svelte/tests/cases/link/basic-pathname/app.html
@@ -1,0 +1,9 @@
+<Link name="Home">Home</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/basic-pathname/index.js
+++ b/packages/svelte/tests/cases/link/basic-pathname/index.js
@@ -1,0 +1,24 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+  expect(a).not.toBeUndefined();
+  expect(a.getAttribute("href")).toEqual("/");
+}

--- a/packages/svelte/tests/cases/link/click/app.html
+++ b/packages/svelte/tests/cases/link/click/app.html
@@ -1,0 +1,9 @@
+<Link name="User" params={{ id: "1" }}>User 1</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/click/index.js
+++ b/packages/svelte/tests/cases/link/click/index.js
@@ -1,0 +1,27 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+import simulant from "simulant";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  history.navigate = jest.fn();
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+  const event = simulant("click");
+  simulant.fire(a, event);
+  expect(history.navigate.mock.calls.length).toBe(1);
+}

--- a/packages/svelte/tests/cases/link/mod-click/app.html
+++ b/packages/svelte/tests/cases/link/mod-click/app.html
@@ -1,0 +1,9 @@
+<Link name="User" params={{ id: "1" }}>User 1</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/mod-click/index.js
+++ b/packages/svelte/tests/cases/link/mod-click/index.js
@@ -1,0 +1,30 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+import simulant from "simulant";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  history.navigate = jest.fn();
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+
+  const modifiers = ["metaKey", "altKey", "ctrlKey", "shiftKey"];
+  modifiers.forEach(m => {
+    simulant.fire(a, "click", { [m]: true });
+    expect(history.navigate.mock.calls.length).toBe(0);
+  });
+}

--- a/packages/svelte/tests/cases/link/not-left-click/app.html
+++ b/packages/svelte/tests/cases/link/not-left-click/app.html
@@ -1,0 +1,9 @@
+<Link name="User" params={{ id: "1" }}>User 1</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/not-left-click/index.js
+++ b/packages/svelte/tests/cases/link/not-left-click/index.js
@@ -1,0 +1,27 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+import simulant from "simulant";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  history.navigate = jest.fn();
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+  const event = simulant("click", { button: 1 });
+  simulant.fire(a, event);
+  expect(history.navigate.mock.calls.length).toBe(0);
+}

--- a/packages/svelte/tests/cases/link/pathname-params/app.html
+++ b/packages/svelte/tests/cases/link/pathname-params/app.html
@@ -1,0 +1,9 @@
+<Link name="User" params={{ id: "1" }}>User 1</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/pathname-params/index.js
+++ b/packages/svelte/tests/cases/link/pathname-params/index.js
@@ -1,0 +1,22 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  new app({ target, store });
+  const a = target.querySelector("a");
+  expect(a.getAttribute("href")).toEqual("/u/1");
+}

--- a/packages/svelte/tests/cases/link/prevent-click/app.html
+++ b/packages/svelte/tests/cases/link/prevent-click/app.html
@@ -1,0 +1,9 @@
+<Link name="User" params={{ id: "1" }}>User 1</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/prevent-click/index.js
+++ b/packages/svelte/tests/cases/link/prevent-click/index.js
@@ -1,0 +1,28 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+import simulant from "simulant";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  history.navigate = jest.fn();
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+  const event = simulant("click");
+  event.preventDefault();
+  simulant.fire(a, event);
+  expect(history.navigate.mock.calls.length).toBe(0);
+}

--- a/packages/svelte/tests/cases/link/query-hash/app.html
+++ b/packages/svelte/tests/cases/link/query-hash/app.html
@@ -1,0 +1,9 @@
+<Link name="Home" query="one=two" hash="test">Home</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/query-hash/index.js
+++ b/packages/svelte/tests/cases/link/query-hash/index.js
@@ -1,0 +1,22 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  new app({ target, store });
+  const a = target.querySelector("a");
+  expect(a.getAttribute("href")).toEqual("/?one=two#test");
+}

--- a/packages/svelte/tests/cases/link/relative/app.html
+++ b/packages/svelte/tests/cases/link/relative/app.html
@@ -1,0 +1,9 @@
+<Link hash="is-a-band">Home</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/relative/index.js
+++ b/packages/svelte/tests/cases/link/relative/index.js
@@ -1,0 +1,22 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory({ locations: ["/u/2"] });
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  new app({ target, store });
+  const a = target.querySelector("a");
+  expect(a.getAttribute("href")).toBe("#is-a-band");
+}

--- a/packages/svelte/tests/cases/link/wrapper-navigating/app.html
+++ b/packages/svelte/tests/cases/link/wrapper-navigating/app.html
@@ -1,0 +1,13 @@
+<Link name="Home" wrapper={Wrapper}>Home</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+  import Wrapper from "./wrapper.html";
+
+  export default {
+    components: { Link },
+    data() {
+      return { Wrapper };
+    }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/wrapper-navigating/index.js
+++ b/packages/svelte/tests/cases/link/wrapper-navigating/index.js
@@ -1,0 +1,24 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+
+import app from "./app.html";
+import cleanText from "../../../utils/cleanText";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+  expect(cleanText(a.textContent)).toBe("false Home");
+}

--- a/packages/svelte/tests/cases/link/wrapper-navigating/wrapper.html
+++ b/packages/svelte/tests/cases/link/wrapper-navigating/wrapper.html
@@ -1,0 +1,2 @@
+<span>{navigating}</span>
+<slot></slot>

--- a/packages/svelte/tests/cases/link/wrapper-while-navigating/app.html
+++ b/packages/svelte/tests/cases/link/wrapper-while-navigating/app.html
@@ -1,0 +1,13 @@
+<Link name="Test" wrapper={Wrapper}>Test</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+  import Wrapper from "./wrapper.html";
+
+  export default {
+    components: { Link },
+    data() {
+      return { Wrapper };
+    }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/wrapper-while-navigating/index.js
+++ b/packages/svelte/tests/cases/link/wrapper-while-navigating/index.js
@@ -1,0 +1,49 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+
+import app from "./app.html";
+import cleanText from "../../../utils/cleanText";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  {
+    name: "Test",
+    path: "test",
+    resolve: {
+      test: () => {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            resolve("done");
+          }, 100);
+        });
+      }
+    }
+  },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render(done) {
+  const target = document.createElement("div");
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+  expect(cleanText(a.textContent)).toBe("false Test");
+
+  a.click();
+
+  expect(cleanText(a.textContent)).toBe("true Test");
+
+  router.once(
+    ({ response }) => {
+      expect(response.name).toBe("Test");
+      expect(cleanText(a.textContent)).toBe("false Test");
+      done();
+    },
+    { initial: false }
+  );
+}

--- a/packages/svelte/tests/cases/link/wrapper-while-navigating/wrapper.html
+++ b/packages/svelte/tests/cases/link/wrapper-while-navigating/wrapper.html
@@ -1,0 +1,2 @@
+<span>{navigating}</span>
+<slot></slot>

--- a/packages/svelte/tests/cases/link/wrapper/app.html
+++ b/packages/svelte/tests/cases/link/wrapper/app.html
@@ -1,0 +1,13 @@
+<Link name="Home" wrapper={Wrapper}>Home</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+  import Wrapper from "./wrapper.html";
+
+  export default {
+    components: { Link },
+    data() {
+      return { Wrapper };
+    }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/wrapper/index.js
+++ b/packages/svelte/tests/cases/link/wrapper/index.js
@@ -1,0 +1,24 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+
+import app from "./app.html";
+import cleanText from "../../../utils/cleanText";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+  expect(cleanText(a.textContent)).toBe("Home includes wrapper");
+}

--- a/packages/svelte/tests/cases/link/wrapper/wrapper.html
+++ b/packages/svelte/tests/cases/link/wrapper/wrapper.html
@@ -1,0 +1,2 @@
+<slot></slot>
+<span>includes wrapper</span>

--- a/packages/svelte/tests/link.spec.js
+++ b/packages/svelte/tests/link.spec.js
@@ -1,185 +1,55 @@
-import InMemory from "@hickory/in-memory";
-import { curi, prepareRoutes } from "@curi/router";
-import simulant from "simulant";
-import { curiStore } from "@curi/svelte";
-
-import Link from "../src/Link.html";
+function test(file, done) {
+  require(file).default(done);
+}
 
 describe("<Link>", () => {
-  const routes = prepareRoutes([
-    { name: "Home", path: "" },
-    { name: "User", path: "u/:id" },
-    { name: "Not Found", path: "(.*)" }
-  ]);
-
-  it("renders an anchor with expected pathname", () => {
-    const history = InMemory();
-
-    const router = curi(history, routes);
-    const store = curiStore(router);
-
-    const node = document.createElement("div");
-    const link = new Link({
-      target: node,
-      store,
-      data: {
-        name: "Home"
-      }
+  describe("href", () => {
+    it("renders an anchor with expected pathname", () => {
+      test("./cases/link/basic-pathname");
     });
 
-    const a = node.querySelector("a");
-    expect(a).not.toBeUndefined();
-    expect(a.getAttribute("href")).toEqual("/");
+    it("uses params attribute to generate pathname", () => {
+      test("./cases/link/pathname-params");
+    });
+
+    it('uses relative href if "name" isn\'t provided', () => {
+      test("./cases/link/relative");
+    });
+
+    it("appends query & hash to end of URI", () => {
+      test("./cases/link/query-hash");
+    });
   });
 
-  it("uses params attribute to generate pathname", () => {
-    const history = InMemory();
-    const router = curi(history, routes);
-    const store = curiStore(router);
-
-    const node = document.createElement("div");
-    const link = new Link({
-      target: node,
-      store,
-      data: {
-        name: "User",
-        params: { id: "1" }
-      }
+  describe("wrapper prop", () => {
+    it("renders the wrapper when provided", () => {
+      test("./cases/link/wrapper");
     });
 
-    const a = node.querySelector("a");
-    expect(a.getAttribute("href")).toEqual("/u/1");
-  });
-
-  it('uses relative href if "name" isn\'t provided', () => {
-    const history = InMemory({ locations: ["/u/2"] });
-    const router = curi(history, routes);
-    const store = curiStore(router);
-
-    const node = document.createElement("div");
-    const link = new Link({
-      target: node,
-      store,
-      data: {
-        hash: "is-a-band"
-      }
+    it("passes navigating=false to wrapper by default", () => {
+      test("./cases/link/wrapper-navigating");
     });
 
-    const a = node.querySelector("a");
-    expect(a.getAttribute("href")).toBe("#is-a-band");
-  });
-
-  it("appends query & hash to end of URI", () => {
-    const history = InMemory();
-    const router = curi(history, routes);
-    const store = curiStore(router);
-
-    const node = document.createElement("div");
-    const link = new Link({
-      target: node,
-      store,
-      data: {
-        name: "Home",
-        hash: "test",
-        query: "one=two"
-      }
+    it("passes navigating=true to wrapper while navigating", done => {
+      test("./cases/link/wrapper-while-navigating", done);
     });
-
-    const a = node.querySelector("a");
-    expect(a.getAttribute("href")).toEqual("/?one=two#test");
   });
 
   describe("clicking a <Link>", () => {
     it("will navigate to the new location", () => {
-      const history = InMemory();
-      history.navigate = jest.fn();
-      const router = curi(history, routes);
-      const store = curiStore(router);
-
-      const node = document.createElement("div");
-      const link = new Link({
-        target: node,
-        store,
-        data: {
-          name: "User",
-          params: { id: 1 }
-        }
-      });
-
-      const a = node.querySelector("a");
-      const event = simulant("click");
-      simulant.fire(a, event);
-      expect(history.navigate.mock.calls.length).toBe(1);
+      test("./cases/link/click");
     });
 
     it("will ignore modified clicks", () => {
-      const history = InMemory();
-      history.navigate = jest.fn();
-      const router = curi(history, routes);
-      const store = curiStore(router);
-
-      const node = document.createElement("div");
-      const link = new Link({
-        target: node,
-        store,
-        data: {
-          name: "User",
-          params: { id: 2 }
-        }
-      });
-
-      const a = node.querySelector("a");
-
-      const modifiers = ["metaKey", "altKey", "ctrlKey", "shiftKey"];
-      modifiers.forEach(m => {
-        simulant.fire(a, "click", { [m]: true });
-        expect(history.navigate.mock.calls.length).toBe(0);
-      });
+      test("./cases/link/mod-click");
     });
 
     it("will ignore click if event.defaultPrevented is true", () => {
-      const history = InMemory();
-      history.navigate = jest.fn();
-      const router = curi(history, routes);
-      const store = curiStore(router);
-
-      const node = document.createElement("div");
-      const link = new Link({
-        target: node,
-        store,
-        data: {
-          name: "User",
-          params: { id: 3 }
-        }
-      });
-
-      const a = node.querySelector("a");
-      const event = simulant("click");
-      event.preventDefault();
-      simulant.fire(a, event);
-      expect(history.navigate.mock.calls.length).toBe(0);
+      test("./cases/link/prevent-click");
     });
 
     it("will ignore click if not done with left mouse button", () => {
-      const history = InMemory();
-      history.navigate = jest.fn();
-      const router = curi(history, routes);
-      const store = curiStore(router);
-
-      const node = document.createElement("div");
-      const link = new Link({
-        target: node,
-        store,
-        data: {
-          name: "User",
-          params: { id: 3 }
-        }
-      });
-
-      const a = node.querySelector("a");
-      const event = simulant("click", { button: 1 });
-      simulant.fire(a, event);
-      expect(history.navigate.mock.calls.length).toBe(0);
+      test("./cases/link/not-left-click");
     });
   });
 });

--- a/packages/svelte/tests/utils/cleanText.js
+++ b/packages/svelte/tests/utils/cleanText.js
@@ -1,0 +1,3 @@
+export default function cleanText(text) {
+  return text.trim().replace(/\s+/, " ");
+}


### PR DESCRIPTION
If the `<Link>` is given a `wrapper` prop, it will render that as the direct child of the anchor and pass its slots to the `wrapper` component. The `wrapper` will also be given a `navigating` boolean prop, which is `false` by default, but `true` after the user clicks the link (until the new response is ready).

```html
<!-- SpinWhileNavigating.html -->
<slots></slots>
{#if navigating }
<Spinner />
{/if}

<script>
  import Spinner from "./Spinner.html";
  export default {
    components: { Spinner }
</script>
```

```html
<!-- NavLinks.html -->
<Link
  name="User"
  params={{ id: 1 }}
  wrapper={SpinWhileNavigating}
>
  User 1
</Link>

<script>
  import SpinWhileNavigating from "./SpinWhileNavigating.html";
  // note that SpinWhileNavigating is provided through data, not components
  export default {
    data: { SpinWhileNavigating }
  };
</script>
```