### PR TITLE
Generate 404 page with @curi/static

### DIFF
--- a/packages/static/.size-snapshot.json
+++ b/packages/static/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/curi-static.js": {
-    "bundled": 7730,
-    "minified": 3137,
-    "gzipped": 1462
+    "bundled": 8398,
+    "minified": 3340,
+    "gzipped": 1526
   }
 }

--- a/packages/static/.size-snapshot.json
+++ b/packages/static/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/curi-static.js": {
-    "bundled": 8398,
-    "minified": 3340,
-    "gzipped": 1526
+    "bundled": 8366,
+    "minified": 3327,
+    "gzipped": 1528
   }
 }

--- a/packages/static/src/staticFiles.ts
+++ b/packages/static/src/staticFiles.ts
@@ -36,11 +36,11 @@ export default async function staticFiles(
 
   // if there is a catch all page to be generated,
   // add it to the input/output array
-  if (config.catchAll) {
-    const { pathname, filename } = config.catchAll;
+  if (config.fallback) {
+    const { pathname, filename } = config.fallback;
     inputOutput.push({
       pathname,
-      outputPath: join(dir, filename, "index.html")
+      outputPath: join(dir, filename)
     });
   }
 

--- a/packages/static/src/types.ts
+++ b/packages/static/src/types.ts
@@ -5,7 +5,7 @@ export interface PageDescriptor {
   params?: Params;
 }
 
-export interface CatchAllDescriptor {
+export interface FallbackDescriptor {
   filename: string;
   pathname: string;
 }
@@ -26,7 +26,7 @@ export interface StaticRouter {
 
 export interface StaticConfiguration {
   pages: Array<PageDescriptor>;
-  catchAll?: CatchAllDescriptor;
+  fallback?: FallbackDescriptor;
   router: StaticRouter;
   output: StaticOutput;
 }

--- a/packages/static/src/types.ts
+++ b/packages/static/src/types.ts
@@ -5,6 +5,11 @@ export interface PageDescriptor {
   params?: Params;
 }
 
+export interface CatchAllDescriptor {
+  filename: string;
+  pathname: string;
+}
+
 export type GetRouterOptions = () => RouterOptions;
 
 export interface StaticOutput {
@@ -21,6 +26,7 @@ export interface StaticRouter {
 
 export interface StaticConfiguration {
   pages: Array<PageDescriptor>;
+  catchAll?: CatchAllDescriptor;
   router: StaticRouter;
   output: StaticOutput;
 }

--- a/packages/static/tests/staticFiles.spec.ts
+++ b/packages/static/tests/staticFiles.spec.ts
@@ -86,7 +86,7 @@ describe("staticFiles()", () => {
           pages,
           catchAll: {
             filename: "404.html",
-            path: "/404"
+            pathname: "/404"
           },
           router: {
             routes

--- a/packages/static/tests/staticFiles.spec.ts
+++ b/packages/static/tests/staticFiles.spec.ts
@@ -16,45 +16,96 @@ const DEFAULT_INSERT = (markup: string, emitted: Emitted) => {
 };
 
 describe("staticFiles()", () => {
-  it("creates HTML files for each route in the correct location", async () => {
-    const fixtures = join(FIXTURES_ROOT, "basic");
-    await remove(fixtures);
-    await ensureDir(fixtures);
+  describe("output files", () => {
+    it("creates HTML files for each route in the correct location", async () => {
+      const fixtures = join(FIXTURES_ROOT, "basic");
+      await remove(fixtures);
+      await ensureDir(fixtures);
 
-    const routes = prepareRoutes([
-      {
-        name: "Home",
-        path: "",
-        response() {
-          return { body: "Home" };
+      const routes = prepareRoutes([
+        {
+          name: "Home",
+          path: "",
+          response() {
+            return { body: "Home" };
+          }
+        },
+        {
+          name: "About",
+          path: "about",
+          response() {
+            return { body: "About" };
+          }
         }
-      },
-      {
-        name: "About",
-        path: "about",
-        response() {
-          return { body: "About" };
+      ]);
+      const pages = [{ name: "Home" }, { name: "About" }];
+      await staticFiles({
+        pages,
+        router: {
+          routes
+        },
+        output: {
+          render: DEFAULT_RENDER,
+          insert: DEFAULT_INSERT,
+          dir: fixtures
         }
-      }
-    ]);
-    const pages = [{ name: "Home" }, { name: "About" }];
-    await staticFiles({
-      pages,
-      router: {
-        routes
-      },
-      output: {
-        render: DEFAULT_RENDER,
-        insert: DEFAULT_INSERT,
-        dir: fixtures
-      }
+      });
+      const expectedPaths = [
+        join(fixtures, "index.html"),
+        join(fixtures, "about", "index.html")
+      ];
+      expectedPaths.forEach(path => {
+        expect(existsSync(path)).toBe(true);
+      });
     });
-    const expectedPaths = [
-      join(fixtures, "index.html"),
-      join(fixtures, "about", "index.html")
-    ];
-    expectedPaths.forEach(path => {
-      expect(existsSync(path)).toBe(true);
+
+    describe("catchAll", () => {
+      it("generates a catch all file if provided", async () => {
+        const fixtures = join(FIXTURES_ROOT, "basic");
+        await remove(fixtures);
+        await ensureDir(fixtures);
+
+        const routes = prepareRoutes([
+          {
+            name: "Home",
+            path: "",
+            response() {
+              return { body: "Home" };
+            }
+          },
+          {
+            name: "About",
+            path: "about",
+            response() {
+              return { body: "About" };
+            }
+          }
+        ]);
+        const pages = [{ name: "Home" }, { name: "About" }];
+        await staticFiles({
+          pages,
+          catchAll: {
+            filename: "404.html",
+            path: "/404"
+          },
+          router: {
+            routes
+          },
+          output: {
+            render: DEFAULT_RENDER,
+            insert: DEFAULT_INSERT,
+            dir: fixtures
+          }
+        });
+        const expectedPaths = [
+          join(fixtures, "index.html"),
+          join(fixtures, "about", "index.html"),
+          join(fixtures, "404.html")
+        ];
+        expectedPaths.forEach(path => {
+          expect(existsSync(path)).toBe(true);
+        });
+      });
     });
   });
 

--- a/packages/static/tests/staticFiles.spec.ts
+++ b/packages/static/tests/staticFiles.spec.ts
@@ -59,9 +59,9 @@ describe("staticFiles()", () => {
       });
     });
 
-    describe("catchAll", () => {
+    describe("fallback", () => {
       it("generates a catch all file if provided", async () => {
-        const fixtures = join(FIXTURES_ROOT, "basic");
+        const fixtures = join(FIXTURES_ROOT, "basic-fallback");
         await remove(fixtures);
         await ensureDir(fixtures);
 
@@ -79,12 +79,19 @@ describe("staticFiles()", () => {
             response() {
               return { body: "About" };
             }
+          },
+          {
+            name: "Catch All",
+            path: "(.*)",
+            response() {
+              return { body: "404" };
+            }
           }
         ]);
         const pages = [{ name: "Home" }, { name: "About" }];
         await staticFiles({
           pages,
-          catchAll: {
+          fallback: {
             filename: "404.html",
             pathname: "/404"
           },

--- a/packages/static/types/types.d.ts
+++ b/packages/static/types/types.d.ts
@@ -3,6 +3,10 @@ export interface PageDescriptor {
     name: string;
     params?: Params;
 }
+export interface CatchAllDescriptor {
+    filename: string;
+    pathname: string;
+}
 export declare type GetRouterOptions = () => RouterOptions;
 export interface StaticOutput {
     render: (emitted: Emitted) => any;
@@ -16,6 +20,7 @@ export interface StaticRouter {
 }
 export interface StaticConfiguration {
     pages: Array<PageDescriptor>;
+    catchAll?: CatchAllDescriptor;
     router: StaticRouter;
     output: StaticOutput;
 }

--- a/packages/static/types/types.d.ts
+++ b/packages/static/types/types.d.ts
@@ -3,7 +3,7 @@ export interface PageDescriptor {
     name: string;
     params?: Params;
 }
-export interface CatchAllDescriptor {
+export interface FallbackDescriptor {
     filename: string;
     pathname: string;
 }
@@ -20,7 +20,7 @@ export interface StaticRouter {
 }
 export interface StaticConfiguration {
     pages: Array<PageDescriptor>;
-    catchAll?: CatchAllDescriptor;
+    fallback?: FallbackDescriptor;
     router: StaticRouter;
     output: StaticOutput;
 }

--- a/website/src/pages/Packages/static.js
+++ b/website/src/pages/Packages/static.js
@@ -196,6 +196,28 @@ staticFiles({
                 </Section>
               </Section>
 
+              <Section tag="h5" title="fallback" id="staticFiles-fallback">
+                <Explanation>
+                  <p>
+                    Some hosts allow you to provide a fallback page for when a
+                    request doesn't match any of your generated HTML files. The{" "}
+                    <IJS>fallback</IJS> option takes the <IJS>pathname</IJS> it
+                    should generate page contents for and the{" "}
+                    <IJS>filename</IJS> to save the file as.
+                  </p>
+                </Explanation>
+
+                <CodeBlock>
+                  {`staticFiles({
+  // ...
+  fallback: {
+    pathname: "/404",
+    filename: "404.html"
+  }
+});`}
+                </CodeBlock>
+              </Section>
+
               <Section tag="h5" title="output" id="staticFiles-output">
                 <Explanation>
                   <p>


### PR DESCRIPTION
This will create a page with the given filename (path generated using `output.dir`) of content generated by navigating to the `pathname`. This is useful for statically hosted sites that support a specific fallback URL (e.g. Netlify uses `404.html`).

```js
staticFiles({
  fallback: {
    filename: "404.html",
    pathname: "/404"
  },
});
```