### PR TITLE
[router@v2] route.resolve is a function

### DIFF
--- a/packages/interactions/route-prefetch/.size-snapshot.json
+++ b/packages/interactions/route-prefetch/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-prefetch.es.js": {
-    "bundled": 1637,
-    "minified": 676,
-    "gzipped": 372,
+    "bundled": 982,
+    "minified": 439,
+    "gzipped": 263,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-route-prefetch.js": {
-    "bundled": 1654,
-    "minified": 689,
-    "gzipped": 380
+    "bundled": 999,
+    "minified": 452,
+    "gzipped": 271
   },
   "dist/curi-route-prefetch.umd.js": {
-    "bundled": 2018,
-    "minified": 842,
-    "gzipped": 450
+    "bundled": 1329,
+    "minified": 605,
+    "gzipped": 342
   },
   "dist/curi-route-prefetch.min.js": {
-    "bundled": 2018,
-    "minified": 842,
-    "gzipped": 450
+    "bundled": 1329,
+    "minified": 605,
+    "gzipped": 342
   }
 }

--- a/packages/interactions/route-prefetch/.size-snapshot.json
+++ b/packages/interactions/route-prefetch/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-prefetch.es.js": {
-    "bundled": 982,
-    "minified": 439,
-    "gzipped": 263,
+    "bundled": 1184,
+    "minified": 550,
+    "gzipped": 308,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-route-prefetch.js": {
-    "bundled": 999,
-    "minified": 452,
-    "gzipped": 271
+    "bundled": 1201,
+    "minified": 563,
+    "gzipped": 317
   },
   "dist/curi-route-prefetch.umd.js": {
-    "bundled": 1329,
-    "minified": 605,
-    "gzipped": 342
+    "bundled": 1537,
+    "minified": 716,
+    "gzipped": 390
   },
   "dist/curi-route-prefetch.min.js": {
-    "bundled": 1329,
-    "minified": 605,
-    "gzipped": 342
+    "bundled": 1537,
+    "minified": 716,
+    "gzipped": 390
   }
 }

--- a/packages/interactions/route-prefetch/README.md
+++ b/packages/interactions/route-prefetch/README.md
@@ -5,9 +5,9 @@
 [badge]: https://img.shields.io/npm/v/@curi/route-prefetch.svg
 [npm-link]: https://npmjs.com/package/@curi/route-prefetch
 
-The `prefetch` route interaction lets you call a route's `on.every()` method outside of route matching.
+The `prefetch` route interaction lets you call a route's `resolve()` method outside of route matching.
 
-**Note:** If you use this route interaction, then your `on.every()` functions should be caching the data. This is because the route's `on.every()` function is always called when matching routes. Caching enables you to bail early with the prefetched data.
+**Note:** If you use this route interaction, then your `resolve` function should be caching the data. This is because the route's `resolve` function is always called when matching routes. Caching enables you to bail early with the prefetched data.
 
 ## Installation
 

--- a/packages/interactions/route-prefetch/package.json
+++ b/packages/interactions/route-prefetch/package.json
@@ -34,7 +34,6 @@
   "author": "Paul Sherman",
   "license": "MIT",
   "dependencies": {
-    "@curi/router": "file:../../router",
-    "@hickory/root": "^1.0.0"
+    "@curi/router": "file:../../router"
   }
 }

--- a/packages/interactions/route-prefetch/src/index.ts
+++ b/packages/interactions/route-prefetch/src/index.ts
@@ -23,7 +23,8 @@ export default function prefetchRoute(): Interaction {
     },
     get: (
       name: string,
-      props?: MatchResponseProperties
+      props?: MatchResponseProperties,
+      external?: any
     ): Promise<ResolveResults> => {
       if (loaders[name] == null) {
         return Promise.resolve({
@@ -31,7 +32,7 @@ export default function prefetchRoute(): Interaction {
           resolved: null
         });
       }
-      return loaders[name](props).then(
+      return loaders[name](props, external).then(
         resolved => ({ resolved, error: null }),
         error => ({ error, resolved: null })
       );

--- a/packages/interactions/route-prefetch/tests/prefetch.spec.ts
+++ b/packages/interactions/route-prefetch/tests/prefetch.spec.ts
@@ -148,6 +148,30 @@ describe("prefetch route interaction", () => {
         });
       });
     });
