### PR TITLE
Move optional active() arguments to object

### DIFF
--- a/packages/interactions/route-active/.size-snapshot.json
+++ b/packages/interactions/route-active/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-route-active.es.js": {
-    "bundled": 1500,
-    "minified": 519,
-    "gzipped": 325,
+    "bundled": 1509,
+    "minified": 558,
+    "gzipped": 331,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-route-active.js": {
-    "bundled": 1517,
-    "minified": 532,
-    "gzipped": 332
+    "bundled": 1526,
+    "minified": 571,
+    "gzipped": 338
   },
   "dist/curi-route-active.umd.js": {
-    "bundled": 1873,
-    "minified": 644,
-    "gzipped": 381
+    "bundled": 1882,
+    "minified": 683,
+    "gzipped": 388
   },
   "dist/curi-route-active.min.js": {
-    "bundled": 1873,
-    "minified": 644,
-    "gzipped": 381
+    "bundled": 1882,
+    "minified": 683,
+    "gzipped": 388
   }
 }

--- a/packages/interactions/route-active/src/index.ts
+++ b/packages/interactions/route-active/src/index.ts
@@ -1,7 +1,5 @@
-import { Route, Response, Interaction } from "@curi/router";
+import { Route, Response, Interaction, Params } from "@curi/router";
 import { HickoryLocation } from "@hickory/root";
