### PR TITLE
Split Link components into Link/NavLink

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 3312,
-    "minified": 1494,
-    "gzipped": 806,
+    "bundled": 3819,
+    "minified": 1774,
+    "gzipped": 862,
     "treeshaked": {
       "rollup": {
-        "code": 600,
-        "import_statements": 95
+        "code": 827,
+        "import_statements": 129
       },
       "webpack": {
-        "code": 2479
+        "code": 2729
       }
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 3626,
-    "minified": 1754,
-    "gzipped": 904
+    "bundled": 4159,
+    "minified": 2059,
+    "gzipped": 959
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 9941,
-    "minified": 3907,
-    "gzipped": 1722
+    "bundled": 11083,
+    "minified": 4293,
+    "gzipped": 1805
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 9911,
-    "minified": 3877,
-    "gzipped": 1706
+    "bundled": 11053,
+    "minified": 4263,
+    "gzipped": 1789
   }
 }

--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 3819,
+    "bundled": 3769,
     "minified": 1774,
     "gzipped": 862,
     "treeshaked": {
@@ -14,17 +14,17 @@
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 4159,
+    "bundled": 4109,
     "minified": 2059,
     "gzipped": 959
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 11083,
+    "bundled": 11017,
     "minified": 4293,
     "gzipped": 1805
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 11053,
+    "bundled": 10987,
     "minified": 4263,
     "gzipped": 1789
   }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Split `Link` into `Link` (regular `children`) and `NavLink` (`children` is a render-invoked function).
+
 ## 2.0.0-alpha.1
 
 * Internal `Link` changes.

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -1,32 +1,62 @@
 import React from "react";
-import { useHref, useNavigationHandler } from "@curi/react-universal";
+import {
+  useHref,
+  useNavigationHandler,
+  useStatefulNavigationHandler
+} from "@curi/react-universal";
 import { canNavigate } from "./utils";
 
 import { RouteLocation } from "@curi/router";
 import { NavigatingChildren } from "@curi/react-universal";
 