+
+    describe("external", () => {
+      it("passes external argument to resolve function call", done => {
+        const external = {};
+
+        const routes = prepareRoutes([
+          {
+            name: "Player",
+            path: "player",
+            resolve(_, ext) {
+              expect(ext).toBe(external);
+              done();
+              return Promise.resolve();
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes, {
+          route: [createPrefetch()],
+          external
+        });
+        router.route.prefetch("Player", {}, router.external);
+      });
+    });
   });
 
   it("resets the registered routes when routes are refreshed", () => {

--- a/packages/interactions/route-prefetch/tests/prefetch.spec.ts
+++ b/packages/interactions/route-prefetch/tests/prefetch.spec.ts
@@ -24,8 +24,8 @@ describe("prefetch route interaction", () => {
         {
           name: "Player",
           path: "player",
-          resolve: {
-            test: () => Promise.resolve()
+          resolve() {
+            return Promise.resolve();
           }
         },
         { name: "Catch All", path: "(.*)" }
@@ -61,8 +61,8 @@ describe("prefetch route interaction", () => {
         {
           name: "Player",
           path: "player/:id",
-          resolve: {
-            test: () => Promise.resolve()
+          resolve() {
+            return Promise.resolve();
           }
         },
         { name: "Catch All", path: "(.*)" }
@@ -98,11 +98,10 @@ describe("prefetch route interaction", () => {
         {
           name,
           path: "throws",
-          resolve: {
-            test: () =>
-              new Promise((resolve, reject) => {
-                reject(errorMessage);
-              })
+          resolve() {
+            return new Promise((resolve, reject) => {
+              reject(errorMessage);
+            });
           }
         },
         { name: "Catch All", path: "(.*)" }
@@ -120,21 +119,19 @@ describe("prefetch route interaction", () => {
     });
 
     describe("props", () => {
-      it("passes arguments to route's on.every() function", done => {
+      it("passes arguments to route's resolve function", done => {
         const routes = prepareRoutes([
           {
             name: "Player",
             path: "player/:id",
-            resolve: {
-              test: function(props) {
-                expect(props).toMatchObject({
-                  name: "Player",
-                  location: locationToPass,
-                  params: paramsToPass
-                });
-                done();
-                return Promise.resolve(true);
-              }
+            resolve(props) {
+              expect(props).toMatchObject({
+                name: "Player",
+                location: locationToPass,
+                params: paramsToPass
+              });
+              done();
+              return Promise.resolve(true);
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -151,41 +148,6 @@ describe("prefetch route interaction", () => {
         });
       });
     });
-
-    describe("which", () => {
-      const one = jest.fn();
-      const two = jest.fn();
-      const routes = prepareRoutes([
-        {
-          name: "Home",
-          path: "",
-          resolve: { one, two }
-        },
-        { name: "Catch All", path: "(.*)" }
-      ]);
-      const router = curi(history, routes, {
-        route: [createPrefetch()]
-      });
-
-      beforeEach(() => {
-        one.mockReset();
-        two.mockReset();
-      });
-
-      it("calls all available async functions when not provided", () => {
-        return router.route.prefetch("Home").then(resolved => {
-          expect(one.mock.calls.length).toBe(1);
-          expect(two.mock.calls.length).toBe(1);
-        });
-      });
-
-      it("only calls async.one() when which = ['one']", () => {
-        return router.route.prefetch("Home", null, ["one"]).then(resolved => {
-          expect(one.mock.calls.length).toBe(1);
-          expect(two.mock.calls.length).toBe(0);
-        });
-      });
-    });
   });
 
   it("resets the registered routes when routes are refreshed", () => {
@@ -193,8 +155,8 @@ describe("prefetch route interaction", () => {
       {
         name: "Player",
         path: "player/:id",
-        resolve: {
-          test: () => Promise.resolve()
+        resolve() {
+          return Promise.resolve();
         }
       },
       { name: "Catch All", path: "(.*)" }

--- a/packages/interactions/route-prefetch/types/index.d.ts
+++ b/packages/interactions/route-prefetch/types/index.d.ts
@@ -1,2 +1,2 @@
 import { Interaction } from "@curi/router";
-export default function prefetchRoute(): Interaction;
+export default function prefetchRoute(external?: any): Interaction;

--- a/packages/interactions/route-prefetch/types/index.d.ts
+++ b/packages/interactions/route-prefetch/types/index.d.ts
@@ -1,3 +1,2 @@
 import { Interaction } from "@curi/router";
-export declare type WhichFns = Array<string>;
 export default function prefetchRoute(): Interaction;

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -483,14 +483,12 @@ Instead, please use the "forward" prop to pass an object of props to be attached
           {
             name: "Test",
             path: "test",
-            resolve: {
-              test: () => {
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    resolve("done");
-                  }, 100);
-                });
-              }
+            resolve() {
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("done");
+                }, 100);
+              });
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -534,15 +532,13 @@ Instead, please use the "forward" prop to pass an object of props to be attached
           {
             name: "Slow",
             path: "slow",
-            resolve: {
-              test: () => {
-                // takes 500ms to resolve
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    resolve("slow");
-                  }, 500);
-                });
-              }
+            resolve() {
+              // takes 500ms to resolve
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("slow");
+                }, 500);
+              });
             }
           },
           {
@@ -600,8 +596,8 @@ Instead, please use the "forward" prop to pass an object of props to be attached
           {
             name: "Loader",
             path: "load",
-            resolve: {
-              test: () => Promise.resolve("done")
+            resolve() {
+              return Promise.resolve("done");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -657,19 +653,17 @@ Instead, please use the "forward" prop to pass an object of props to be attached
           {
             name: "Slow",
             path: "slow",
-            resolve: {
-              test: () => {
-                return new Promise(resolve => {
+            resolve() {
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("Finally finished");
                   setTimeout(() => {
-                    resolve("Finally finished");
-                    setTimeout(() => {
-                      expect(mockError.mock.calls.length).toBe(0);
-                      console.error = realError;
-                      done();
-                    });
-                  }, 100);
-                });
-              }
+                    expect(mockError.mock.calls.length).toBe(0);
+                    console.error = realError;
+                    done();
+                  });
+                }, 100);
+              });
             }
           },
           { name: "Catch All", path: "(.*)" }

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -527,14 +527,12 @@ Instead, please use the "forward" prop to pass an object of props to be attached
           {
             name: "Test",
             path: "test",
-            resolve: {
-              test: () => {
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    resolve("done");
-                  }, 100);
-                });
-              }
+            resolve() {
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("done");
+                }, 100);
+              });
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -569,15 +567,13 @@ Instead, please use the "forward" prop to pass an object of props to be attached
           {
             name: "Slow",
             path: "slow",
-            resolve: {
-              test: () => {
-                // takes 500ms to resolve
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    resolve("slow");
-                  }, 500);
-                });
-              }
+            resolve() {
+              // takes 500ms to resolve
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("slow");
+                }, 500);
+              });
             }
           },
           {
@@ -629,8 +625,8 @@ Instead, please use the "forward" prop to pass an object of props to be attached
           {
             name: "Loader",
             path: "load",
-            resolve: {
-              test: () => Promise.resolve("done")
+            resolve() {
+              return Promise.resolve("done");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -677,20 +673,18 @@ Instead, please use the "forward" prop to pass an object of props to be attached
           {
             name: "Blork",
             path: "blork",
-            resolve: {
-              test: () => {
-                return new Promise(resolve => {
+            resolve() {
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("Finally finished");
+                  // need to verify error in another timeout
                   setTimeout(() => {
-                    resolve("Finally finished");
-                    // need to verify error in another timeout
-                    setTimeout(() => {
-                      expect(mockError.mock.calls.length).toBe(0);
-                      console.error = realError;
-                      done();
-                    });
-                  }, 500);
-                });
-              }
+                    expect(mockError.mock.calls.length).toBe(0);
+                    console.error = realError;
+                    done();
+                  });
+                }, 500);
+              });
             }
           },
           { name: "Catch All", path: "(.*)" }