-
-type LocationCheck = (l: HickoryLocation) => boolean;
 
 function acceptableRouteName(
   name: string,
@@ -12,6 +10,14 @@ function acceptableRouteName(
     name === response.name ||
     !!(partial && response.partials.some((n: string) => name === n))
   );
+}
+
+export type LocationCheck = (l: HickoryLocation) => boolean;
+
+export interface ActiveCheckOptions {
+  params?: Params;
+  partial?: boolean;
+  locationCheck?: LocationCheck;
 }
 
 export default function checkIfActive(): Interaction {
@@ -33,26 +39,24 @@ export default function checkIfActive(): Interaction {
     get: (
       name: string,
       response: Response,
-      params?: { [key: string]: string },
-      partial?: boolean,
-      locationCheck?: LocationCheck
+      options: ActiveCheckOptions
     ): boolean => {
       if (
         routeParams[name] == null ||
-        !acceptableRouteName(name, response, partial)
+        !acceptableRouteName(name, response, options.partial)
       ) {
         return false;
       }
       const routeKeysToCheck = routeParams[name];
       for (let r = 0, length = routeKeysToCheck.length; r < length; r++) {
         const key = routeKeysToCheck[r];
-        const param = params[key];
+        const param = options.params[key];
         if (!param || param !== response.params[key]) {
           return false;
         }
       }
-      if (locationCheck) {
-        return locationCheck(response.location);
+      if (options.locationCheck) {
+        return options.locationCheck(response.location);
       }
       return true;
     },

--- a/packages/interactions/route-active/tests/active.spec.ts
+++ b/packages/interactions/route-active/tests/active.spec.ts
@@ -34,7 +34,7 @@ describe("active route interaction", () => {
 
       const { response } = router.current();
       const playerIsActive = router.route.active("Does Not Exist", response, {
-        id: "6"
+        params: { id: "6" }
       });
       expect(playerIsActive).toBe(false);
     });
@@ -56,7 +56,7 @@ describe("active route interaction", () => {
 
       const { response } = router.current();
       const playerIsActive = router.route.active("Player", response, {
-        id: "6"
+        params: { id: "6" }
       });
       expect(playerIsActive).toBe(false);
     });
@@ -79,7 +79,7 @@ describe("active route interaction", () => {
 
         const { response } = router.current();
         const playerIsActive = router.route.active("Player", response, {
-          id: "7"
+          params: { id: "7" }
         });
         expect(playerIsActive).toBe(true);
       });
@@ -101,13 +101,41 @@ describe("active route interaction", () => {
 
         const { response } = router.current();
         const playerIsActive = router.route.active("Player", response, {
-          id: "6"
+          params: { id: "6" }
         });
         expect(playerIsActive).toBe(false);
       });
     });
 
     describe("partial", () => {
+      it("defaults to false (returns false when name is partial match but partial is not provided)", () => {
+        const history = InMemory({
+          locations: ["/player/6/coach"]
+        });
+        const routes = prepareRoutes([
+          {
+            name: "Player",
+            path: "player/:id",
+            children: [
+              {
+                name: "Coach",
+                path: "coach"
+              }
+            ]
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes, {
+          route: [createActive()]
+        });
+
+        const { response } = router.current();
+        const playerIsActive = router.route.active("Player", response, {
+          params: { id: "6" }
+        });
+        expect(playerIsActive).toBe(false);
+      });
+
       it("returns false when name is partial match but partial is not true", () => {
         const history = InMemory({
           locations: ["/player/6/coach"]
@@ -131,7 +159,8 @@ describe("active route interaction", () => {
 
         const { response } = router.current();
         const playerIsActive = router.route.active("Player", response, {
-          id: "6"
+          params: { id: "6" },
+          partial: false
         });
         expect(playerIsActive).toBe(false);
       });
@@ -158,18 +187,16 @@ describe("active route interaction", () => {
         });
 
         const { response } = router.current();
-        const playerIsActive = router.route.active(
-          "Player",
-          response,
-          { id: "6" },
-          true
-        );
+        const playerIsActive = router.route.active("Player", response, {
+          params: { id: "6" },
+          partial: true
+        });
         expect(playerIsActive).toBe(true);
       });
     });
 
-    describe("location check", () => {
-      it("returns true when route matches and location check returns true", () => {
+    describe("locationCheck", () => {
+      it("returns true when route matches and locationCheck returns true", () => {
         const history = InMemory({
           locations: ["/#test"]
         });
@@ -185,17 +212,13 @@ describe("active route interaction", () => {
         });
 
         const { response } = router.current();
-        const isActive = router.route.active(
-          "Home",
-          response,
-          null,
-          null,
-          location => location.hash === "test"
-        );
+        const isActive = router.route.active("Home", response, {
+          locationCheck: location => location.hash === "test"
+        });
         expect(isActive).toBe(true);
       });
 
-      it("returns false when route matches but location check returns false", () => {
+      it("returns false when route matches but locationCheck returns false", () => {
         const history = InMemory({
           locations: ["/#test"]
         });
@@ -211,17 +234,13 @@ describe("active route interaction", () => {
         });
 
         const { response } = router.current();
-        const isActive = router.route.active(
-          "Home",
-          response,
-          null,
-          null,
-          location => false
-        );
+        const isActive = router.route.active("Home", response, {
+          locationCheck: location => false
+        });
         expect(isActive).toBe(false);
       });
 
-      it("doesn't call location check if route doesn't match", () => {
+      it("doesn't call locationCheck if route doesn't match", () => {
         const history = InMemory({
           locations: ["/not-a#test"]
         });
@@ -237,13 +256,9 @@ describe("active route interaction", () => {
         });
         const locationCheck = jest.fn(() => true);
         const { response } = router.current();
-        const isActive = router.route.active(
-          "Home",
-          response,
-          null,
-          null,
+        const isActive = router.route.active("Home", response, {
           locationCheck
-        );
+        });
         expect(isActive).toBe(false);
         expect(locationCheck.mock.calls.length).toBe(0);
       });
@@ -271,7 +286,9 @@ describe("active route interaction", () => {
       const playerIsActive = router.route.active(
         "Player",
         router.current().response,
-        { id: "7" }
+        {
+          params: { id: "7" }
+        }
       );
       expect(playerIsActive).toBe(true);
 
@@ -280,7 +297,9 @@ describe("active route interaction", () => {
       const playerIsActiveAfterRefresh = router.route.active(
         "Player",
         router.current().response,
-        { id: "7" }
+        {
+          params: { id: "7" }
+        }
       );
       expect(playerIsActiveAfterRefresh).toBe(false);
     });

--- a/packages/interactions/route-active/types/index.d.ts
+++ b/packages/interactions/route-active/types/index.d.ts
@@ -1,2 +1,9 @@
-import { Interaction } from "@curi/router";
+import { Interaction, Params } from "@curi/router";
+import { HickoryLocation } from "@hickory/root";
+export declare type LocationCheck = (l: HickoryLocation) => boolean;
+export interface ActiveCheckOptions {
+    params?: Params;
+    partial?: boolean;
+    locationCheck?: LocationCheck;
+}
 export default function checkIfActive(): Interaction;

--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 965
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 9815,
-    "minified": 3855,
-    "gzipped": 1733
+    "bundled": 9899,
+    "minified": 3886,
+    "gzipped": 1741
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 9785,
-    "minified": 3825,
-    "gzipped": 1718
+    "bundled": 9869,
+    "minified": 3856,
+    "gzipped": 1726
   }
 }

--- a/packages/react-universal/.size-snapshot.json
+++ b/packages/react-universal/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-universal.es.js": {
-    "bundled": 4740,
-    "minified": 2413,
-    "gzipped": 1030,
+    "bundled": 4808,
+    "minified": 2444,
+    "gzipped": 1037,
     "treeshaked": {
       "rollup": {
         "code": 110,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-react-universal.js": {
-    "bundled": 5137,
-    "minified": 2747,
-    "gzipped": 1134
+    "bundled": 5205,
+    "minified": 2778,
+    "gzipped": 1140
   },
   "dist/curi-react-universal.umd.js": {
-    "bundled": 5678,
-    "minified": 2477,
-    "gzipped": 1146
+    "bundled": 5754,
+    "minified": 2508,
+    "gzipped": 1153
   },
   "dist/curi-react-universal.min.js": {
-    "bundled": 5668,
-    "minified": 2467,
-    "gzipped": 1131
+    "bundled": 5744,
+    "minified": 2498,
+    "gzipped": 1138
   }
 }

--- a/packages/react-universal/package.json
+++ b/packages/react-universal/package.json
@@ -37,7 +37,6 @@
     "react": "16.8.0-alpha.1"
   },
   "dependencies": {
-    "@curi/route-active": "file:../interactions/route-active",
     "@curi/router": "file:../router",
     "@hickory/root": "^1.0.0",
     "@types/react": "^16.7.18"

--- a/packages/react-universal/src/hooks/useActive.ts
+++ b/packages/react-universal/src/hooks/useActive.ts
@@ -9,7 +9,7 @@ export interface ActiveHookProps {
   name: string;
   params?: Params;
   partial?: boolean;
-  checkLocation?: LocationCheck;
+  locationCheck?: LocationCheck;
 }
 
 export default function useActive(props: ActiveHookProps) {
@@ -28,12 +28,10 @@ const router = curi(history, routes, {
       );
     }
   }
-  let isActive = router.route.active(
-    props.name,
-    response,
-    props.params,
-    props.partial,
-    props.checkLocation
-  );
+  let isActive = router.route.active(props.name, response, {
+    params: props.params,
+    partial: props.partial,
+    locationCheck: props.locationCheck
+  });
   return isActive;
 }

--- a/packages/react-universal/tests/useActive.spec.tsx
+++ b/packages/react-universal/tests/useActive.spec.tsx
@@ -130,7 +130,7 @@ const router = curi(history, routes, {
     });
   });
 
-  describe("checkLocation", () => {
+  describe("locationCheck", () => {
     it("is called with location if route is active", () => {
       const history = InMemory({ locations: ["/contact"] });
       const router = curi(history, routes, {
@@ -142,7 +142,7 @@ const router = curi(history, routes, {
       function App() {
         const { response } = useCuri();
         theLocation = response.location;
-        const active = useActive({ name: "Contact", checkLocation: locCheck });
+        const active = useActive({ name: "Contact", locationCheck: locCheck });
         return null;
       }
       ReactDOM.render(
@@ -166,7 +166,7 @@ const router = curi(history, routes, {
       function App() {
         const { response } = useCuri();
         theResponse = response;
-        const active = useActive({ name: "Contact", checkLocation: locCheck });
+        const active = useActive({ name: "Contact", locationCheck: locCheck });
         return null;
       }
       ReactDOM.render(
@@ -188,7 +188,7 @@ const router = curi(history, routes, {
         const active = useActive({
           name: "Contact",
           partial: true,
-          checkLocation: () => true
+          locationCheck: () => true
         });
         expect(active).toBe(true);
         return null;
@@ -211,7 +211,7 @@ const router = curi(history, routes, {
         const active = useActive({
           name: "Contact",
           partial: true,
-          checkLocation: () => false
+          locationCheck: () => false
         });
         expect(active).toBe(false);
         return null;

--- a/packages/react-universal/types/hooks/useActive.d.ts
+++ b/packages/react-universal/types/hooks/useActive.d.ts
@@ -5,6 +5,6 @@ export interface ActiveHookProps {
     name: string;
     params?: Params;
     partial?: boolean;
-    checkLocation?: LocationCheck;
+    locationCheck?: LocationCheck;
 }
 export default function useActive(props: ActiveHookProps): any;

--- a/website/src/pages/Guides/history.js
+++ b/website/src/pages/Guides/history.js
@@ -164,8 +164,8 @@ const inMemoryHistory = InMemory();`}
         <p>
           The history object will map URL strings into location objects. Only
           the <IJS>pathname</IJS>, <IJS>query</IJS> (search), and{" "}
-          <IJS>hash</IJS> segments of a URL are used; locations ignore the
-          domain and protocol segments of a URL.
+          <IJS>hash</IJS> components of a URL are used; locations ignore a URL's
+          domain and protocol.
         </p>
 
         <p>

--- a/website/src/pages/Packages/react-dom/v2/api/useActive.js
+++ b/website/src/pages/Packages/react-dom/v2/api/useActive.js
@@ -113,18 +113,18 @@ useActive({ name: "User", partial: true }); // true`}
 
       <HashSection
         tag="h4"
-        meta={{ title: "checkLocation", hash: "useActve-checkLocation" }}
+        meta={{ title: "locationCheck", hash: "useActve-locationCheck" }}
       >
         <p>
           The base active check only checks that the route (i.e. pathname) is
-          active. <IJS>checkLocation</IJS> allows you to check if other segments
-          of the location are also active.
+          active. <IJS>locationCheck</IJS> allows you to check if other parts of
+          the location are also active.
         </p>
 
         <CodeBlock lang="jsx">
           {`useActive({
   name: "Results",
-  checkLocation: loc => location.query === "page=3"
+  locationCheck: loc => loc.query === "page=3"
 });
 
 // active for /results?page=3

--- a/website/src/pages/Packages/react-native/v2/api/useActive.js
+++ b/website/src/pages/Packages/react-native/v2/api/useActive.js
@@ -113,18 +113,18 @@ useActive({ name: "User", partial: true }); // true`}
 
       <HashSection
         tag="h4"
-        meta={{ title: "checkLocation", hash: "useActve-checkLocation" }}
+        meta={{ title: "locationCheck", hash: "useActve-locationCheck" }}
       >
         <p>
           The base active check only checks that the route (i.e. pathname) is
-          active. <IJS>checkLocation</IJS> allows you to check if other segments
-          of the location are also active.
+          active. <IJS>locationCheck</IJS> allows you to check if other parts of
+          the location are also active.
         </p>
 
         <CodeBlock lang="jsx">
           {`useActive({
   name: "Results",
-  checkLocation: loc => location.query === "page=3"
+  locationCheck: loc => loc.query === "page=3"
 });
 
 // active for /results?page=3

--- a/website/src/pages/Packages/route-active/v2/api/active.js
+++ b/website/src/pages/Packages/route-active/v2/api/active.js
@@ -57,43 +57,52 @@ const isActive = router.route.active(
           <p>The response to check the route against.</p>
         </HashSection>
 
-        <HashSection meta={{ title: "params", hash: "params" }} tag="h4">
-          <p>Any route params for the route that is being checked.</p>
-        </HashSection>
-
-        <HashSection meta={{ title: "partial", hash: "partial" }} tag="h4">
+        <HashSection meta={{ title: "optional", hash: "optional" }} tag="h4">
           <p>
-            When <IJS>true</IJS>, ancestor routes can be considered active.
-            (default <IJS>false</IJS>).
+            An optional argument with additional properties can be passed as the
+            third argument.
           </p>
-        </HashSection>
-
-        <HashSection
-          meta={{ title: "locationCheck", hash: "locationCheck" }}
-          tag="h4"
-        >
-          <p>
-            A function that receives a location object and returns a boolean.
-          </p>
-
-          <p>
-            Route matching determines if the <IJS>pathname</IJS> for the current
-            response's location matches the provided route. If you want to
-            compare other location segments (<IJS>hash</IJS> or <IJS>query</IJS>
-            ), you can use the <IJS>locationCheck</IJS> argument.
-          </p>
-
-          <p>This function will only be called when the route matches.</p>
 
           <CodeBlock>
             {`const isActive = router.route.active(
   'Some Route',
   response,
-  null,
-  false,
-  location => location.hash === "comments"
+  {
+    params: { id: 1 },
+    partial: false,
+    locationCheck: location => location.hash === "comments"
+  }
 );`}
           </CodeBlock>
+          <HashSection meta={{ title: "params", hash: "params" }} tag="h5">
+            <p>Any route params for the route that is being checked.</p>
+          </HashSection>
+
+          <HashSection meta={{ title: "partial", hash: "partial" }} tag="h5">
+            <p>
+              When <IJS>true</IJS>, ancestor routes can be considered active.
+              (default <IJS>false</IJS>).
+            </p>
+          </HashSection>
+
+          <HashSection
+            meta={{ title: "locationCheck", hash: "locationCheck" }}
+            tag="h5"
+          >
+            <p>
+              A function that receives a location object and returns a boolean.
+            </p>
+
+            <p>
+              Route matching determines if the <IJS>pathname</IJS> for the
+              current response's location matches the provided route. If you
+              want to compare other location parts (<IJS>hash</IJS> or{" "}
+              <IJS>query</IJS>
+              ), you can use the <IJS>locationCheck</IJS> argument.
+            </p>
+
+            <p>This function will only be called when the route matches.</p>
+          </HashSection>
         </HashSection>
       </HashSection>
     </HashSection>

--- a/website/src/pages/Tutorials/react-basics.js
+++ b/website/src/pages/Tutorials/react-basics.js
@@ -198,8 +198,8 @@ cd curi-react-bookstore # enter the new app directory`}
         <p>
           A route's <IJS>path</IJS> is what the router uses to identify if a
           location matches the route. The <IJS>path</IJS> is only matched
-          against the location's pathname, the other segments of a URL are not
-          used for matching.
+          against the location's pathname, the other parts of a URL are not used
+          for matching.
         </p>
 
         <HashSection meta={pathMeta} className="aside" tag="h3">


### PR DESCRIPTION
Group the optional arguments to the `active` interaction in an options object.

```js
const isActive = router.route.active("Article", response, {
  params: { id: "123" },
  partial: false,
  locationCheck: (loc) => loc.hash === "comments"
});
```