### PR TITLE
Move more Link functionality to useNavigationHandler

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 3664,
-    "minified": 1641,
-    "gzipped": 868,
+    "bundled": 3312,
+    "minified": 1494,
+    "gzipped": 806,
     "treeshaked": {
       "rollup": {
-        "code": 739,
+        "code": 600,
         "import_statements": 95
       },
       "webpack": {
-        "code": 2622
+        "code": 2479
       }
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 3978,
-    "minified": 1901,
-    "gzipped": 965
+    "bundled": 3626,
+    "minified": 1754,
+    "gzipped": 904
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 9899,
-    "minified": 3886,
-    "gzipped": 1741
+    "bundled": 9941,
+    "minified": 3907,
+    "gzipped": 1722
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 9869,
-    "minified": 3856,
-    "gzipped": 1726
+    "bundled": 9911,
+    "minified": 3877,
+    "gzipped": 1706
   }
 }

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -13,27 +13,18 @@ export interface LinkProps extends RouteLocation {
 }
 
 const HookLink = React.forwardRef((props: LinkProps, ref: React.Ref<any>) => {
-  const [navigating, setNavigating] = React.useState(false);
   const href = useHref(props);
-  const { handler, cancel } = useNavigationHandler<
-    React.MouseEvent<HTMLElement>
-  >(props, setNavigating, canNavigate);
-  React.useEffect(() => {
-    return () => {
-      if (cancel.current) {
-        cancel.current();
-      }
-    };
-  }, []);
 
-  const { anchor: Anchor = "a", children, forward } = props;
+  const { eventHandler, children } = useNavigationHandler<
+    React.MouseEvent<HTMLElement>
+  >(props, canNavigate);
+
+  const { anchor: Anchor = "a", forward } = props;
 
   return (
     // @ts-ignore
-    <Anchor onClick={handler} href={href} ref={ref} {...forward}>
-      {typeof children === "function"
-        ? (children as NavigatingChildren)(navigating)
-        : children}
+    <Anchor onClick={eventHandler} href={href} ref={ref} {...forward}>
+      {children}
     </Anchor>
   );
 });

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 2227,
-    "minified": 845,
-    "gzipped": 485,
+    "bundled": 1875,
+    "minified": 698,
+    "gzipped": 412,
     "treeshaked": {
       "rollup": {
-        "code": 685,
+        "code": 546,
         "import_statements": 132
       },
       "webpack": {
-        "code": 1774
+        "code": 1631
       }
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 2504,
-    "minified": 1063,
-    "gzipped": 577
+    "bundled": 2152,
+    "minified": 916,
+    "gzipped": 509
   }
 }

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -20,28 +20,16 @@ function canNavigate(event: GestureResponderEvent) {
 }
 
 const HookLink = React.forwardRef((props: LinkProps, ref: React.Ref<any>) => {
-  const [navigating, setNavigating] = React.useState(false);
-  const { handler, cancel } = useNavigationHandler<GestureResponderEvent>(
-    props,
-    setNavigating,
-    canNavigate
-  );
-  React.useEffect(() => {
-    return () => {
-      if (cancel.current) {
-        cancel.current();
-      }
-    };
-  }, []);
+  const { eventHandler, children } = useNavigationHandler<
+    GestureResponderEvent
+  >(props, canNavigate);
 
-  const { anchor: Anchor = TouchableHighlight, children, forward } = props;
+  const { anchor: Anchor = TouchableHighlight, forward } = props;
 
   return (
     // @ts-ignore
-    <Anchor onPress={handler} ref={ref} {...forward}>
-      {typeof children === "function"
-        ? (children as NavigatingChildren)(navigating)
-        : children}
+    <Anchor onPress={eventHandler} ref={ref} {...forward}>
+      {children}
     </Anchor>
   );
 });

--- a/packages/react-universal/.size-snapshot.json
+++ b/packages/react-universal/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-universal.es.js": {
-    "bundled": 4808,
-    "minified": 2444,
-    "gzipped": 1037,
+    "bundled": 5190,
+    "minified": 2612,
+    "gzipped": 1054,
     "treeshaked": {
       "rollup": {
         "code": 110,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-react-universal.js": {
-    "bundled": 5205,
-    "minified": 2778,
-    "gzipped": 1140
+    "bundled": 5587,
+    "minified": 2946,
+    "gzipped": 1160
   },
   "dist/curi-react-universal.umd.js": {
-    "bundled": 5754,
-    "minified": 2508,
-    "gzipped": 1153
+    "bundled": 6162,
+    "minified": 2668,
+    "gzipped": 1177
   },
   "dist/curi-react-universal.min.js": {
-    "bundled": 5744,
-    "minified": 2498,
-    "gzipped": 1138
+    "bundled": 6152,
+    "minified": 2658,
+    "gzipped": 1162
   }
 }

--- a/packages/react-universal/src/hooks/useNavigationHandler.ts
+++ b/packages/react-universal/src/hooks/useNavigationHandler.ts
@@ -24,13 +24,20 @@ export default function useNavigationHandler<
   T extends React.BaseSyntheticEvent
 >(
   props: NavigationHookProps<T>,
-  setNavigating: (n: boolean) => void,
   canNavigate: CanNavigate<T> = defaultCanNavigate
 ) {
   const { router } = useCuri();
   const cancel = React.useRef(undefined);
+  const [navigating, setNavigating] = React.useState(false);
+  React.useEffect(() => {
+    return () => {
+      if (cancel.current) {
+        cancel.current();
+      }
+    };
+  }, []);
 
-  function handler(event: T) {
+  function eventHandler(event: T) {
     if (props.onNav) {
       props.onNav(event);
     }
@@ -60,5 +67,11 @@ export default function useNavigationHandler<
       });
     }
   }
-  return { handler, cancel };
+  return {
+    eventHandler,
+    children:
+      typeof props.children === "function"
+        ? (props.children as NavigatingChildren)(navigating)
+        : props.children
+  };
 }

--- a/packages/react-universal/types/hooks/useNavigationHandler.d.ts
+++ b/packages/react-universal/types/hooks/useNavigationHandler.d.ts
@@ -10,7 +10,7 @@ export interface NavigationHookProps<T> extends RouteLocation {
     method?: NavType;
 }
 export declare type CanNavigate<T> = (e: T, forward?: object) => boolean;
-export default function useNavigationHandler<T extends React.BaseSyntheticEvent>(props: NavigationHookProps<T>, setNavigating: (n: boolean) => void, canNavigate?: CanNavigate<T>): {
-    handler: (event: T) => void;
-    cancel: React.MutableRefObject<any>;
+export default function useNavigationHandler<T extends React.BaseSyntheticEvent>(props: NavigationHookProps<T>, canNavigate?: CanNavigate<T>): {
+    eventHandler: (event: T) => void;
+    children: {};
 };


### PR DESCRIPTION
`useNavigationHandler` keeps track of `navigating` state itself, calls the `children` function (if it is a function), and cancels the current navigation if it unmounts while the navigation is active.