### PR TITLE
Routes array must be prepared

### DIFF
--- a/packages/interactions/route-prefetch/.size-snapshot.json
+++ b/packages/interactions/route-prefetch/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-prefetch.es.js": {
-    "bundled": 1184,
-    "minified": 550,
-    "gzipped": 308,
+    "bundled": 1002,
+    "minified": 443,
+    "gzipped": 266,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-route-prefetch.js": {
-    "bundled": 1201,
-    "minified": 563,
-    "gzipped": 317
+    "bundled": 1019,
+    "minified": 456,
+    "gzipped": 273
   },
   "dist/curi-route-prefetch.umd.js": {
-    "bundled": 1537,
-    "minified": 716,
-    "gzipped": 390
+    "bundled": 1349,
+    "minified": 609,
+    "gzipped": 344
   },
   "dist/curi-route-prefetch.min.js": {
-    "bundled": 1537,
-    "minified": 716,
-    "gzipped": 390
+    "bundled": 1349,
+    "minified": 609,
+    "gzipped": 344
   }
 }

--- a/packages/interactions/route-prefetch/types/index.d.ts
+++ b/packages/interactions/route-prefetch/types/index.d.ts
@@ -1,2 +1,2 @@
 import { Interaction } from "@curi/router";
-export default function prefetchRoute(external?: any): Interaction;
+export default function prefetchRoute(): Interaction;

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 19268,
-    "minified": 6748,
-    "gzipped": 2717,
+    "bundled": 18433,
+    "minified": 6244,
+    "gzipped": 2504,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 19503,
-    "minified": 6938,
-    "gzipped": 2804
+    "bundled": 18668,
+    "minified": 6434,
+    "gzipped": 2587
   },
   "dist/curi-router.umd.js": {
-    "bundled": 31048,
-    "minified": 9474,
-    "gzipped": 3946
+    "bundled": 30185,
+    "minified": 9027,
+    "gzipped": 3740
   },
   "dist/curi-router.min.js": {
-    "bundled": 31008,
-    "minified": 9434,
-    "gzipped": 3929
+    "bundled": 30155,
+    "minified": 8997,
+    "gzipped": 3722
   }
 }

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -3,13 +3,11 @@ import pathnameInteraction from "./interactions/pathname";
 import finishResponse from "./finishResponse";
 import matchLocation from "./matchLocation";
 import resolveMatchedRoute from "./resolveMatchedRoute";
-import { privatePrepareRoutes } from "./prepareRoutes";
 
 import { History, PendingNavigation, Action, NavType } from "@hickory/root";
 
 import {
   RouteDescriptor,
-  UserRoutes,
   CompiledRouteArray,
   ResolveResults
 } from "./types/route";