--- a/packages/react-universal/tests/Navigating.spec.tsx
+++ b/packages/react-universal/tests/Navigating.spec.tsx
@@ -15,23 +15,19 @@ describe("<Navigating>", () => {
     {
       name: "Slow",
       path: "slow",
-      resolve: {
-        data() {
-          return new Promise(resolve => {
-            setTimeout(resolve, 1000, "slow");
-          });
-        }
+      resolve() {
+        return new Promise(resolve => {
+          setTimeout(resolve, 1000, "slow");
+        });
       }
     },
     {
       name: "Fast",
       path: "fast",
-      resolve: {
-        data() {
-          return new Promise(resolve => {
-            setTimeout(resolve, 50, "slow");
-          });
-        }
+      resolve() {
+        return new Promise(resolve => {
+          setTimeout(resolve, 50, "slow");
+        });
       }
     },
     { name: "Catch All", path: "(.*)" }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 19239,
-    "minified": 6737,
-    "gzipped": 2714,
+    "bundled": 19268,
+    "minified": 6748,
+    "gzipped": 2717,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 19474,
-    "minified": 6927,
-    "gzipped": 2800
+    "bundled": 19503,
+    "minified": 6938,
+    "gzipped": 2804
   },
   "dist/curi-router.umd.js": {
-    "bundled": 31017,
-    "minified": 9463,
-    "gzipped": 3943
+    "bundled": 31048,
+    "minified": 9474,
+    "gzipped": 3946
   },
   "dist/curi-router.min.js": {
-    "bundled": 30977,
-    "minified": 9423,
-    "gzipped": 3926
+    "bundled": 31008,
+    "minified": 9434,
+    "gzipped": 3929
   }
 }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 19666,
-    "minified": 6876,
-    "gzipped": 2778,
+    "bundled": 19239,
+    "minified": 6737,
+    "gzipped": 2714,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 19901,
-    "minified": 7066,
-    "gzipped": 2864
+    "bundled": 19474,
+    "minified": 6927,
+    "gzipped": 2800
   },
   "dist/curi-router.umd.js": {
-    "bundled": 31472,
-    "minified": 9602,
-    "gzipped": 4004
+    "bundled": 31017,
+    "minified": 9463,
+    "gzipped": 3943
   },
   "dist/curi-router.min.js": {
-    "bundled": 31432,
-    "minified": 9562,
-    "gzipped": 3990
+    "bundled": 30977,
+    "minified": 9423,
+    "gzipped": 3926
   }
 }

