### PR TITLE
Svelte <Link forward> passes props to <a>

### DIFF
--- a/packages/svelte/src/Link.html
+++ b/packages/svelte/src/Link.html
@@ -1,4 +1,4 @@
-<a href="{href}" on:click="handleClick(event)">
+<a href="{href}" on:click="handleClick(event)" {...forward}>
 	{#if wrapper}
 		<svelte:component this={wrapper} navigating={navigating}>
 			<slot></slot>

--- a/packages/svelte/tests/cases/link/forward-props/app.html
+++ b/packages/svelte/tests/cases/link/forward-props/app.html
@@ -1,0 +1,9 @@
+<Link name="Home" forward={{ class: "test", target: "_blank" }}>Home</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link }
+  }  
+</script>

--- a/packages/svelte/tests/cases/link/forward-props/index.js
+++ b/packages/svelte/tests/cases/link/forward-props/index.js
@@ -1,0 +1,24 @@
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const history = InMemory();
+const router = curi(history, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+  expect(a.classList.contains("test")).toBe(true);
+  expect(a.getAttribute("target")).toBe("_blank");
+}

--- a/packages/svelte/tests/link.spec.js
+++ b/packages/svelte/tests/link.spec.js
@@ -21,6 +21,12 @@ describe("<Link>", () => {
     });
   });
 
+  describe("forward prop", () => {
+    it('forwards "forward" properties to the anchor', () => {
+      test("./cases/link/forward-props");
+    });
+  });
+
   describe("wrapper prop", () => {
     it("renders the wrapper when provided", () => {
       test("./cases/link/wrapper");


### PR DESCRIPTION
Any properties of the `forward` object will be passed to the rendered anchor. This is the same API as the React packages. 

```html
<Link name="Home" forward={{ class: "active" }}>Home</Link>
<!-- renders -->
<a href="/" class="active">Home</a>
```