@@ -33,7 +31,7 @@ import {
 
 export default function createRouter(
   history: History,
-  routeArray: UserRoutes,
+  routeArray: CompiledRouteArray,
   options: RouterOptions = {}
 ): CuriRouter {
   const {
@@ -67,9 +65,9 @@ export default function createRouter(
   const oneTimers: Array<Observer> = [];
   let cancellers: Array<Cancellable> = [];
 
-  function setupRoutesAndInteractions(userRoutes?: UserRoutes): void {
+  function setupRoutesAndInteractions(userRoutes?: CompiledRouteArray): void {
     if (userRoutes) {
-      routes = privatePrepareRoutes(userRoutes, true);
+      routes = userRoutes;
       for (let key in routeInteractions) {
         delete routeInteractions[key];
       }
@@ -279,7 +277,7 @@ export default function createRouter(
         });
       };
     },
-    refresh(routes?: Array<RouteDescriptor>) {
+    refresh(routes?: CompiledRouteArray) {
       refreshing = true;
       setupRoutesAndInteractions(routes);
     },

--- a/packages/router/src/prepareRoutes.ts
+++ b/packages/router/src/prepareRoutes.ts
@@ -1,40 +1,12 @@
 import createRoute from "./createRoute";
 
-import {
-  UserRoutes,
-  CompiledRoute,
-  RouteDescriptor,
-  CompiledRouteArray
-} from "./types/route";
+import { RouteDescriptor, CompiledRouteArray } from "./types/route";
 
 export default function prepareRoutes(
-  userRoutes: UserRoutes
+  userRoutes: Array<RouteDescriptor>
 ): CompiledRouteArray {
-  return privatePrepareRoutes(userRoutes);
-}
-
-export function privatePrepareRoutes(
-  userRoutes: UserRoutes,
-  _privateInternalCall: boolean = false
-): CompiledRouteArray {
-  let hasWarned = false;
   const usedNames: Set<string> = new Set();
   return userRoutes.map(route => {
-    if ((route as CompiledRoute).public !== undefined) {
-      return route as CompiledRoute;
-    }
-    if (process.env.NODE_ENV !== "production") {
-      if (_privateInternalCall && !hasWarned) {
-        console.warn(`Deprecation Warning:
-You passed a plain array to your curi() call. This will be removed in the next major version. Instead, you should pass a compiled routes array.
-
-import { curi, prepareRoutes } from "@curi/router";
-
-const routes = prepareRoutes([...]);
-const router = curi(history, routes);`);
-        hasWarned = true;
-      }
-    }
     return createRoute(route as RouteDescriptor, null, usedNames);
   });
 }

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -2,7 +2,7 @@ import { History, Action, NavType } from "@hickory/root";
 import { PathFunctionOptions } from "path-to-regexp";
 
 import { Interaction, Interactions } from "./interaction";
-import { UserRoutes } from "./route";
+import { CompiledRouteArray } from "./route";
 import { Response, Params } from "./response";
 
 export interface Navigation {
@@ -55,7 +55,7 @@ export interface NavigationDetails {
 export type CancelNavigateCallbacks = () => void;
 
 export interface CuriRouter {
-  refresh: (routeArray?: UserRoutes) => void;
+  refresh: (routeArray?: CompiledRouteArray) => void;
   observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
   once: (fn: Observer, options?: ResponseHandlerOptions) => void;
   cancel: (fn: Cancellable) => RemoveCancellable;

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -15,8 +15,7 @@ export {
   AsyncMatchFn,
   ResolveResults,
   CompiledRoute,
-  CompiledRouteArray,
-  UserRoutes
+  CompiledRouteArray
 } from "./route";
 export {
   Response,

--- a/packages/router/src/types/route.ts
+++ b/packages/router/src/types/route.ts
@@ -75,4 +75,3 @@ export interface PathMatching {
 }
 
 export type CompiledRouteArray = Array<CompiledRoute>;
-export type UserRoutes = Array<CompiledRoute | RouteDescriptor>;

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -51,27 +51,6 @@ describe("curi", () => {
       });
     });
 
-    it("warns when passed a non-compiled routes array", () => {
-      const realWarn = console.warn;
-      const fakeWarn = (console.warn = jest.fn());
-
-      const routes = [
-        { name: "Home", path: "" },
-        { name: "About", path: "about" },
-        {
-          name: "Contact",
-          path: "contact",
-          children: [
-            { name: "Email", path: "email" },
-            { name: "Phone", path: "phone" }
-          ]
-        }
-      ];
-      const router = curi(history, routes);
-      expect(fakeWarn.mock.calls.length).toBe(1);
-      console.warn = realWarn;
-    });
-
     it("makes interactions available through router.route", () => {
       const routes = prepareRoutes([{ name: "Home", path: "" }]);
       const createfakeInteraction = () => ({

--- a/packages/router/types/curi.d.ts
+++ b/packages/router/types/curi.d.ts
@@ -1,4 +1,4 @@
 import { History } from "@hickory/root";
-import { UserRoutes } from "./types/route";
+import { CompiledRouteArray } from "./types/route";
 import { CuriRouter, RouterOptions } from "./types/curi";
-export default function createRouter(history: History, routeArray: UserRoutes, options?: RouterOptions): CuriRouter;
+export default function createRouter(history: History, routeArray: CompiledRouteArray, options?: RouterOptions): CuriRouter;

--- a/packages/router/types/prepareRoutes.d.ts
+++ b/packages/router/types/prepareRoutes.d.ts
@@ -1,3 +1,2 @@
-import { UserRoutes, CompiledRouteArray } from "./types/route";
-export default function prepareRoutes(userRoutes: UserRoutes): CompiledRouteArray;
-export declare function privatePrepareRoutes(userRoutes: UserRoutes, _privateInternalCall?: boolean): CompiledRouteArray;
+import { RouteDescriptor, CompiledRouteArray } from "./types/route";
+export default function prepareRoutes(userRoutes: Array<RouteDescriptor>): CompiledRouteArray;

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -1,7 +1,7 @@
 import { History, Action, NavType } from "@hickory/root";
 import { PathFunctionOptions } from "path-to-regexp";
 import { Interaction, Interactions } from "./interaction";
-import { UserRoutes } from "./route";
+import { CompiledRouteArray } from "./route";
 import { Response, Params } from "./response";
 export interface Navigation {
     action: Action;
@@ -44,7 +44,7 @@ export interface NavigationDetails {
 }
 export declare type CancelNavigateCallbacks = () => void;
 export interface CuriRouter {
-    refresh: (routeArray?: UserRoutes) => void;
+    refresh: (routeArray?: CompiledRouteArray) => void;
     observe: (fn: Observer, options?: ResponseHandlerOptions) => RemoveObserver;
     once: (fn: Observer, options?: ResponseHandlerOptions) => void;
     cancel: (fn: Cancellable) => RemoveCancellable;

--- a/packages/router/types/types/index.d.ts
+++ b/packages/router/types/types/index.d.ts
@@ -1,4 +1,4 @@
 export { RegisterInteraction, GetInteraction, Interaction, Interactions } from "./interaction";
-export { Route, SyncRoute, AsyncRoute, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, ResolveResults, CompiledRoute, CompiledRouteArray, UserRoutes } from "./route";
+export { Route, SyncRoute, AsyncRoute, RouteDescriptor, ParamParser, ParamParsers, ResponseBuilder, AsyncMatchFn, ResolveResults, CompiledRoute, CompiledRouteArray } from "./route";
 export { Response, RawParams, Params, RedirectLocation, MatchResponseProperties, SettableResponseProperties } from "./response";
 export { CuriRouter, RouterOptions, Observer, Emitted, ResponseHandlerOptions, RemoveObserver, Navigation, CurrentResponse, Cancellable, CancelActiveNavigation, CancelNavigateCallbacks, RemoveCancellable } from "./curi";

--- a/packages/router/types/types/route.d.ts
+++ b/packages/router/types/types/route.d.ts
@@ -56,4 +56,3 @@ export interface PathMatching {
     keys: Array<Key>;
 }
 export declare type CompiledRouteArray = Array<CompiledRoute>;
-export declare type UserRoutes = Array<CompiledRoute | RouteDescriptor>;

--- a/packages/vue/tests/focus.spec.ts
+++ b/packages/vue/tests/focus.spec.ts
@@ -10,10 +10,10 @@ describe("curi-focus directive", () => {
   let vueWrapper;
   const history = InMemory();
 
-  const routes = [
+  const routes = prepareRoutes([
     { name: "Place", path: "place/:name" },
     { name: "Catch All", path: "(.*)" }
-  ];
+  ]);
   const router = curi(history, routes);
 
   const Vue = createLocalVue();


### PR DESCRIPTION
Removes the ability to pass a raw (unprepared) array of routes to `curi()`.

`prepareRoutes` must now be used to prepare the array of routes.

```js
import { prepareRoutes } from "@curi/router";

const routes = prepareRoutes([
 { name: "Home", path: "" },
  // ...
]);

const router = curi(history, routes);
```