--- a/packages/router/src/createRoute.ts
+++ b/packages/router/src/createRoute.ts
@@ -54,14 +54,12 @@ const createRoute = (
 
   const pathname = PathToRegexp.compile(fullPath);
 
-  const resolve = options.resolve || {};
-
   return {
     public: {
       name: options.name,
       path: path,
       keys: keys.map(key => key.name),
-      resolve,
+      resolve: options.resolve,
       extra: options.extra,
       pathname
     },
@@ -70,7 +68,7 @@ const createRoute = (
       keys,
       mustBeExact
     },
-    sync: !Object.keys(resolve).length,
+    sync: options.resolve === undefined,
     response: options.response,
     children,
     paramParsers: options.params

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -240,6 +240,7 @@ export default function createRouter(
   const router: CuriRouter = {
     route: routeInteractions,
     history,
+    external,
     observe(fn: Observer, options?: ResponseHandlerOptions): RemoveObserver {
       const { initial = true } = options || {};
 

--- a/packages/router/src/resolveMatchedRoute.ts
+++ b/packages/router/src/resolveMatchedRoute.ts
@@ -1,38 +1,17 @@
 import { Match } from "./types/match";
-import { ResolveResults } from "./types/route";
+import { ResolveResults, AsyncRoute } from "./types/route";
 
-export interface KeyPromiseGroup {
-  keys: Array<string>;
-  promises: Array<Promise<any>>;
-}
-/*
- * This will call any initial/every match functions for the matching route
- */
 export default function resolveRoute(
   match: Match,
   global: any
 ): Promise<ResolveResults> {
-  const { resolve } = match.route.public;
+  const { resolve } = <AsyncRoute>match.route.public;
+  if (!resolve) {
+    return Promise.resolve({ resolved: null, error: "No resolve function" });
+  }
 
-  const { keys, promises } = Object.keys(resolve).reduce(
-    (acc, key) => {
-      acc.keys.push(key);
-      acc.promises.push(resolve[key](match.match, global));
-      return acc;
-    },
-    { keys: [], promises: [] } as KeyPromiseGroup
-  );
-
-  return Promise.all(promises).then(
-    results => {
-      return {
-        resolved: results.reduce((acc, curr, index) => {
-          acc[keys[index]] = curr;
-          return acc;
-        }, {}),
-        error: null
-      };
-    },
+  return resolve(match.match, global).then(
+    resolved => ({ resolved, error: null }),
     error => ({ error, resolved: null })
   );
 }

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -59,8 +59,9 @@ export interface CuriRouter {
   observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
   once: (fn: Observer, options?: ResponseHandlerOptions) => void;
   cancel: (fn: Cancellable) => RemoveCancellable;
-  route: Interactions;
-  history: History;
   current(): CurrentResponse;
   navigate(options: NavigationDetails): CancelNavigateCallbacks;
+  route: Interactions;
+  history: History;
+  external: any;
 }

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -6,13 +6,13 @@ export {
 } from "./interaction";
 export {
   Route,
+  SyncRoute,
+  AsyncRoute,
   RouteDescriptor,
   ParamParser,
   ParamParsers,
   ResponseBuilder,
   AsyncMatchFn,
-  AsyncGroup,
-  Resolved,
   ResolveResults,
   CompiledRoute,
   CompiledRouteArray,

--- a/packages/router/src/types/route.ts
+++ b/packages/router/src/types/route.ts
@@ -5,11 +5,8 @@ import {
   SettableResponseProperties
 } from "./response";
 
-export interface Resolved {
-  [key: string]: any;
-}
 export interface ResolveResults {
-  resolved: Resolved | null;
+  resolved: any;
   error: any;
 }
 
@@ -19,7 +16,7 @@ export interface ParamParsers {
 }
 
 export interface ResponseBuilder {
-  resolved: Resolved | null;
+  resolved: any;
   error: any;
   match: MatchResponseProperties;
   external: any;
@@ -33,9 +30,6 @@ export type AsyncMatchFn = (
   matched?: Readonly<MatchResponseProperties>,
   external?: any
 ) => Promise<any>;
-export interface AsyncGroup {
-  [key: string]: AsyncMatchFn;
-}
 
 export interface RouteDescriptor {
   name: string;
@@ -44,7 +38,7 @@ export interface RouteDescriptor {
   params?: ParamParsers;
   children?: Array<RouteDescriptor>;
   response?: ResponseFn;
-  resolve?: AsyncGroup;
+  resolve?: AsyncMatchFn;
   extra?: { [key: string]: any };
 }
 
@@ -61,14 +55,18 @@ export interface CompiledRoute {
  * These are the route properties that will be available
  * to route interactions
  */
-export interface Route {
+export interface Route<R = unknown> {
   name: string;
   path: string;
   keys: Array<string | number>;
-  resolve: AsyncGroup;
-  extra?: { [key: string]: any };
+  extra?: {
+    [key: string]: any;
+  };
   pathname: PathFunction;
+  resolve: R;
 }
+export interface SyncRoute extends Route<undefined> {}
+export interface AsyncRoute extends Route<AsyncMatchFn> {}
 
 export interface PathMatching {
   mustBeExact: boolean;

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -403,6 +403,19 @@ describe("curi", () => {
           ]);
           const router = curi(history, routes, { external });
         });
+
+        it("is available from the router", () => {
+          const history = InMemory();
+          const external = "hey!";
+          const routes = prepareRoutes([
+            {
+              name: "Not Found",
+              path: "(.*)"
+            }
+          ]);
+          const router = curi(history, routes, { external });
+          expect(router.external).toBe(external);
+        });
       });
     });
 

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -366,12 +366,10 @@ describe("curi", () => {
             {
               name: "Start",
               path: "",
-              resolve: {
-                test(match, e) {
-                  expect(e).toBe(external);
-                  done();
-                  return Promise.resolve(true);
-                }
+              resolve(match, e) {
+                expect(e).toBe(external);
+                done();
+                return Promise.resolve(true);
               }
             },
             {
@@ -424,8 +422,8 @@ describe("curi", () => {
           {
             name: "Home",
             path: "",
-            resolve: {
-              test: () => Promise.resolve()
+            resolve() {
+              return Promise.resolve();
             }
           }
         ]);
@@ -446,8 +444,8 @@ describe("curi", () => {
               {
                 name: "Child",
                 path: "child",
-                resolve: {
-                  test: () => Promise.resolve()
+                resolve() {
+                  return Promise.resolve();
                 }
               }
             ]
@@ -489,8 +487,8 @@ describe("curi", () => {
           {
             name: "Catch All",
             path: "(.*)",
-            resolve: {
-              test: () => Promise.resolve()
+            resolve() {
+              return Promise.resolve();
             }
           }
         ]);
@@ -759,8 +757,8 @@ describe("curi", () => {
           {
             name: "Home",
             path: "",
-            resolve: {
-              test: () => Promise.resolve()
+            resolve() {
+              return Promise.resolve();
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -789,11 +787,9 @@ describe("curi", () => {
                 {
                   name: "How",
                   path: ":method",
-                  resolve: {
-                    test: () => {
-                      promiseResolved = true;
-                      return Promise.resolve(promiseResolved);
-                    }
+                  resolve() {
+                    promiseResolved = true;
+                    return Promise.resolve(promiseResolved);
                   }
                 }
               ]
@@ -820,8 +816,8 @@ describe("curi", () => {
                 {
                   name: "How",
                   path: ":method",
-                  resolve: {
-                    test: () => Promise.resolve()
+                  resolve() {
+                    return Promise.resolve();
                   }
                 }
               ]
@@ -862,8 +858,8 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              resolve: {
-                test: () => Promise.resolve()
+              resolve() {
+                return Promise.resolve();
               }
             }
           ]);
@@ -881,8 +877,8 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              resolve: {
-                test: () => Promise.resolve()
+              resolve() {
+                return Promise.resolve();
               }
             }
           ]);
@@ -997,8 +993,8 @@ describe("curi", () => {
           {
             name: "Home",
             path: "",
-            resolve: {
-              test: () => Promise.resolve()
+            resolve() {
+              return Promise.resolve();
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1027,11 +1023,9 @@ describe("curi", () => {
                 {
                   name: "How",
                   path: ":method",
-                  resolve: {
-                    test: () => {
-                      promiseResolved = true;
-                      return Promise.resolve(promiseResolved);
-                    }
+                  resolve() {
+                    promiseResolved = true;
+                    return Promise.resolve(promiseResolved);
                   }
                 }
               ]
@@ -1058,8 +1052,8 @@ describe("curi", () => {
                 {
                   name: "How",
                   path: ":method",
-                  resolve: {
-                    test: () => Promise.resolve()
+                  resolve() {
+                    return Promise.resolve();
                   }
                 }
               ]
@@ -1100,8 +1094,8 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              resolve: {
-                test: () => Promise.resolve()
+              resolve() {
+                return Promise.resolve();
               }
             }
           ]);
@@ -1119,8 +1113,8 @@ describe("curi", () => {
             {
               name: "Home",
               path: "",
-              resolve: {
-                test: () => Promise.resolve()
+              resolve() {
+                return Promise.resolve();
               }
             }
           ]);
@@ -1263,22 +1257,20 @@ describe("curi", () => {
           {
             name: "Slow",
             path: "slow",
-            resolve: {
-              test: () => {
-                // takes 500ms to resolve
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    resolve("done");
-                  }, 500);
-                });
-              }
+            resolve() {
+              // takes 500ms to resolve
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("done");
+                }, 500);
+              });
             }
           },
           {
             name: "Fast",
             path: "fast",
-            resolve: {
-              test: () => Promise.resolve("complete")
+            resolve() {
+              return Promise.resolve("complete");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1301,8 +1293,8 @@ describe("curi", () => {
           {
             name: "Loader",
             path: "loader/:id",
-            resolve: {
-              test: () => Promise.resolve("complete")
+            resolve() {
+              return Promise.resolve("complete");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1340,22 +1332,20 @@ describe("curi", () => {
           {
             name: "Slow",
             path: "slow",
-            resolve: {
-              test: () => {
-                // takes 500ms to resolve
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    resolve("done");
-                  }, 500);
-                });
-              }
+            resolve() {
+              // takes 500ms to resolve
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("done");
+                }, 500);
+              });
             }
           },
           {
             name: "Fast",
             path: "fast",
-            resolve: {
-              test: () => Promise.resolve("complete")
+            resolve() {
+              return Promise.resolve("complete");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1377,8 +1367,8 @@ describe("curi", () => {
           {
             name: "Loader",
             path: "loader/:id",
-            resolve: {
-              test: () => Promise.resolve("complete")
+            resolve() {
+              return Promise.resolve("complete");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1411,8 +1401,8 @@ describe("curi", () => {
           {
             name: "Loader",
             path: "loader/:id",
-            resolve: {
-              test: () => Promise.resolve("complete")
+            resolve() {
+              return Promise.resolve("complete");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1445,22 +1435,20 @@ describe("curi", () => {
           {
             name: "Slow",
             path: "slow",
-            resolve: {
-              test: () => {
-                // takes 500ms to resolve
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    resolve("done");
-                  }, 500);
-                });
-              }
+            resolve() {
+              // takes 500ms to resolve
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("done");
+                }, 500);
+              });
             }
           },
           {
             name: "Fast",
             path: "fast",
-            resolve: {
-              test: () => Promise.resolve("complete")
+            resolve() {
+              return Promise.resolve("complete");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1506,8 +1494,8 @@ describe("curi", () => {
         {
           name: "About",
           path: "about",
-          resolve: {
-            wait: () => Promise.resolve("wait")
+          resolve() {
+            return Promise.resolve("wait");
           }
         },
         { name: "Catch All", path: "(.*)" }
@@ -1530,8 +1518,8 @@ describe("curi", () => {
           {
             name: "About",
             path: "about",
-            resolve: {
-              wait: () => Promise.resolve("wait")
+            resolve() {
+              return Promise.resolve("wait");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1563,8 +1551,8 @@ describe("curi", () => {
           {
             name: "About",
             path: "about",
-            resolve: {
-              wait: () => Promise.resolve("wait")
+            resolve() {
+              return Promise.resolve("wait");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1591,8 +1579,8 @@ describe("curi", () => {
           {
             name: "About",
             path: "about",
-            resolve: {
-              wait: () => Promise.resolve("wait")
+            resolve() {
+              return Promise.resolve("wait");
             }
           },
           { name: "Catch All", path: "(.*)" }
@@ -1622,15 +1610,15 @@ describe("curi", () => {
         {
           name: "About",
           path: "about",
-          resolve: {
-            wait: () => Promise.resolve("wait")
+          resolve() {
+            return Promise.resolve("wait");
           }
         },
         {
           name: "Contact",
           path: "contact",
-          resolve: {
-            wait: () => Promise.resolve("wait")
+          resolve() {
+            return Promise.resolve("wait");
           }
         },
         { name: "Catch All", path: "(.*)" }

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -624,13 +624,14 @@ describe("route matching/response generation", () => {
             name: "Catch All"
           });
           done();
+          return Promise.resolve();
         });
 
         const routes = prepareRoutes([
           {
             name: "Catch All",
             path: ":anything",
-            resolve: { spy }
+            resolve: spy
           }
         ]);
 
@@ -643,41 +644,19 @@ describe("route matching/response generation", () => {
         const spy = jest.fn((_, e) => {
           expect(e).toBe(external);
           done();
+          return Promise.resolve();
         });
 
         const routes = prepareRoutes([
           {
             name: "Catch All",
             path: ":anything",
-            resolve: { spy }
+            resolve: spy
           }
         ]);
 
         const history = InMemory({ locations: ["/hello?one=two"] });
         curi(history, routes, { external });
-      });
-
-      it("calls all resolve functions", done => {
-        const one = jest.fn();
-        const two = jest.fn();
-        const routes = prepareRoutes([
-          {
-            name: "Catch All",
-            path: ":anything",
-            resolve: {
-              one,
-              two
-            }
-          }
-        ]);
-
-        const history = InMemory({ locations: ["/hello?one=two"] });
-        const router = curi(history, routes);
-        router.once(() => {
-          expect(one.mock.calls.length).toBe(1);
-          expect(one.mock.calls.length).toBe(1);
-          done();
-        });
       });
     });
 
@@ -698,9 +677,7 @@ describe("route matching/response generation", () => {
           {
             name: "First",
             path: "first",
-            resolve: {
-              spy
-            },
+            resolve: spy,
             response: responseSpy
           },
           {
@@ -713,12 +690,10 @@ describe("route matching/response generation", () => {
               done();
               return {};
             },
-            resolve: {
-              // re-use the spy so that this route's response
-              // fn isn't call until after the first route's spy
-              // fn has resolved
-              spy
-            }
+            // re-use the spy so that this route's response
+            // fn isn't call until after the first route's spy
+            // fn has resolved
+            resolve: spy
           }
         ]);
 
@@ -749,8 +724,8 @@ describe("route matching/response generation", () => {
             {
               name: "Catch All",
               path: ":anything",
-              resolve: {
-                fails: () => Promise.reject("woops!")
+              resolve() {
+                return Promise.reject("woops!");
               },
               response: ({ resolved }) => {
                 expect(resolved).toBe(null);
@@ -763,7 +738,7 @@ describe("route matching/response generation", () => {
           const router = curi(history, routes);
         });
 
-        it("is an object with named resolve function properties for async routes", () => {
+        it("is the resolve results", () => {
           const routes = prepareRoutes([
             {
               name: "Catch All",
@@ -773,9 +748,8 @@ describe("route matching/response generation", () => {
                 expect(resolved.yo).toBe("yo!");
                 return {};
               },
-              resolve: {
-                test: () => Promise.resolve(1),
-                yo: () => Promise.resolve("yo!")
+              resolve() {
+                return Promise.resolve({ test: 1, yo: "yo!" });
               }
             }
           ]);
@@ -797,8 +771,8 @@ describe("route matching/response generation", () => {
               name: "Catch All",
               path: ":anything",
               response: spy,
-              resolve: {
-                fails: () => Promise.reject("rejected")
+              resolve() {
+                return Promise.reject("rejected");
               }
             }
           ]);
@@ -818,8 +792,8 @@ describe("route matching/response generation", () => {
               name: "Catch All",
               path: ":anything",
               response: spy,
-              resolve: {
-                succeed: () => Promise.resolve("hurray!")
+              resolve() {
+                return Promise.resolve("hurray!");
               }
             }
           ]);

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -96,15 +96,17 @@ describe("public route properties", () => {
   });
 
   describe("resolve", () => {
-    it("is the resolve functions", done => {
+    it("is the resolve function", done => {
       const history = InMemory({ locations: ["/test"] });
       const routes = prepareRoutes([
         {
           name: "Test",
           path: "test",
-          resolve: {
-            iTest: () => Promise.resolve("iTest"),
-            eTest: () => Promise.resolve("eTest")
+          resolve() {
+            return Promise.all([
+              Promise.resolve("iTest"),
+              Promise.resolve("eTest")
+            ]);
           }
         }
       ]);
@@ -112,15 +114,15 @@ describe("public route properties", () => {
         route: [PropertyReporter()]
       });
       const routeProperties = router.route.properties("Test");
-      const { iTest, eTest } = routeProperties.resolve;
-      Promise.all([iTest(), eTest()]).then(([iResult, eResult]) => {
+
+      routeProperties.resolve().then(([iResult, eResult]) => {
         expect(iResult).toBe("iTest");
         expect(eResult).toBe("eTest");
         done();
       });
     });
 
-    it("is an empty object when route.resolve isn't provided", done => {
+    it("is undefined when route.resolve isn't provided", done => {
       const history = InMemory({ locations: ["/test"] });
       const routes = prepareRoutes([
         {
@@ -132,24 +134,7 @@ describe("public route properties", () => {
         route: [PropertyReporter()]
       });
       const routeProperties = router.route.properties("Test");
-      expect(routeProperties.resolve).toEqual({});
-      done();
-    });
-
-    it("is an empty object when route.resolve is an empty object", done => {
-      const history = InMemory({ locations: ["/test"] });
-      const routes = prepareRoutes([
-        {
-          name: "Test",
-          path: "test",
-          resolve: {}
-        }
-      ]);
-      const router = curi(history, routes, {
-        route: [PropertyReporter()]
-      });
-      const routeProperties = router.route.properties("Test");
-      expect(routeProperties.resolve).toEqual({});
+      expect(routeProperties.resolve).toBeUndefined();
       done();
     });
   });

--- a/packages/router/types/resolveMatchedRoute.d.ts
+++ b/packages/router/types/resolveMatchedRoute.d.ts
@@ -1,7 +1,3 @@
 import { Match } from "./types/match";
 import { ResolveResults } from "./types/route";
-export interface KeyPromiseGroup {
-    keys: Array<string>;
-    promises: Array<Promise<any>>;
-}
 export default function resolveRoute(match: Match, global: any): Promise<ResolveResults>;

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -48,8 +48,9 @@ export interface CuriRouter {
     observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
     once: (fn: Observer, options?: ResponseHandlerOptions) => void;
     cancel: (fn: Cancellable) => RemoveCancellable;
-    route: Interactions;
-    history: History;
     current(): CurrentResponse;
     navigate(options: NavigationDetails): CancelNavigateCallbacks;
+    route: Interactions;
+    history: History;
+    external: any;
 }

--- a/packages/router/types/types/index.d.ts
+++ b/packages/router/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
-export { Route, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, AsyncGroup, Resolved, ResolveResults, CompiledRoute, CompiledRouteArray, UserRoutes } from "./route";
+export { Route, SyncRoute, AsyncRoute, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, ResolveResults, CompiledRoute, CompiledRouteArray, UserRoutes } from "./route";
 export { Response, RawParams, Params, RedirectLocation, MatchResponseProperties, SettableResponseProperties } from "./response";
 export { CuriRouter, RouterOptions, Observer, Emitted, ResponseHandlerOptions, RemoveObserver, Navigation, CurrentResponse, Cancellable, CancelActiveNavigation, CancelNavigateCallbacks, RemoveCancellable } from "./curi";

--- a/packages/router/types/types/route.d.ts
+++ b/packages/router/types/types/route.d.ts
@@ -1,10 +1,7 @@
 import { RegExpOptions, Key, PathFunction } from "path-to-regexp";
 import { MatchResponseProperties, SettableResponseProperties } from "./response";
-export interface Resolved {
-    [key: string]: any;
-}
 export interface ResolveResults {
-    resolved: Resolved | null;
+    resolved: any;
     error: any;
 }
 export declare type ParamParser = (input: string) => any;
@@ -12,16 +9,13 @@ export interface ParamParsers {
     [key: string]: ParamParser;
 }
 export interface ResponseBuilder {
-    resolved: Resolved | null;
+    resolved: any;
     error: any;
     match: MatchResponseProperties;
     external: any;
 }
 export declare type ResponseFn = (props: Readonly<ResponseBuilder>) => SettableResponseProperties;
 export declare type AsyncMatchFn = (matched?: Readonly<MatchResponseProperties>, external?: any) => Promise<any>;
-export interface AsyncGroup {
-    [key: string]: AsyncMatchFn;
-}
 export interface RouteDescriptor {
     name: string;
     path: string;
@@ -29,7 +23,7 @@ export interface RouteDescriptor {
     params?: ParamParsers;
     children?: Array<RouteDescriptor>;
     response?: ResponseFn;
-    resolve?: AsyncGroup;
+    resolve?: AsyncMatchFn;
     extra?: {
         [key: string]: any;
     };
@@ -42,15 +36,19 @@ export interface CompiledRoute {
     pathMatching: PathMatching;
     paramParsers?: ParamParsers;
 }
-export interface Route {
+export interface Route<R = unknown> {
     name: string;
     path: string;
     keys: Array<string | number>;
-    resolve: AsyncGroup;
     extra?: {
         [key: string]: any;
     };
     pathname: PathFunction;
+    resolve: R;
+}
+export interface SyncRoute extends Route<undefined> {
+}
+export interface AsyncRoute extends Route<AsyncMatchFn> {
 }
 export interface PathMatching {
     mustBeExact: boolean;

--- a/packages/static/src/types.ts
+++ b/packages/static/src/types.ts
@@ -1,4 +1,9 @@
-import { RouteDescriptor, Params, Emitted, RouterOptions } from "@curi/router";
+import {
+  CompiledRouteArray,
+  Params,
+  Emitted,
+  RouterOptions
+} from "@curi/router";
 
 export interface PageDescriptor {
   name: string;
@@ -14,13 +19,13 @@ export type GetRouterOptions = () => RouterOptions;
 
 export interface StaticOutput {
   render: (emitted: Emitted) => any;
-  insert: (markup: any) => string;
+  insert: (markup: any, emitted?: Emitted) => string;
   dir: string;
   redirects?: boolean;
 }
 
 export interface StaticRouter {
-  routes: Array<RouteDescriptor>;
+  routes: CompiledRouteArray;
   getRouterOptions?: GetRouterOptions;
 }
 
@@ -38,7 +43,7 @@ export interface Result {
 }
 
 export interface PathnamesConfiguration {
-  routes: Array<RouteDescriptor>;
+  routes: CompiledRouteArray;
   pages: Array<PageDescriptor>;
   routerOptions?: RouterOptions;
 }

--- a/packages/static/tests/staticFiles.spec.ts
+++ b/packages/static/tests/staticFiles.spec.ts
@@ -325,8 +325,8 @@ describe("staticFiles()", () => {
           {
             name: "Home",
             path: "",
-            resolve: {
-              async: () => Promise.resolve(true)
+            resolve() {
+              return Promise.resolve(true);
             },
             response() {
               return { body: "Home" };

--- a/packages/static/types/types.d.ts
+++ b/packages/static/types/types.d.ts
@@ -1,4 +1,4 @@
-import { RouteDescriptor, Params, Emitted, RouterOptions } from "@curi/router";
+import { CompiledRouteArray, Params, Emitted, RouterOptions } from "@curi/router";
 export interface PageDescriptor {
     name: string;
     params?: Params;
@@ -10,12 +10,12 @@ export interface FallbackDescriptor {
 export declare type GetRouterOptions = () => RouterOptions;
 export interface StaticOutput {
     render: (emitted: Emitted) => any;
-    insert: (markup: any) => string;
+    insert: (markup: any, emitted?: Emitted) => string;
     dir: string;
     redirects?: boolean;
 }
 export interface StaticRouter {
-    routes: Array<RouteDescriptor>;
+    routes: CompiledRouteArray;
     getRouterOptions?: GetRouterOptions;
 }
 export interface StaticConfiguration {
@@ -30,7 +30,7 @@ export interface Result {
     error?: Error;
 }
 export interface PathnamesConfiguration {
-    routes: Array<RouteDescriptor>;
+    routes: CompiledRouteArray;
     pages: Array<PageDescriptor>;
     routerOptions?: RouterOptions;
 }

--- a/packages/svelte/tests/cases/link/wrapper-destroy-callbacks/index.js
+++ b/packages/svelte/tests/cases/link/wrapper-destroy-callbacks/index.js
@@ -8,7 +8,7 @@ import cleanText from "../../../utils/cleanText";
 /*
  * This test verifies that the Link does not update the wrapper's
  * state after the Link has been destroyed.
- * 
+ *
  * The test relies on the wrapper calling a global method (console.warn)
  * when it updates. console.warn is mocked so that we can track its calls
  * to determine if it is called the expected number of times.
@@ -19,14 +19,12 @@ const routes = prepareRoutes([
   {
     name: "Test",
     path: "test",
-    resolve: {
-      test: () => {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve("done");
-          }, 100);
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve("done");
+        }, 100);
+      });
     }
   },
   { name: "Not Found", path: "(.*)" }

--- a/packages/svelte/tests/cases/link/wrapper-while-navigating/index.js
+++ b/packages/svelte/tests/cases/link/wrapper-while-navigating/index.js
@@ -10,14 +10,12 @@ const routes = prepareRoutes([
   {
     name: "Test",
     path: "test",
-    resolve: {
-      test: () => {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve("done");
-          }, 100);
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve("done");
+        }, 100);
+      });
     }
   },
   { name: "Not Found", path: "(.*)" }

--- a/packages/svelte/tests/cases/navigating/call/index.js
+++ b/packages/svelte/tests/cases/navigating/call/index.js
@@ -10,23 +10,19 @@ const routes = prepareRoutes([
   {
     name: "Slow",
     path: "slow",
-    resolve: {
-      data() {
-        return new Promise(resolve => {
-          setTimeout(resolve, 1000, "slow");
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(resolve, 1000, "slow");
+      });
     }
   },
   {
     name: "Fast",
     path: "fast",
-    resolve: {
-      data() {
-        return new Promise(resolve => {
-          setTimeout(resolve, 50, "slow");
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(resolve, 50, "slow");
+      });
     }
   },
   { name: "Catch All", path: "(.*)" }

--- a/packages/svelte/tests/cases/navigating/mount/index.js
+++ b/packages/svelte/tests/cases/navigating/mount/index.js
@@ -10,23 +10,19 @@ const routes = prepareRoutes([
   {
     name: "Slow",
     path: "slow",
-    resolve: {
-      data() {
-        return new Promise(resolve => {
-          setTimeout(resolve, 1000, "slow");
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(resolve, 1000, "slow");
+      });
     }
   },
   {
     name: "Fast",
     path: "fast",
-    resolve: {
-      data() {
-        return new Promise(resolve => {
-          setTimeout(resolve, 50, "slow");
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(resolve, 50, "slow");
+      });
     }
   },
   { name: "Catch All", path: "(.*)" }

--- a/packages/svelte/tests/cases/navigating/nav-async/index.js
+++ b/packages/svelte/tests/cases/navigating/nav-async/index.js
@@ -10,23 +10,19 @@ const routes = prepareRoutes([
   {
     name: "Slow",
     path: "slow",
-    resolve: {
-      data() {
-        return new Promise(resolve => {
-          setTimeout(resolve, 1000, "slow");
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(resolve, 1000, "slow");
+      });
     }
   },
   {
     name: "Fast",
     path: "fast",
-    resolve: {
-      data() {
-        return new Promise(resolve => {
-          setTimeout(resolve, 50, "slow");
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(resolve, 50, "slow");
+      });
     }
   },
   { name: "Catch All", path: "(.*)" }

--- a/packages/svelte/tests/cases/navigating/nav-sync/index.js
+++ b/packages/svelte/tests/cases/navigating/nav-sync/index.js
@@ -10,23 +10,19 @@ const routes = prepareRoutes([
   {
     name: "Slow",
     path: "slow",
-    resolve: {
-      data() {
-        return new Promise(resolve => {
-          setTimeout(resolve, 1000, "slow");
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(resolve, 1000, "slow");
+      });
     }
   },
   {
     name: "Fast",
     path: "fast",
-    resolve: {
-      data() {
-        return new Promise(resolve => {
-          setTimeout(resolve, 50, "slow");
-        });
-      }
+    resolve() {
+      return new Promise(resolve => {
+        setTimeout(resolve, 50, "slow");
+      });
     }
   },
   { name: "Catch All", path: "(.*)" }

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -150,14 +150,12 @@ describe("<curi-link>", () => {
         {
           name: "Test",
           path: "test",
-          resolve: {
-            test: () => {
-              return new Promise(resolve => {
-                setTimeout(() => {
-                  resolve("done");
-                }, 100);
-              });
-            }
+          resolve() {
+            return new Promise(resolve => {
+              setTimeout(() => {
+                resolve("done");
+              }, 100);
+            });
           }
         },
         { name: "Catch All", path: "(.*)" }
@@ -253,21 +251,19 @@ describe("<curi-link>", () => {
           {
             name: "Slow",
             path: "slow",
-            resolve: {
-              test: () => {
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    resolve("slow");
-                  }, 100);
-                });
-              }
+            resolve() {
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("slow");
+                }, 100);
+              });
             }
           },
           {
             name: "Fast",
             path: "fast",
-            resolve: {
-              test: () => Promise.resolve("fast")
+            resolve() {
+              return Promise.resolve("fast");
             }
           },
           { name: "Catch All", path: "(.*)" }


### PR DESCRIPTION
This PR is for `@curi/router` v2 because of breaking changes.

Instead of `route.resolve` being an object whose properties are async function, each route can have a single `resolve` function.

If multiple async actions should be called, `Promise.all` can be used to wait for all of them to resolve.

```js
// v1
{
  name: "User",
  path: "u/:id",
  resolve {
    body: () => import(...),
    data: ({ params }) => getUser(params.id)
  },
  response({ resolved }) {
    const { body, data } = resolved;
  }
}

// v2
{
  name: "User",
  path: "u/:id",
  resolve({ params }) {
    const body = import(...);
    const data = getUser(params.id);
    return Promise.all([ body, data ]);
  },
  response({ resolved }) {
    const [body, data] = resolved;
  }
}
```

In theory, breaking asynchronous actions into multiple functions is convenient, but it has drawbacks. For example, if multiple async actions need to verify that the user is authenticated, they would all need to check the authentication status.

This also affects `@curi/route-prefetch`. The `which` argument is removed and calling the interaction now only calls the route's `resolve` function.