-export interface LinkProps extends RouteLocation {
+export interface BaseLinkProps extends RouteLocation {
   onNav?: (e: React.MouseEvent<HTMLElement>) => void;
   anchor?: React.ReactType;
-  children: NavigatingChildren | React.ReactNode;
   forward?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 
-const HookLink = React.forwardRef((props: LinkProps, ref: React.Ref<any>) => {
-  const href = useHref(props);
+export interface LinkProps extends BaseLinkProps {
+  children: React.ReactNode;
+}
 
-  const { eventHandler, children } = useNavigationHandler<
-    React.MouseEvent<HTMLElement>
-  >(props, canNavigate);
+export interface NavLinkProps extends BaseLinkProps {
+  children: NavigatingChildren;
+}
 
-  const { anchor: Anchor = "a", forward } = props;
+export const Link = React.forwardRef(
+  (props: LinkProps, ref: React.Ref<any>) => {
+    const href = useHref(props);
 
-  return (
-    // @ts-ignore
-    <Anchor onClick={eventHandler} href={href} ref={ref} {...forward}>
-      {children}
-    </Anchor>
-  );
-});
+    const { eventHandler } = useNavigationHandler<
+      React.MouseEvent<HTMLElement>
+    >(props, canNavigate);
 
-export default HookLink;
+    const { anchor: Anchor = "a", forward, children } = props;
+
+    return (
+      // @ts-ignore
+      <Anchor onClick={eventHandler} href={href} ref={ref} {...forward}>
+        {children}
+      </Anchor>
+    );
+  }
+);
+
+export const NavLink = React.forwardRef(
+  (props: NavLinkProps, ref: React.Ref<any>) => {
+    const href = useHref(props);
+
+    const { eventHandler, navigating } = useStatefulNavigationHandler<
+      React.MouseEvent<HTMLElement>
+    >(props, canNavigate);
+
+    const { anchor: Anchor = "a", forward, children } = props;
+
+    return (
+      // @ts-ignore
+      <Anchor onClick={eventHandler} href={href} ref={ref} {...forward}>
+        {children(navigating)}
+      </Anchor>
+    );
+  }
+);

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -34,7 +34,6 @@ export const Link = React.forwardRef(
     const { anchor: Anchor = "a", forward, children } = props;
 
     return (
-      // @ts-ignore
       <Anchor onClick={eventHandler} href={href} ref={ref} {...forward}>
         {children}
       </Anchor>
@@ -53,7 +52,6 @@ export const NavLink = React.forwardRef(
     const { anchor: Anchor = "a", forward, children } = props;
 
     return (
-      // @ts-ignore
       <Anchor onClick={eventHandler} href={href} ref={ref} {...forward}>
         {children(navigating)}
       </Anchor>

--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -1,8 +1,8 @@
-export { LinkProps } from "./Link";
+export { LinkProps, NavLinkProps } from "./Link";
 export { FocusHookProps } from "./hooks/useNavigationFocus";
 
 import useNavigationFocus from "./hooks/useNavigationFocus";
-import Link from "./Link";
+import { Link, NavLink } from "./Link";
 
 export * from "@curi/react-universal";
-export { Link, useNavigationFocus };
+export { Link, NavLink, useNavigationFocus };

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -58,109 +58,111 @@ describe("<Link>", () => {
     });
   });
 
-  describe("name", () => {
-    it("sets the href attribute using the named route's path", () => {
-      ReactDOM.render(
-        <Router>
-          <Link name="Test">Test</Link>}
-        </Router>,
-        node
-      );
-      const a = node.querySelector("a");
-      expect(a.getAttribute("href")).toBe("/");
-    });
-
-    it("creates a relative link if 'to' is undefined", () => {
-      const history = InMemory({
-        locations: ["/the-initial-location"]
+  describe("href", () => {
+    describe("name", () => {
+      it("sets the href attribute using the named route's path", () => {
+        ReactDOM.render(
+          <Router>
+            <Link name="Test">Test</Link>}
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/");
       });
-      const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-      const router = curi(history, routes);
-      const Router = curiProvider(router);
-      ReactDOM.render(
-        <Router>
-          <Link name={null}>Test</Link>
-        </Router>,
-        node
-      );
-      const a = node.querySelector("a");
-      expect(a.getAttribute("href")).toBe("");
-    });
-  });
 
-  describe("params", () => {
-    let history, router, Router;
-    const routes = prepareRoutes([
-      { name: "Park", path: "park/:name" },
-      { name: "Catch All", path: "(.*)" }
-    ]);
-
-    beforeEach(() => {
-      history = InMemory();
-      router = curi(history, routes);
-      Router = curiProvider(router);
+      it("creates a relative link if 'name' is undefined", () => {
+        const history = InMemory({
+          locations: ["/the-initial-location"]
+        });
+        const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+        ReactDOM.render(
+          <Router>
+            <Link name={null}>Test</Link>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("");
+      });
     });
 
-    it("uses params to generate the href", () => {
-      const params = { name: "Glacier" };
-      ReactDOM.render(
-        <Router>
-          <Link name="Park" params={params}>
-            Test
-          </Link>
-        </Router>,
-        node
-      );
-      const a = node.querySelector("a");
-      expect(a.getAttribute("href")).toBe("/park/Glacier");
-    });
-
-    it("updates href when props change", () => {
-      const params = { name: "Glacier" };
-      ReactDOM.render(
-        <Router>
-          <Link name="Park" params={params}>
-            Test
-          </Link>
-        </Router>,
-        node
-      );
-      let a = node.querySelector("a");
-      expect(a.getAttribute("href")).toBe("/park/Glacier");
-
-      const newParams = { name: "Yellowstone" };
-      ReactDOM.render(
-        <Router>
-          <Link name="Park" params={newParams}>
-            Test
-          </Link>
-        </Router>,
-        node
-      );
-      a = node.querySelector("a");
-      expect(a.getAttribute("href")).toBe("/park/Yellowstone");
-    });
-  });
-
-  describe("hash & query", () => {
-    it("merges hash & query props with the pathname when creating href", () => {
-      const history = InMemory();
+    describe("params", () => {
+      let history, router, Router;
       const routes = prepareRoutes([
-        { name: "Test", path: "test" },
+        { name: "Park", path: "park/:name" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
-      const Router = curiProvider(router);
-      ReactDOM.render(
-        <Router>
-          <Link name="Test" query="one=two" hash="hashtag">
-            Test
-          </Link>
-        </Router>,
-        node
-      );
-      const a = node.querySelector("a");
-      expect(a.getAttribute("href")).toBe("/test?one=two#hashtag");
+
+      beforeEach(() => {
+        history = InMemory();
+        router = curi(history, routes);
+        Router = curiProvider(router);
+      });
+
+      it("uses params to generate the href", () => {
+        const params = { name: "Glacier" };
+        ReactDOM.render(
+          <Router>
+            <Link name="Park" params={params}>
+              Test
+            </Link>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/park/Glacier");
+      });
+
+      it("updates href when props change", () => {
+        const params = { name: "Glacier" };
+        ReactDOM.render(
+          <Router>
+            <Link name="Park" params={params}>
+              Test
+            </Link>
+          </Router>,
+          node
+        );
+        let a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/park/Glacier");
+
+        const newParams = { name: "Yellowstone" };
+        ReactDOM.render(
+          <Router>
+            <Link name="Park" params={newParams}>
+              Test
+            </Link>
+          </Router>,
+          node
+        );
+        a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/park/Yellowstone");
+      });
+    });
+
+    describe("hash & query", () => {
+      it("merges hash & query props with the pathname when creating href", () => {
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+        ReactDOM.render(
+          <Router>
+            <Link name="Test" query="one=two" hash="hashtag">
+              Test
+            </Link>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/test?one=two#hashtag");
+      });
     });
   });
 
@@ -204,348 +206,27 @@ describe("<Link>", () => {
   });
 
   describe("children", () => {
-    describe("React Node", () => {
-      it("renders the provided children value(s)", () => {
-        const history = InMemory();
-        const routes = prepareRoutes([
-          { name: "Test", path: "test" },
-          { name: "Catch All", path: "(.*)" }
-        ]);
-        const router = curi(history, routes);
-        const Router = curiProvider(router);
-        const children = "Test Value";
-        ReactDOM.render(
-          <Router>
-            <Link name="Test">{children}</Link>
-          </Router>,
-          node
-        );
-        const a = node.querySelector("a");
-        expect(a.textContent).toBe(children);
-      });
-    });
-
-    describe("render-invoked function", () => {
-      it("calls the function with the component's navigating state (initial navigating=false)", () => {
-        const history = InMemory();
-        const routes = prepareRoutes([
-          { name: "Test", path: "test" },
-          { name: "Catch All", path: "(.*)" }
-        ]);
-        const router = curi(history, routes);
-        const Router = curiProvider(router);
-        ReactDOM.render(
-          <Router>
-            <Link name="Test">
-              {navigating => {
-                expect(navigating).toBe(false);
-                return null;
-              }}
-            </Link>
-          </Router>,
-          node
-        );
-        const a = node.querySelector("a");
-      });
+    it("renders the provided children", () => {
+      const history = InMemory();
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+      const children = "Test Value";
+      ReactDOM.render(
+        <Router>
+          <Link name="Test">{children}</Link>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      expect(a.textContent).toBe(children);
     });
   });
 
   describe("clicking a link", () => {
-    it("calls history.navigate", () => {
-      const history = InMemory();
-      const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
-      const routes = prepareRoutes([
-        { name: "Test", path: "test" },
-        { name: "Catch All", path: "(.*)" }
-      ]);
-      const router = curi(history, routes);
-      const Router = curiProvider(router);
-      ReactDOM.render(
-        <Router>
-          <Link name="Test">Test</Link>
-        </Router>,
-        node
-      );
-      const a = node.querySelector("a");
-      const leftClickEvent = {
-        defaultPrevented: false,
-        preventDefault() {
-          this.defaultPrevented = true;
-        },
-        metaKey: null,
-        altKey: null,
-        ctrlKey: null,
-        shiftKey: null,
-        button: 0
-      };
-      Simulate.click(a, leftClickEvent);
-      expect(mockNavigate.mock.calls.length).toBe(1);
-    });
-
-    describe("children(navigating)", () => {
-      it("children(true) after clicking", () => {
-        // if a link has no on methods, finished will be called almost
-        // immediately (although this style should only be used for routes
-        // with on methods)
-        const history = InMemory();
-        const routes = prepareRoutes([
-          {
-            name: "Test",
-            path: "test",
-            resolve() {
-              return new Promise(resolve => {
-                setTimeout(() => {
-                  resolve("done");
-                }, 100);
-              });
-            }
-          },
-          { name: "Catch All", path: "(.*)" }
-        ]);
-        const router = curi(history, routes);
-        const Router = curiProvider(router);
-
-        ReactDOM.render(
-          <Router>
-            <Link name="Test">
-              {navigating => {
-                return <div>{navigating.toString()}</div>;
-              }}
-            </Link>
-          </Router>,
-          node
-        );
-        const a = node.querySelector("a");
-        expect(a.textContent).toBe("false");
-        const leftClickEvent = {
-          defaultPrevented: false,
-          preventDefault() {
-            this.defaultPrevented = true;
-          },
-          metaKey: null,
-          altKey: null,
-          ctrlKey: null,
-          shiftKey: null,
-          button: 0
-        };
-        Simulate.click(a, leftClickEvent);
-        expect(a.textContent).toBe("true");
-      });
-
-      it("children(false) when navigation is cancelled", () => {
-        const history = InMemory();
-        const routes = prepareRoutes([
-          { name: "Test", path: "test" },
-          {
-            name: "Slow",
-            path: "slow",
-            resolve() {
-              // takes 500ms to resolve
-              return new Promise(resolve => {
-                setTimeout(() => {
-                  resolve("slow");
-                }, 500);
-              });
-            }
-          },
-          {
-            name: "Fast",
-            path: "fast"
-          },
-          { name: "Catch All", path: "(.*)" }
-        ]);
-        const router = curi(history, routes);
-        const Router = curiProvider(router);
-
-        ReactDOM.render(
-          <Router>
-            <React.Fragment>
-              <Link name="Slow">
-                {navigating => {
-                  return <div>Slow {navigating.toString()}</div>;
-                }}
-              </Link>
-              <Link name="Fast">
-                {navigating => {
-                  return <div>Fast {navigating.toString()}</div>;
-                }}
-              </Link>
-            </React.Fragment>
-          </Router>,
-          node
-        );
-        const [slowLink, fastLink] = node.querySelectorAll("a");
-        expect(slowLink.textContent).toBe("Slow false");
-        const leftClickEvent = {
-          defaultPrevented: false,
-          preventDefault() {
-            this.defaultPrevented = true;
-          },
-          metaKey: null,
-          altKey: null,
-          ctrlKey: null,
-          shiftKey: null,
-          button: 0
-        };
-        Simulate.click(slowLink, leftClickEvent);
-        expect(slowLink.textContent).toBe("Slow true");
-
-        Simulate.click(fastLink, leftClickEvent);
-        expect(slowLink.textContent).toBe("Slow false");
-      });
-
-      it("children(false) when navigation is finished", done => {
-        const history = InMemory();
-        const routes = prepareRoutes([
-          { name: "Test", path: "test" },
-          {
-            name: "Loader",
-            path: "load",
-            resolve() {
-              return Promise.resolve("done");
-            }
-          },
-          { name: "Catch All", path: "(.*)" }
-        ]);
-        const router = curi(history, routes);
-        const Router = curiProvider(router);
-
-        ReactDOM.render(
-          <Router>
-            <Link name="Loader">
-              {navigating => {
-                return <div>{navigating.toString()}</div>;
-              }}
-            </Link>
-          </Router>,
-          node
-        );
-        const a = node.querySelector("a");
-        expect(a.textContent).toBe("false");
-        const leftClickEvent = {
-          defaultPrevented: false,
-          preventDefault() {
-            this.defaultPrevented = true;
-          },
-          metaKey: null,
-          altKey: null,
-          ctrlKey: null,
-          shiftKey: null,
-          button: 0
-        };
-        Simulate.click(a, leftClickEvent);
-        expect(a.textContent).toBe("true");
-        router.once(
-          ({ response }) => {
-            expect(response.name).toBe("Loader");
-            expect(a.textContent).toBe("false");
-            done();
-          },
-          { initial: false }
-        );
-      });
-
-      it("does not call setState if component has unmounted", done => {
-        const realError = console.error;
-        const mockError = jest.fn();
-        console.error = mockError;
-
-        const history = InMemory();
-        const routes = prepareRoutes([
-          { name: "Test", path: "test" },
-          {
-            name: "Slow",
-            path: "slow",
-            resolve() {
-              return new Promise(resolve => {
-                setTimeout(() => {
-                  resolve("Finally finished");
-                  setTimeout(() => {
-                    expect(mockError.mock.calls.length).toBe(0);
-                    console.error = realError;
-                    done();
-                  });
-                }, 100);
-              });
-            }
-          },
-          { name: "Catch All", path: "(.*)" }
-        ]);
-        const router = curi(history, routes);
-        const Router = curiProvider(router);
-
-        ReactDOM.render(
-          <Router>
-            <Link name="Slow">
-              {navigating => {
-                return <div>{navigating.toString()}</div>;
-              }}
-            </Link>
-          </Router>,
-          node
-        );
-        const a = node.querySelector("a");
-        expect(a.textContent).toBe("false");
-        const leftClickEvent = {
-          defaultPrevented: false,
-          preventDefault() {
-            this.defaultPrevented = true;
-          },
-          metaKey: null,
-          altKey: null,
-          ctrlKey: null,
-          shiftKey: null,
-          button: 0
-        };
-        Simulate.click(a, leftClickEvent);
-
-        // unmount the Link to verify that it doesn't call setState()
-        ReactDOM.unmountComponentAtNode(node);
-      });
-    });
-
-    it("includes hash, query, and state in location passed to history.navigate", () => {
-      const history = InMemory();
-      const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
-      const routes = prepareRoutes([
-        { name: "Test", path: "test" },
-        { name: "Catch All", path: "(.*)" }
-      ]);
-      const router = curi(history, routes);
-      const Router = curiProvider(router);
-
-      ReactDOM.render(
-        <Router>
-          <Link name="Test" hash="thing" query="one=1" state="yo">
-            Test
-          </Link>
-        </Router>,
-        node
-      );
-      const a = node.querySelector("a");
-      const leftClickEvent = {
-        defaultPrevented: false,
-        preventDefault() {
-          this.defaultPrevented = true;
-        },
-        metaKey: null,
-        altKey: null,
-        ctrlKey: null,
-        shiftKey: null,
-        button: 0
-      };
-      Simulate.click(a, leftClickEvent);
-      const mockLocation = mockNavigate.mock.calls[0][0];
-      expect(mockLocation).toMatchObject({
-        pathname: "/test",
-        hash: "thing",
-        query: "one=1",
-        state: "yo"
-      });
-    });
-
     describe("onNav", () => {
       it("calls onNav prop func if provided", () => {
         const history = InMemory();

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -5,7 +5,6 @@ import { Simulate } from "react-dom/test-utils";
 import InMemory from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, Link } from "@curi/react-dom";
 
 describe("<Link>", () => {

--- a/packages/react-dom/tests/NavLink.spec.tsx
+++ b/packages/react-dom/tests/NavLink.spec.tsx
@@ -1,0 +1,676 @@
+import "jest";
+import React from "react";
+import ReactDOM from "react-dom";
+import { Simulate } from "react-dom/test-utils";
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+
+// @ts-ignore (resolved by jest)
+import { curiProvider, NavLink } from "@curi/react-dom";
+
+describe("<NavLink>", () => {
+  let node;
+  let history, router, Router: React.FunctionComponent;
+  const routes = prepareRoutes([
+    { name: "Test", path: "" },
+    { name: "Best", path: "best" },
+    { name: "Catch All", path: "(.*)" }
+  ]);
+
+  beforeEach(() => {
+    node = document.createElement("div");
+    history = InMemory();
+    router = curi(history, routes);
+    Router = curiProvider(router);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  describe("anchor", () => {
+    it("renders an <a> by default", () => {
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test">{() => null}</NavLink>}
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      expect(a).toBeDefined();
+    });
+
+    it("renders the provided component instead of an anchor", () => {
+      const StyledAnchor = props => (
+        <a style={{ color: "orange" }} {...props} />
+      );
+      ReactDOM.render(
+        <Router>
+          <NavLink anchor={StyledAnchor} name="Test">
+            {() => null}
+          </NavLink>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      expect(a).toBeDefined();
+      expect(getComputedStyle(a).color).toBe("orange");
+    });
+  });
+
+  describe("href", () => {
+    describe("name", () => {
+      it("sets the href attribute using the named route's path", () => {
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Test">{() => null}</NavLink>}
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/");
+      });
+
+      it("creates a relative link if 'to' is undefined", () => {
+        const history = InMemory({
+          locations: ["/the-initial-location"]
+        });
+        const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+        ReactDOM.render(
+          <Router>
+            <NavLink name={null}>{() => null}</NavLink>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("");
+      });
+    });
+
+    describe("params", () => {
+      let history, router, Router;
+      const routes = prepareRoutes([
+        { name: "Park", path: "park/:name" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+
+      beforeEach(() => {
+        history = InMemory();
+        router = curi(history, routes);
+        Router = curiProvider(router);
+      });
+
+      it("uses params to generate the href", () => {
+        const params = { name: "Glacier" };
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Park" params={params}>
+              {() => null}
+            </NavLink>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/park/Glacier");
+      });
+
+      it("updates href when props change", () => {
+        const params = { name: "Glacier" };
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Park" params={params}>
+              {() => null}
+            </NavLink>
+          </Router>,
+          node
+        );
+        let a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/park/Glacier");
+
+        const newParams = { name: "Yellowstone" };
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Park" params={newParams}>
+              {() => null}
+            </NavLink>
+          </Router>,
+          node
+        );
+        a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/park/Yellowstone");
+      });
+    });
+
+    describe("hash & query", () => {
+      it("merges hash & query props with the pathname when creating href", () => {
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Test" query="one=two" hash="hashtag">
+              {() => null}
+            </NavLink>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.getAttribute("href")).toBe("/test?one=two#hashtag");
+      });
+    });
+  });
+
+  describe("forward", () => {
+    it("passes forward to the rendered anchor", () => {
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test" forward={{ className: "hi" }}>
+            {() => null}
+          </NavLink>
+        </Router>,
+        node
+      );
+
+      const a = node.querySelector("a");
+      expect(a.classList.contains("hi")).toBe(true);
+    });
+  });
+
+  describe("ref", () => {
+    it("returns the anchor's ref, not the link's", () => {
+      const history = InMemory();
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+      const ref = React.createRef();
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test" ref={ref}>
+            {() => null}
+          </NavLink>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      expect(a).toBe(ref.current);
+    });
+  });
+
+  describe("children", () => {
+    it("is called with the <NavLink>'s current navigating state (false on mount)", () => {
+      const history = InMemory();
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+      const children = jest.fn(() => null);
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test">{children}</NavLink>
+        </Router>,
+        node
+      );
+      expect(children.mock.calls.length).toBe(1);
+      expect(children.mock.calls[0][0]).toBe(false);
+    });
+  });
+
+  describe("clicking a link", () => {
+    it("calls history.navigate", () => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test">{() => null}</NavLink>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      const leftClickEvent = {
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+        metaKey: null,
+        altKey: null,
+        ctrlKey: null,
+        shiftKey: null,
+        button: 0
+      };
+      Simulate.click(a, leftClickEvent);
+      expect(mockNavigate.mock.calls.length).toBe(1);
+    });
+
+    describe("children(navigating)", () => {
+      it("children(true) after clicking", () => {
+        // if a link has no on methods, finished will be called almost
+        // immediately (although this style should only be used for routes
+        // with on methods)
+        const history = InMemory();
+        const routes = prepareRoutes([
+          {
+            name: "Test",
+            path: "test",
+            resolve() {
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("done");
+                }, 100);
+              });
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Test">
+              {navigating => {
+                return <div>{navigating.toString()}</div>;
+              }}
+            </NavLink>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.textContent).toBe("false");
+        const leftClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        Simulate.click(a, leftClickEvent);
+        expect(a.textContent).toBe("true");
+      });
+
+      it("children(false) when navigation is cancelled", () => {
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          {
+            name: "Slow",
+            path: "slow",
+            resolve() {
+              // takes 500ms to resolve
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("slow");
+                }, 500);
+              });
+            }
+          },
+          {
+            name: "Fast",
+            path: "fast"
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        ReactDOM.render(
+          <Router>
+            <React.Fragment>
+              <NavLink name="Slow">
+                {navigating => {
+                  return <div>Slow {navigating.toString()}</div>;
+                }}
+              </NavLink>
+              <NavLink name="Fast">
+                {navigating => {
+                  return <div>Fast {navigating.toString()}</div>;
+                }}
+              </NavLink>
+            </React.Fragment>
+          </Router>,
+          node
+        );
+        const [slowLink, fastLink] = node.querySelectorAll("a");
+        expect(slowLink.textContent).toBe("Slow false");
+        const leftClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        Simulate.click(slowLink, leftClickEvent);
+        expect(slowLink.textContent).toBe("Slow true");
+
+        Simulate.click(fastLink, leftClickEvent);
+        expect(slowLink.textContent).toBe("Slow false");
+      });
+
+      it("children(false) when navigation is finished", done => {
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          {
+            name: "Loader",
+            path: "load",
+            resolve() {
+              return Promise.resolve("done");
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Loader">
+              {navigating => {
+                return <div>{navigating.toString()}</div>;
+              }}
+            </NavLink>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.textContent).toBe("false");
+        const leftClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        Simulate.click(a, leftClickEvent);
+        expect(a.textContent).toBe("true");
+        router.once(
+          ({ response }) => {
+            expect(response.name).toBe("Loader");
+            expect(a.textContent).toBe("false");
+            done();
+          },
+          { initial: false }
+        );
+      });
+
+      it("does not try to update state if component has unmounted", done => {
+        const realError = console.error;
+        const mockError = jest.fn();
+        console.error = mockError;
+
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          {
+            name: "Slow",
+            path: "slow",
+            resolve() {
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("Finally finished");
+                  setTimeout(() => {
+                    expect(mockError.mock.calls.length).toBe(0);
+                    console.error = realError;
+                    done();
+                  });
+                }, 100);
+              });
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Slow">
+              {navigating => {
+                return <div>{navigating.toString()}</div>;
+              }}
+            </NavLink>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        expect(a.textContent).toBe("false");
+        const leftClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        Simulate.click(a, leftClickEvent);
+
+        // unmount the Link to verify that it doesn't call setState()
+        ReactDOM.unmountComponentAtNode(node);
+      });
+    });
+
+    it("includes hash, query, and state in location passed to history.navigate", () => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test" hash="thing" query="one=1" state="yo">
+            {() => null}
+          </NavLink>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      const leftClickEvent = {
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+        metaKey: null,
+        altKey: null,
+        ctrlKey: null,
+        shiftKey: null,
+        button: 0
+      };
+      Simulate.click(a, leftClickEvent);
+      const mockLocation = mockNavigate.mock.calls[0][0];
+      expect(mockLocation).toMatchObject({
+        pathname: "/test",
+        hash: "thing",
+        query: "one=1",
+        state: "yo"
+      });
+    });
+
+    describe("onNav", () => {
+      it("calls onNav prop func if provided", () => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
+        history.navigate = mockNavigate;
+        const onNav = jest.fn();
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Test" onNav={onNav}>
+              {() => null}
+            </NavLink>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        const leftClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        Simulate.click(a, leftClickEvent);
+        expect(onNav.mock.calls.length).toBe(1);
+        expect(mockNavigate.mock.calls.length).toBe(1);
+      });
+
+      it("does not call history.navigate if onNav prevents default", () => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
+        history.navigate = mockNavigate;
+        const onNav = jest.fn(event => {
+          event.preventDefault();
+        });
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Test" onNav={onNav}>
+              {() => null}
+            </NavLink>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        const leftClickEvent = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          metaKey: null,
+          altKey: null,
+          ctrlKey: null,
+          shiftKey: null,
+          button: 0
+        };
+        Simulate.click(a, leftClickEvent);
+        expect(onNav.mock.calls.length).toBe(1);
+        expect(mockNavigate.mock.calls.length).toBe(0);
+      });
+    });
+
+    it("doesn't call history.navigate for modified clicks", () => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test">{() => null}</NavLink>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      const modifiedClickEvent = {
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+        metaKey: null,
+        altKey: null,
+        ctrlKey: null,
+        shiftKey: null,
+        button: 0
+      };
+      const modifiers = ["metaKey", "altKey", "ctrlKey", "shiftKey"];
+      modifiers.forEach(m => {
+        const eventCopy = Object.assign({}, modifiedClickEvent);
+        eventCopy[m] = true;
+        Simulate.click(a, eventCopy);
+        expect(mockNavigate.mock.calls.length).toBe(0);
+      });
+    });
+
+    it("doesn't call history.navigate if event.preventDefault has been called", () => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test">{() => null}</NavLink>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      const preventedEvent = {
+        defaultPrevented: true,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+        metaKey: null,
+        altKey: null,
+        ctrlKey: null,
+        shiftKey: null,
+        button: 0
+      };
+      Simulate.click(a, preventedEvent);
+      expect(mockNavigate.mock.calls.length).toBe(0);
+    });
+  });
+});

--- a/packages/react-dom/tests/NavLink.spec.tsx
+++ b/packages/react-dom/tests/NavLink.spec.tsx
@@ -5,7 +5,6 @@ import { Simulate } from "react-dom/test-utils";
 import InMemory from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, NavLink } from "@curi/react-dom";
 
 describe("<NavLink>", () => {

--- a/packages/react-dom/types/Link.d.ts
+++ b/packages/react-dom/types/Link.d.ts
@@ -1,11 +1,16 @@
 import React from "react";
 import { RouteLocation } from "@curi/router";
 import { NavigatingChildren } from "@curi/react-universal";
-export interface LinkProps extends RouteLocation {
+export interface BaseLinkProps extends RouteLocation {
     onNav?: (e: React.MouseEvent<HTMLElement>) => void;
     anchor?: React.ReactType;
-    children: NavigatingChildren | React.ReactNode;
     forward?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
 }
-declare const HookLink: React.ForwardRefExoticComponent<LinkProps & React.RefAttributes<any>>;
-export default HookLink;
+export interface LinkProps extends BaseLinkProps {
+    children: React.ReactNode;
+}
+export interface NavLinkProps extends BaseLinkProps {
+    children: NavigatingChildren;
+}
+export declare const Link: React.ForwardRefExoticComponent<LinkProps & React.RefAttributes<any>>;
+export declare const NavLink: React.ForwardRefExoticComponent<NavLinkProps & React.RefAttributes<any>>;

--- a/packages/react-dom/types/index.d.ts
+++ b/packages/react-dom/types/index.d.ts
@@ -1,6 +1,6 @@
-export { LinkProps } from "./Link";
+export { LinkProps, NavLinkProps } from "./Link";
 export { FocusHookProps } from "./hooks/useNavigationFocus";
 import useNavigationFocus from "./hooks/useNavigationFocus";
-import Link from "./Link";
+import { Link, NavLink } from "./Link";
 export * from "@curi/react-universal";
-export { Link, useNavigationFocus };
+export { Link, NavLink, useNavigationFocus };

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 2353,
+    "bundled": 2303,
     "minified": 973,
     "gzipped": 466,
     "treeshaked": {
@@ -14,7 +14,7 @@
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 2653,
+    "bundled": 2603,
     "minified": 1213,
     "gzipped": 566
   }

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 1875,
-    "minified": 698,
-    "gzipped": 412,
+    "bundled": 2353,
+    "minified": 973,
+    "gzipped": 466,
     "treeshaked": {
       "rollup": {
-        "code": 546,
-        "import_statements": 132
+        "code": 757,
+        "import_statements": 166
       },
       "webpack": {
-        "code": 1631
+        "code": 1868
       }
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 2152,
-    "minified": 916,
-    "gzipped": 509
+    "bundled": 2653,
+    "minified": 1213,
+    "gzipped": 566
   }
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Split `Link` into `Link` (regular `children`) and `NavLink` (`children` is a render-invoked function).
+
 ## 2.0.0-alpha.1
 
 * Internal `Link` changes.

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -1,37 +1,65 @@
 import React from "react";
 import { TouchableHighlight } from "react-native";
-import { useNavigationHandler } from "@curi/react-universal";
+import {
+  useNavigationHandler,
+  useStatefulNavigationHandler
+} from "@curi/react-universal";
 
 import { GestureResponderEvent } from "react-native";
 import { RouteLocation } from "@curi/router";
 import { NavigatingChildren } from "@curi/react-universal";
 import { NavType } from "@hickory/root";
 
-export interface LinkProps extends RouteLocation {
+export interface BaseLinkProps extends RouteLocation {
   onNav?: (e: GestureResponderEvent) => void;
   anchor?: React.ReactType;
-  children: NavigatingChildren | React.ReactNode;
   forward?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
   method?: NavType;
+}
+
+export interface LinkProps extends BaseLinkProps {
+  children: React.ReactNode;
+}
+
+export interface NavLinkProps extends BaseLinkProps {
+  children: NavigatingChildren;
 }
 
 function canNavigate(event: GestureResponderEvent) {
   return !event.defaultPrevented;
 }
 
-const HookLink = React.forwardRef((props: LinkProps, ref: React.Ref<any>) => {
-  const { eventHandler, children } = useNavigationHandler<
-    GestureResponderEvent
-  >(props, canNavigate);
+export const Link = React.forwardRef(
+  (props: LinkProps, ref: React.Ref<any>) => {
+    const { eventHandler } = useNavigationHandler<GestureResponderEvent>(
+      props,
+      canNavigate
+    );
 
-  const { anchor: Anchor = TouchableHighlight, forward } = props;
+    const { anchor: Anchor = TouchableHighlight, forward, children } = props;
 
-  return (
-    // @ts-ignore
-    <Anchor onPress={eventHandler} ref={ref} {...forward}>
-      {children}
-    </Anchor>
-  );
-});
+    return (
+      // @ts-ignore
+      <Anchor onPress={eventHandler} ref={ref} {...forward}>
+        {children}
+      </Anchor>
+    );
+  }
+);
 
-export default HookLink;
+export const NavLink = React.forwardRef(
+  (props: NavLinkProps, ref: React.Ref<any>) => {
+    const { eventHandler, navigating } = useStatefulNavigationHandler<
+      GestureResponderEvent
+    >(props, canNavigate);
+
+    const { anchor: Anchor = TouchableHighlight, forward, children } = props;
+
+    return (
+      // @ts-ignore
+      <Anchor onPress={eventHandler} ref={ref} {...forward}>
+        {children(navigating)}
+      </Anchor>
+    );
+  }
+);

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -39,7 +39,6 @@ export const Link = React.forwardRef(
     const { anchor: Anchor = TouchableHighlight, forward, children } = props;
 
     return (
-      // @ts-ignore
       <Anchor onPress={eventHandler} ref={ref} {...forward}>
         {children}
       </Anchor>
@@ -56,7 +55,6 @@ export const NavLink = React.forwardRef(
     const { anchor: Anchor = TouchableHighlight, forward, children } = props;
 
     return (
-      // @ts-ignore
       <Anchor onPress={eventHandler} ref={ref} {...forward}>
         {children(navigating)}
       </Anchor>

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,7 +1,7 @@
-export { LinkProps } from "./Link";
+export { LinkProps, NavLinkProps } from "./Link";
 
 export * from "@curi/react-universal";
 
-import Link from "./Link";
+import { Link, NavLink } from "./Link";
 
-export { Link };
+export { Link, NavLink };

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -6,7 +6,6 @@ import InMemory from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 import { TouchableHighlight, Text } from "react-native";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, Link } from "@curi/react-native";
 
 import { NavType } from "@hickory/root";

--- a/packages/react-native/tests/NavLink.spec.tsx
+++ b/packages/react-native/tests/NavLink.spec.tsx
@@ -7,7 +7,7 @@ import { curi, prepareRoutes } from "@curi/router";
 import { TouchableHighlight, Text } from "react-native";
 
 // @ts-ignore (resolved by jest)
-import { curiProvider, Link } from "@curi/react-native";
+import { curiProvider, NavLink } from "@curi/react-native";
 
 import { NavType } from "@hickory/root";
 
@@ -22,7 +22,7 @@ function fakeEvent(props = {}) {
   };
 }
 
-describe("<Link>", () => {
+describe("<NavLink>", () => {
   describe("anchor", () => {
     it("renders a <TouchableHighlight> by default", () => {
       const history = InMemory();
@@ -34,9 +34,9 @@ describe("<Link>", () => {
       const Router = curiProvider(router);
       const tree = renderer.create(
         <Router>
-          <Link name="Test">
-            <Text>Test</Text>
-          </Link>
+          <NavLink name="Test">
+            {navigating => <Text>{navigating}</Text>}
+          </NavLink>
         </Router>
       );
       const anchor = tree.root.findByType(TouchableHighlight);
@@ -58,9 +58,9 @@ describe("<Link>", () => {
 
       const tree = renderer.create(
         <Router>
-          <Link name="Test" anchor={StyledAnchor}>
-            <Text>Test</Text>
-          </Link>
+          <NavLink name="Test" anchor={StyledAnchor}>
+            {navigating => <Text>{navigating}</Text>}
+          </NavLink>
         </Router>
       );
       const anchor = tree.root.find(StyledAnchor);
@@ -80,9 +80,9 @@ describe("<Link>", () => {
 
         const tree = renderer.create(
           <Router>
-            <Link name={null}>
-              <Text>Test</Text>
-            </Link>
+            <NavLink name={null}>
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -110,9 +110,9 @@ describe("<Link>", () => {
         const params = { name: "Glacier" };
         const tree = renderer.create(
           <Router>
-            <Link name="Park" params={params}>
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Park" params={params}>
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -131,9 +131,9 @@ describe("<Link>", () => {
         const params = { name: "Glacier" };
         const tree = renderer.create(
           <Router>
-            <Link name="Park" params={params}>
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Park" params={params}>
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -143,9 +143,9 @@ describe("<Link>", () => {
         const newParams = { name: "Yellowstone" };
         tree.update(
           <Router>
-            <Link name="Park" params={newParams}>
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Park" params={newParams}>
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         anchor.props.onPress(fakeEvent());
@@ -170,9 +170,9 @@ describe("<Link>", () => {
 
         const tree = renderer.create(
           <Router>
-            <Link name="Test" query="one=two" hash="hashtag">
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Test" query="one=two" hash="hashtag">
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
 
@@ -202,9 +202,9 @@ describe("<Link>", () => {
       const style = { backgroundColor: "red" };
       const tree = renderer.create(
         <Router>
-          <Link name="Test" forward={{ style }}>
-            <Text>Test</Text>
-          </Link>
+          <NavLink name="Test" forward={{ style }}>
+            {navigating => <Text>{navigating}</Text>}
+          </NavLink>
         </Router>
       );
       const anchor = tree.root.findByType(TouchableHighlight);
@@ -227,9 +227,9 @@ describe("<Link>", () => {
       const ref = React.createRef();
       const tree = renderer.create(
         <Router>
-          <Link name="Parks" ref={ref}>
-            <Text>Test</Text>
-          </Link>
+          <NavLink name="Parks" ref={ref}>
+            {navigating => <Text>{navigating}</Text>}
+          </NavLink>
         </Router>
       );
       const anchor = tree.root.findByType(TouchableHighlight);
@@ -238,7 +238,7 @@ describe("<Link>", () => {
   });
 
   describe("children", () => {
-    it("renders the provided children value(s)", () => {
+    it("is called with the <NavLink>'s current navigating state (false on mount)", () => {
       const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
@@ -247,18 +247,16 @@ describe("<Link>", () => {
       const router = curi(history, routes);
       const Router = curiProvider(router);
 
-      const children = "Test Value";
       const tree = renderer.create(
         <Router>
-          <Link name="Test">
-            <Text>{children}</Text>
-          </Link>
+          <NavLink name="Test">
+            {navigating => {
+              expect(navigating).toBe(false);
+              return <Text>Test</Text>;
+            }}
+          </NavLink>
         </Router>
       );
-      const anchor = tree.root.findByType(TouchableHighlight);
-      const text = anchor.findByType(Text);
-      expect(anchor).toBeDefined();
-      expect(text.instance.props.children).toBe(children);
     });
   });
 
@@ -281,9 +279,9 @@ describe("<Link>", () => {
 
         const tree = renderer.create(
           <Router>
-            <Link name="Test">
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Test">
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -301,9 +299,9 @@ describe("<Link>", () => {
 
         const tree = renderer.create(
           <Router>
-            <Link name="Test" method="ANCHOR">
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Test" method="ANCHOR">
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -321,9 +319,9 @@ describe("<Link>", () => {
 
         const tree = renderer.create(
           <Router>
-            <Link name="Test" method="PUSH">
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Test" method="PUSH">
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -341,9 +339,9 @@ describe("<Link>", () => {
 
         const tree = renderer.create(
           <Router>
-            <Link name="Test" method="REPLACE">
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Test" method="REPLACE">
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -361,14 +359,200 @@ describe("<Link>", () => {
 
         const tree = renderer.create(
           <Router>
-            <Link name="Test" method={"whatchamacallit" as NavType}>
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Test" method={"whatchamacallit" as NavType}>
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
         anchor.props.onPress(fakeEvent());
         expect(mockNavigate.mock.calls[0][1]).toBe("ANCHOR");
+      });
+    });
+
+    describe("children(navigating)", () => {
+      it("children(true) after clicking", () => {
+        // if a link has no on methods, finished will be called almost
+        // immediately (although this style should only be used for routes
+        // with resolve methods)
+        const history = InMemory();
+        const routes = prepareRoutes([
+          {
+            name: "Test",
+            path: "test",
+            resolve() {
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("done");
+                }, 100);
+              });
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        const tree = renderer.create(
+          <Router>
+            <NavLink name="Test">
+              {navigating => {
+                return <Text>{navigating.toString()}</Text>;
+              }}
+            </NavLink>
+          </Router>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        const text = anchor.findByType(Text);
+        expect(text.instance.props.children).toBe("false");
+
+        anchor.props.onPress(fakeEvent());
+
+        expect(text.instance.props.children).toBe("true");
+      });
+
+      it("children(false) when navigation is cancelled", () => {
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          {
+            name: "Slow",
+            path: "slow",
+            resolve() {
+              // takes 500ms to resolve
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("slow");
+                }, 500);
+              });
+            }
+          },
+          {
+            name: "Fast",
+            path: "fast"
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        const tree = renderer.create(
+          <Router>
+            <React.Fragment>
+              <NavLink name="Slow">
+                {navigating => {
+                  return <Text>{`Slow ${navigating.toString()}`}</Text>;
+                }}
+              </NavLink>
+              <NavLink name="Fast">
+                {navigating => {
+                  return <Text>{`Fast ${navigating.toString()}`}</Text>;
+                }}
+              </NavLink>
+            </React.Fragment>
+          </Router>
+        );
+        const [slowLink, fastLink] = tree.root.findAllByType(
+          TouchableHighlight
+        );
+
+        const text = slowLink.findByType(Text);
+
+        expect(text.instance.props.children).toBe("Slow false");
+
+        slowLink.props.onPress(fakeEvent());
+        expect(text.instance.props.children).toBe("Slow true");
+
+        fastLink.props.onPress(fakeEvent());
+        expect(text.instance.props.children).toBe("Slow false");
+      });
+
+      it("children(false) when navigation is finished", done => {
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          {
+            name: "Loader",
+            path: "load",
+            resolve() {
+              return Promise.resolve("done");
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        const tree = renderer.create(
+          <Router>
+            <NavLink name="Loader">
+              {navigating => {
+                return <Text>{navigating.toString()}</Text>;
+              }}
+            </NavLink>
+          </Router>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+        const text = anchor.findByType(Text);
+        expect(text.instance.props.children).toBe("false");
+
+        anchor.props.onPress(fakeEvent());
+        expect(text.instance.props.children).toBe("true");
+
+        router.once(
+          ({ response }) => {
+            expect(response.name).toBe("Loader");
+            expect(text.instance.props.children).toBe("false");
+            done();
+          },
+          { initial: false }
+        );
+      });
+
+      it("does not call setState if component has unmounted", done => {
+        const realError = console.error;
+        const mockError = jest.fn();
+        console.error = mockError;
+
+        const history = InMemory();
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          {
+            name: "Blork",
+            path: "blork",
+            resolve() {
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  resolve("Finally finished");
+                  // need to verify error in another timeout
+                  setTimeout(() => {
+                    expect(mockError.mock.calls.length).toBe(0);
+                    console.error = realError;
+                    done();
+                  });
+                }, 500);
+              });
+            }
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        const tree = renderer.create(
+          <Router>
+            <NavLink name="Blork">
+              {navigating => {
+                return <Text>{navigating.toString()}</Text>;
+              }}
+            </NavLink>
+          </Router>
+        );
+        const anchor = tree.root.findByType(TouchableHighlight);
+
+        anchor.props.onPress(fakeEvent());
+
+        tree.unmount();
       });
     });
 
@@ -388,9 +572,9 @@ describe("<Link>", () => {
 
         const tree = renderer.create(
           <Router>
-            <Link name="Test" onNav={onNav}>
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Test" onNav={onNav}>
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -417,9 +601,9 @@ describe("<Link>", () => {
 
         const tree = renderer.create(
           <Router>
-            <Link name="Test" onNav={onNav}>
-              <Text>Test</Text>
-            </Link>
+            <NavLink name="Test" onNav={onNav}>
+              {navigating => <Text>{navigating}</Text>}
+            </NavLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -443,9 +627,9 @@ describe("<Link>", () => {
 
       const tree = renderer.create(
         <Router>
-          <Link name="Test">
-            <Text>Test</Text>
-          </Link>
+          <NavLink name="Test">
+            {navigating => <Text>{navigating}</Text>}
+          </NavLink>
         </Router>
       );
       const anchor = tree.root.findByType(TouchableHighlight);

--- a/packages/react-native/tests/NavLink.spec.tsx
+++ b/packages/react-native/tests/NavLink.spec.tsx
@@ -6,7 +6,6 @@ import InMemory from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 import { TouchableHighlight, Text } from "react-native";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, NavLink } from "@curi/react-native";
 
 import { NavType } from "@hickory/root";

--- a/packages/react-native/types/Link.d.ts
+++ b/packages/react-native/types/Link.d.ts
@@ -3,12 +3,17 @@ import { GestureResponderEvent } from "react-native";
 import { RouteLocation } from "@curi/router";
 import { NavigatingChildren } from "@curi/react-universal";
 import { NavType } from "@hickory/root";
-export interface LinkProps extends RouteLocation {
+export interface BaseLinkProps extends RouteLocation {
     onNav?: (e: GestureResponderEvent) => void;
     anchor?: React.ReactType;
-    children: NavigatingChildren | React.ReactNode;
     forward?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
     method?: NavType;
 }
-declare const HookLink: React.ForwardRefExoticComponent<LinkProps & React.RefAttributes<any>>;
-export default HookLink;
+export interface LinkProps extends BaseLinkProps {
+    children: React.ReactNode;
+}
+export interface NavLinkProps extends BaseLinkProps {
+    children: NavigatingChildren;
+}
+export declare const Link: React.ForwardRefExoticComponent<LinkProps & React.RefAttributes<any>>;
+export declare const NavLink: React.ForwardRefExoticComponent<NavLinkProps & React.RefAttributes<any>>;

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -1,4 +1,4 @@
-export { LinkProps } from "./Link";
+export { LinkProps, NavLinkProps } from "./Link";
 export * from "@curi/react-universal";
-import Link from "./Link";
-export { Link };
+import { Link, NavLink } from "./Link";
+export { Link, NavLink };

--- a/packages/react-universal/.size-snapshot.json
+++ b/packages/react-universal/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-universal.es.js": {
-    "bundled": 5190,
-    "minified": 2612,
-    "gzipped": 1054,
+    "bundled": 5678,
+    "minified": 2837,
+    "gzipped": 1065,
     "treeshaked": {
       "rollup": {
         "code": 110,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-react-universal.js": {
-    "bundled": 5587,
-    "minified": 2946,
-    "gzipped": 1160
+    "bundled": 6114,
+    "minified": 3208,
+    "gzipped": 1180
   },
   "dist/curi-react-universal.umd.js": {
-    "bundled": 6162,
-    "minified": 2668,
-    "gzipped": 1177
+    "bundled": 6727,
+    "minified": 2844,
+    "gzipped": 1205
   },
   "dist/curi-react-universal.min.js": {
-    "bundled": 6152,
-    "minified": 2658,
-    "gzipped": 1162
+    "bundled": 6717,
+    "minified": 2834,
+    "gzipped": 1191
   }
 }

--- a/packages/react-universal/CHANGELOG.md
+++ b/packages/react-universal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Split `useNavigationHandler` into `useNavigationHandler` and `useStatefulNavigationHandler`. The latter is for tracking the component's `navigating` state.
+
 ## 2.0.0-alpha.1
 
 * Internal `useNavigationHandler` changes.

--- a/packages/react-universal/src/hooks/useNavigationHandler.ts
+++ b/packages/react-universal/src/hooks/useNavigationHandler.ts
@@ -7,8 +7,16 @@ import { NavType } from "@hickory/root";
 
 export type NavigatingChildren = (navigating: boolean) => ReactNode;
 
-export interface NavigationHookProps<T> extends RouteLocation {
-  children: NavigatingChildren | React.ReactNode;
+export interface NavigationHookProps<T> extends BaseNavigationHookProps<T> {
+  children: React.ReactNode;
+}
+
+export interface StatefulNavigationHookProps<T>
+  extends BaseNavigationHookProps<T> {
+  children: NavigatingChildren;
+}
+
+export interface BaseNavigationHookProps<T> extends RouteLocation {
   onNav?: (e: T) => void;
   forward?: object;
   method?: NavType;
@@ -20,15 +28,45 @@ function defaultCanNavigate() {
 
 export type CanNavigate<T> = (e: T, forward?: object) => boolean;
 
-export default function useNavigationHandler<
+export function useNavigationHandler<T extends React.BaseSyntheticEvent>(
+  props: NavigationHookProps<T>,
+  canNavigate: CanNavigate<T> = defaultCanNavigate
+) {
+  const { router } = useCuri();
+
+  function eventHandler(event: T) {
+    if (props.onNav) {
+      props.onNav(event);
+    }
+
+    if (canNavigate(event, props.forward)) {
+      event.preventDefault();
+
+      router.navigate({
+        method: props.method || "ANCHOR",
+        name: props.name,
+        params: props.params,
+        query: props.query,
+        state: props.state,
+        hash: props.hash
+      });
+    }
+  }
+  return {
+    eventHandler
+  };
+}
+
+export function useStatefulNavigationHandler<
   T extends React.BaseSyntheticEvent
 >(
-  props: NavigationHookProps<T>,
+  props: StatefulNavigationHookProps<T>,
   canNavigate: CanNavigate<T> = defaultCanNavigate
 ) {
   const { router } = useCuri();
   const cancel = React.useRef(undefined);
   const [navigating, setNavigating] = React.useState(false);
+
   React.useEffect(() => {
     return () => {
       if (cancel.current) {
@@ -45,15 +83,12 @@ export default function useNavigationHandler<
     if (canNavigate(event, props.forward)) {
       event.preventDefault();
 
-      let cancelled, finished;
       // only trigger re-renders when children uses state
-      if (typeof props.children === "function") {
-        cancelled = finished = () => {
-          cancel.current = undefined;
-          setNavigating(false);
-        };
-        setNavigating(true);
-      }
+      const done = () => {
+        cancel.current = undefined;
+        setNavigating(false);
+      };
+      setNavigating(true);
 
       cancel.current = router.navigate({
         method: props.method || "ANCHOR",
@@ -62,16 +97,14 @@ export default function useNavigationHandler<
         query: props.query,
         state: props.state,
         hash: props.hash,
-        cancelled,
-        finished
+        cancelled: done,
+        finished: done
       });
     }
   }
+
   return {
     eventHandler,
-    children:
-      typeof props.children === "function"
-        ? (props.children as NavigatingChildren)(navigating)
-        : props.children
+    navigating
   };
 }

--- a/packages/react-universal/src/index.ts
+++ b/packages/react-universal/src/index.ts
@@ -11,7 +11,10 @@ import useBlock from "./hooks/useBlock";
 import useLocation from "./hooks/useLocation";
 import useHref from "./hooks/useHref";
 import useNavigating from "./hooks/useNavigating";
-import useNavigationHandler from "./hooks/useNavigationHandler";
+import {
+  useStatefulNavigationHandler,
+  useNavigationHandler
+} from "./hooks/useNavigationHandler";
 
 export {
   curiProvider,
@@ -22,5 +25,6 @@ export {
   useLocation,
   useHref,
   useNavigating,
+  useStatefulNavigationHandler,
   useNavigationHandler
 };

--- a/packages/react-universal/tests/useNavigationHandler.spec.tsx
+++ b/packages/react-universal/tests/useNavigationHandler.spec.tsx
@@ -1,0 +1,164 @@
+import "jest";
+import React from "react";
+import ReactDOM from "react-dom";
+import { Simulate } from "react-dom/test-utils";
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+
+// @ts-ignore (resolved by jest)
+import { curiProvider, useNavigationHandler } from "@curi/react-universal";
+
+function createClick(opts?: {}) {
+  return {
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    metaKey: null,
+    altKey: null,
+    ctrlKey: null,
+    shiftKey: null,
+    button: 0,
+    ...opts
+  };
+}
+
+describe("useNavigationHandler", () => {
+  let node;
+  let history, router, Router: React.FunctionComponent;
+  const routes = prepareRoutes([
+    { name: "Test", path: "" },
+    { name: "Best", path: "best" },
+    { name: "Catch All", path: "(.*)" }
+  ]);
+
+  beforeEach(() => {
+    node = document.createElement("div");
+    history = InMemory();
+    router = curi(history, routes);
+    Router = curiProvider(router);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  describe("event handler", () => {
+    it("it uses nav props (name, params, hash, query, and state) to generate nav location", () => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      function Link(props) {
+        const { eventHandler } = useNavigationHandler(props);
+        return (
+          <a href="#" onClick={eventHandler}>
+            {props.children}
+          </a>
+        );
+      }
+
+      ReactDOM.render(
+        <Router>
+          <Link name="Test" hash="thing" query="one=1" state="yo">
+            Test
+          </Link>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      const leftClickEvent = createClick();
+      Simulate.click(a, leftClickEvent);
+      const mockLocation = mockNavigate.mock.calls[0][0];
+      expect(mockLocation).toMatchObject({
+        pathname: "/test",
+        hash: "thing",
+        query: "one=1",
+        state: "yo"
+      });
+    });
+
+    it("calls onNav prop func if provided", () => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+      const onNav = jest.fn();
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      function Link(props) {
+        const { eventHandler } = useNavigationHandler(props);
+        return (
+          <a href="#" onClick={eventHandler}>
+            {props.children}
+          </a>
+        );
+      }
+
+      ReactDOM.render(
+        <Router>
+          <Link name="Test" onNav={onNav}>
+            Test
+          </Link>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      const leftClickEvent = createClick();
+      Simulate.click(a, leftClickEvent);
+      expect(onNav.mock.calls.length).toBe(1);
+      expect(mockNavigate.mock.calls.length).toBe(1);
+    });
+
+    describe("canNavigate", () => {
+      function canNavigate() {
+        return false;
+      }
+
+      it("does not call history.navigate if canNavigate returns false", () => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
+        history.navigate = mockNavigate;
+
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        function Link(props) {
+          const { eventHandler } = useNavigationHandler(props, canNavigate);
+          return (
+            <a href="#" onClick={eventHandler}>
+              {props.children}
+            </a>
+          );
+        }
+
+        ReactDOM.render(
+          <Router>
+            <Link name="Test">Test</Link>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        const leftClickEvent = createClick();
+
+        Simulate.click(a, leftClickEvent);
+
+        expect(mockNavigate.mock.calls.length).toBe(0);
+      });
+    });
+  });
+});

--- a/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
+++ b/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
@@ -1,0 +1,312 @@
+import "jest";
+import React from "react";
+import ReactDOM from "react-dom";
+import { Simulate } from "react-dom/test-utils";
+import InMemory from "@hickory/in-memory";
+import { curi, prepareRoutes } from "@curi/router";
+
+import wait from "./utils/wait";
+
+// @ts-ignore (resolved by jest)
+import {
+  curiProvider,
+  useStatefulNavigationHandler
+} from "@curi/react-universal";
+
+function createClick(opts?: {}) {
+  return {
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    metaKey: null,
+    altKey: null,
+    ctrlKey: null,
+    shiftKey: null,
+    button: 0,
+    ...opts
+  };
+}
+
+describe("useStatefulNavigationHandler", () => {
+  let node;
+  let history, router, Router: React.FunctionComponent;
+  const routes = prepareRoutes([
+    { name: "Test", path: "" },
+    { name: "Best", path: "best" },
+    { name: "Catch All", path: "(.*)" }
+  ]);
+
+  beforeEach(() => {
+    node = document.createElement("div");
+    history = InMemory();
+    router = curi(history, routes);
+    Router = curiProvider(router);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  describe("event handler", () => {
+    it("it uses nav props (name, params, hash, query, and state) to generate nav location", () => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      function NavLink(props) {
+        const { eventHandler, navigating } = useStatefulNavigationHandler(
+          props
+        );
+        return (
+          <a href="#" onClick={eventHandler}>
+            {props.children(navigating)}
+          </a>
+        );
+      }
+
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test" hash="thing" query="one=1" state="yo">
+            {() => null}
+          </NavLink>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      const leftClickEvent = createClick();
+      Simulate.click(a, leftClickEvent);
+      const mockLocation = mockNavigate.mock.calls[0][0];
+      expect(mockLocation).toMatchObject({
+        pathname: "/test",
+        hash: "thing",
+        query: "one=1",
+        state: "yo"
+      });
+    });
+
+    it("calls onNav prop func if provided", () => {
+      const history = InMemory();
+      const mockNavigate = jest.fn();
+      history.navigate = mockNavigate;
+      const onNav = jest.fn();
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      function NavLink(props) {
+        const { eventHandler, navigating } = useStatefulNavigationHandler(
+          props
+        );
+        return (
+          <a href="#" onClick={eventHandler}>
+            {props.children(navigating)}
+          </a>
+        );
+      }
+
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test" onNav={onNav}>
+            {() => null}
+          </NavLink>
+        </Router>,
+        node
+      );
+      const a = node.querySelector("a");
+      const leftClickEvent = createClick();
+      Simulate.click(a, leftClickEvent);
+      expect(onNav.mock.calls.length).toBe(1);
+      expect(mockNavigate.mock.calls.length).toBe(1);
+    });
+
+    describe("canNavigate", () => {
+      function canNavigate() {
+        return false;
+      }
+
+      it("does not call history.navigate if canNavigate returns false", () => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
+        history.navigate = mockNavigate;
+
+        const routes = prepareRoutes([
+          { name: "Test", path: "test" },
+          { name: "Catch All", path: "(.*)" }
+        ]);
+        const router = curi(history, routes);
+        const Router = curiProvider(router);
+
+        function NavLink(props) {
+          const { eventHandler, navigating } = useStatefulNavigationHandler(
+            props,
+            canNavigate
+          );
+          return (
+            <a href="#" onClick={eventHandler}>
+              {props.children(navigating)}
+            </a>
+          );
+        }
+
+        ReactDOM.render(
+          <Router>
+            <NavLink name="Test">{() => null}</NavLink>
+          </Router>,
+          node
+        );
+        const a = node.querySelector("a");
+        const leftClickEvent = createClick();
+
+        Simulate.click(a, leftClickEvent);
+
+        expect(mockNavigate.mock.calls.length).toBe(0);
+      });
+    });
+  });
+
+  describe("navigating", () => {
+    it("is false on initial render", () => {
+      const history = InMemory();
+
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      function NavLink(props) {
+        const { eventHandler, navigating } = useStatefulNavigationHandler(
+          props
+        );
+        expect(navigating).toBe(false);
+        return (
+          <a href="#" onClick={eventHandler}>
+            {props.children(navigating)}
+          </a>
+        );
+      }
+
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Test">{navigating => navigating.toString()}</NavLink>
+        </Router>,
+        node
+      );
+    });
+
+    it("is true when navigation starts", () => {
+      const history = InMemory();
+
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        {
+          name: "Slow",
+          path: "slow",
+          resolve() {
+            // takes 100ms to resolve
+            return new Promise(resolve => {
+              setTimeout(() => {
+                resolve("slow");
+              }, 100);
+            });
+          }
+        },
+        {
+          name: "Fast",
+          path: "fast"
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      function NavLink(props) {
+        const { eventHandler, navigating } = useStatefulNavigationHandler(
+          props
+        );
+        return <a onClick={eventHandler}>{props.children(navigating)}</a>;
+      }
+
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Slow">{navigating => navigating.toString()}</NavLink>
+        </Router>,
+        node
+      );
+
+      const a = node.querySelector("a");
+
+      expect(a.textContent).toBe("false");
+
+      const leftClickEvent = createClick();
+      Simulate.click(a, leftClickEvent);
+
+      expect(a.textContent).toBe("true");
+    });
+
+    it("is false when navigation finishes", async () => {
+      const history = InMemory();
+
+      const routes = prepareRoutes([
+        { name: "Test", path: "test" },
+        {
+          name: "Slow",
+          path: "slow",
+          resolve() {
+            // takes 50ms to resolve
+            return new Promise(resolve => {
+              setTimeout(() => {
+                resolve("slow");
+              }, 50);
+            });
+          }
+        },
+        {
+          name: "Fast",
+          path: "fast"
+        },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = curi(history, routes);
+      const Router = curiProvider(router);
+
+      function NavLink(props) {
+        const { eventHandler, navigating } = useStatefulNavigationHandler(
+          props
+        );
+        return <a onClick={eventHandler}>{props.children(navigating)}</a>;
+      }
+
+      ReactDOM.render(
+        <Router>
+          <NavLink name="Slow">{navigating => navigating.toString()}</NavLink>
+        </Router>,
+        node
+      );
+
+      const a = node.querySelector("a");
+
+      expect(a.textContent).toBe("false");
+
+      const leftClickEvent = createClick();
+      Simulate.click(a, leftClickEvent);
+
+      expect(a.textContent).toBe("true");
+
+      await wait(100);
+
+      expect(a.textContent).toBe("false");
+    });
+  });
+});

--- a/packages/react-universal/types/hooks/useNavigationHandler.d.ts
+++ b/packages/react-universal/types/hooks/useNavigationHandler.d.ts
@@ -3,14 +3,22 @@ import { ReactNode } from "react";
 import { RouteLocation } from "@curi/router";
 import { NavType } from "@hickory/root";
 export declare type NavigatingChildren = (navigating: boolean) => ReactNode;
-export interface NavigationHookProps<T> extends RouteLocation {
-    children: NavigatingChildren | React.ReactNode;
+export interface NavigationHookProps<T> extends BaseNavigationHookProps<T> {
+    children: React.ReactNode;
+}
+export interface StatefulNavigationHookProps<T> extends BaseNavigationHookProps<T> {
+    children: NavigatingChildren;
+}
+export interface BaseNavigationHookProps<T> extends RouteLocation {
     onNav?: (e: T) => void;
     forward?: object;
     method?: NavType;
 }
 export declare type CanNavigate<T> = (e: T, forward?: object) => boolean;
-export default function useNavigationHandler<T extends React.BaseSyntheticEvent>(props: NavigationHookProps<T>, canNavigate?: CanNavigate<T>): {
+export declare function useNavigationHandler<T extends React.BaseSyntheticEvent>(props: NavigationHookProps<T>, canNavigate?: CanNavigate<T>): {
     eventHandler: (event: T) => void;
-    children: {};
+};
+export declare function useStatefulNavigationHandler<T extends React.BaseSyntheticEvent>(props: StatefulNavigationHookProps<T>, canNavigate?: CanNavigate<T>): {
+    eventHandler: (event: T) => void;
+    navigating: boolean;
 };

--- a/packages/react-universal/types/index.d.ts
+++ b/packages/react-universal/types/index.d.ts
@@ -9,5 +9,5 @@ import useBlock from "./hooks/useBlock";
 import useLocation from "./hooks/useLocation";
 import useHref from "./hooks/useHref";
 import useNavigating from "./hooks/useNavigating";
-import useNavigationHandler from "./hooks/useNavigationHandler";
-export { curiProvider, Curious, useCuri, useActive, useBlock, useLocation, useHref, useNavigating, useNavigationHandler };
+import { useStatefulNavigationHandler, useNavigationHandler } from "./hooks/useNavigationHandler";
+export { curiProvider, Curious, useCuri, useActive, useBlock, useLocation, useHref, useNavigating, useStatefulNavigationHandler, useNavigationHandler };


### PR DESCRIPTION
The `useNavigationHandler` hook is split into two hooks: `useNavigationHandler`, which does not track navigating state and `useStatefulNavigationHandler`, which tracks navigating state.

The `Link` uses `useNavigationHandler` and expects its `children` prop to be a valid React node.

The `NavLink` uses `useStatefulNavigationhandler` and expects its `children` prop to be a function that receives the component's `navigating` state.

Both the `@curi/react-dom` and `@curi/react-native` packages export `Link` and `NavLink`.

```jsx
<Link name="Test">Test</Link>

<NavLink name="Test">
  {navigating => (
    <div>{navigating ? "Is Navigating" : "Not Navigating"}</div>
  )}
</NavLink>
```

The `NavLink` is only useful for asynchronous routes. If a route has no `resolve` method, there is no reason to display that it is navigating.