### PR TITLE
Rename NavLink to AsyncLink

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 3769,
-    "minified": 1774,
-    "gzipped": 862,
+    "bundled": 3773,
+    "minified": 1778,
+    "gzipped": 863,
     "treeshaked": {
       "rollup": {
         "code": 827,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 4109,
-    "minified": 2059,
-    "gzipped": 959
+    "bundled": 4115,
+    "minified": 2065,
+    "gzipped": 961
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 10993,
-    "minified": 4273,
-    "gzipped": 1793
+    "bundled": 10999,
+    "minified": 4275,
+    "gzipped": 1795
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 10963,
-    "minified": 4243,
-    "gzipped": 1779
+    "bundled": 10969,
+    "minified": 4245,
+    "gzipped": 1781
   }
 }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Split `Link` into `Link` (regular `children`) and `NavLink` (`children` is a render-invoked function).
+* Split `Link` into `Link` (regular `children`) and `AsyncLink` (`children` is a render-invoked function).
 
 ## 2.0.0-alpha.1
 

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -19,7 +19,7 @@ export interface LinkProps extends BaseLinkProps {
   children: React.ReactNode;
 }
 
-export interface NavLinkProps extends BaseLinkProps {
+export interface AsyncLinkProps extends BaseLinkProps {
   children: NavigatingChildren;
 }
 
@@ -41,8 +41,8 @@ export const Link = React.forwardRef(
   }
 );
 
-export const NavLink = React.forwardRef(
-  (props: NavLinkProps, ref: React.Ref<any>) => {
+export const AsyncLink = React.forwardRef(
+  (props: AsyncLinkProps, ref: React.Ref<any>) => {
     const href = useHref(props);
 
     const { eventHandler, navigating } = useStatefulNavigationHandler<

--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -1,8 +1,8 @@
-export { LinkProps, NavLinkProps } from "./Link";
+export { LinkProps, AsyncLinkProps } from "./Link";
 export { FocusHookProps } from "./hooks/useNavigationFocus";
 
 import useNavigationFocus from "./hooks/useNavigationFocus";
-import { Link, NavLink } from "./Link";
+import { Link, AsyncLink } from "./Link";
 
 export * from "@curi/react-universal";
-export { Link, NavLink, useNavigationFocus };
+export { Link, AsyncLink, useNavigationFocus };

--- a/packages/react-dom/tests/AsyncLink.spec.tsx
+++ b/packages/react-dom/tests/AsyncLink.spec.tsx
@@ -5,9 +5,9 @@ import { Simulate } from "react-dom/test-utils";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-import { curiProvider, NavLink } from "@curi/react-dom";
+import { curiProvider, AsyncLink } from "@curi/react-dom";
 
-describe("<NavLink>", () => {
+describe("<AsyncLink>", () => {
   let node;
   let history, router, Router: React.FunctionComponent;
   const routes = prepareRoutes([
@@ -31,7 +31,7 @@ describe("<NavLink>", () => {
     it("renders an <a> by default", () => {
       ReactDOM.render(
         <Router>
-          <NavLink name="Test">{() => null}</NavLink>}
+          <AsyncLink name="Test">{() => null}</AsyncLink>}
         </Router>,
         node
       );
@@ -45,9 +45,9 @@ describe("<NavLink>", () => {
       );
       ReactDOM.render(
         <Router>
-          <NavLink anchor={StyledAnchor} name="Test">
+          <AsyncLink anchor={StyledAnchor} name="Test">
             {() => null}
-          </NavLink>
+          </AsyncLink>
         </Router>,
         node
       );
@@ -62,7 +62,7 @@ describe("<NavLink>", () => {
       it("sets the href attribute using the named route's path", () => {
         ReactDOM.render(
           <Router>
-            <NavLink name="Test">{() => null}</NavLink>}
+            <AsyncLink name="Test">{() => null}</AsyncLink>}
           </Router>,
           node
         );
@@ -79,7 +79,7 @@ describe("<NavLink>", () => {
         const Router = curiProvider(router);
         ReactDOM.render(
           <Router>
-            <NavLink name={null}>{() => null}</NavLink>
+            <AsyncLink name={null}>{() => null}</AsyncLink>
           </Router>,
           node
         );
@@ -105,9 +105,9 @@ describe("<NavLink>", () => {
         const params = { name: "Glacier" };
         ReactDOM.render(
           <Router>
-            <NavLink name="Park" params={params}>
+            <AsyncLink name="Park" params={params}>
               {() => null}
-            </NavLink>
+            </AsyncLink>
           </Router>,
           node
         );
@@ -119,9 +119,9 @@ describe("<NavLink>", () => {
         const params = { name: "Glacier" };
         ReactDOM.render(
           <Router>
-            <NavLink name="Park" params={params}>
+            <AsyncLink name="Park" params={params}>
               {() => null}
-            </NavLink>
+            </AsyncLink>
           </Router>,
           node
         );
@@ -131,9 +131,9 @@ describe("<NavLink>", () => {
         const newParams = { name: "Yellowstone" };
         ReactDOM.render(
           <Router>
-            <NavLink name="Park" params={newParams}>
+            <AsyncLink name="Park" params={newParams}>
               {() => null}
-            </NavLink>
+            </AsyncLink>
           </Router>,
           node
         );
@@ -153,9 +153,9 @@ describe("<NavLink>", () => {
         const Router = curiProvider(router);
         ReactDOM.render(
           <Router>
-            <NavLink name="Test" query="one=two" hash="hashtag">
+            <AsyncLink name="Test" query="one=two" hash="hashtag">
               {() => null}
-            </NavLink>
+            </AsyncLink>
           </Router>,
           node
         );
@@ -169,9 +169,9 @@ describe("<NavLink>", () => {
     it("passes forward to the rendered anchor", () => {
       ReactDOM.render(
         <Router>
-          <NavLink name="Test" forward={{ className: "hi" }}>
+          <AsyncLink name="Test" forward={{ className: "hi" }}>
             {() => null}
-          </NavLink>
+          </AsyncLink>
         </Router>,
         node
       );
@@ -193,9 +193,9 @@ describe("<NavLink>", () => {
       const ref = React.createRef();
       ReactDOM.render(
         <Router>
-          <NavLink name="Test" ref={ref}>
+          <AsyncLink name="Test" ref={ref}>
             {() => null}
-          </NavLink>
+          </AsyncLink>
         </Router>,
         node
       );
@@ -205,7 +205,7 @@ describe("<NavLink>", () => {
   });
 
   describe("children", () => {
-    it("is called with the <NavLink>'s current navigating state (false on mount)", () => {
+    it("is called with the <AsyncLink>'s current navigating state (false on mount)", () => {
       const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
@@ -216,7 +216,7 @@ describe("<NavLink>", () => {
       const children = jest.fn(() => null);
       ReactDOM.render(
         <Router>
-          <NavLink name="Test">{children}</NavLink>
+          <AsyncLink name="Test">{children}</AsyncLink>
         </Router>,
         node
       );
@@ -238,7 +238,7 @@ describe("<NavLink>", () => {
       const Router = curiProvider(router);
       ReactDOM.render(
         <Router>
-          <NavLink name="Test">{() => null}</NavLink>
+          <AsyncLink name="Test">{() => null}</AsyncLink>
         </Router>,
         node
       );
@@ -283,11 +283,11 @@ describe("<NavLink>", () => {
 
         ReactDOM.render(
           <Router>
-            <NavLink name="Test">
+            <AsyncLink name="Test">
               {navigating => {
                 return <div>{navigating.toString()}</div>;
               }}
-            </NavLink>
+            </AsyncLink>
           </Router>,
           node
         );
@@ -336,16 +336,16 @@ describe("<NavLink>", () => {
         ReactDOM.render(
           <Router>
             <React.Fragment>
-              <NavLink name="Slow">
+              <AsyncLink name="Slow">
                 {navigating => {
                   return <div>Slow {navigating.toString()}</div>;
                 }}
-              </NavLink>
-              <NavLink name="Fast">
+              </AsyncLink>
+              <AsyncLink name="Fast">
                 {navigating => {
                   return <div>Fast {navigating.toString()}</div>;
                 }}
-              </NavLink>
+              </AsyncLink>
             </React.Fragment>
           </Router>,
           node
@@ -388,11 +388,11 @@ describe("<NavLink>", () => {
 
         ReactDOM.render(
           <Router>
-            <NavLink name="Loader">
+            <AsyncLink name="Loader">
               {navigating => {
                 return <div>{navigating.toString()}</div>;
               }}
-            </NavLink>
+            </AsyncLink>
           </Router>,
           node
         );
@@ -452,11 +452,11 @@ describe("<NavLink>", () => {
 
         ReactDOM.render(
           <Router>
-            <NavLink name="Slow">
+            <AsyncLink name="Slow">
               {navigating => {
                 return <div>{navigating.toString()}</div>;
               }}
-            </NavLink>
+            </AsyncLink>
           </Router>,
           node
         );
@@ -493,9 +493,9 @@ describe("<NavLink>", () => {
 
       ReactDOM.render(
         <Router>
-          <NavLink name="Test" hash="thing" query="one=1" state="yo">
+          <AsyncLink name="Test" hash="thing" query="one=1" state="yo">
             {() => null}
-          </NavLink>
+          </AsyncLink>
         </Router>,
         node
       );
@@ -536,9 +536,9 @@ describe("<NavLink>", () => {
 
         ReactDOM.render(
           <Router>
-            <NavLink name="Test" onNav={onNav}>
+            <AsyncLink name="Test" onNav={onNav}>
               {() => null}
-            </NavLink>
+            </AsyncLink>
           </Router>,
           node
         );
@@ -575,9 +575,9 @@ describe("<NavLink>", () => {
 
         ReactDOM.render(
           <Router>
-            <NavLink name="Test" onNav={onNav}>
+            <AsyncLink name="Test" onNav={onNav}>
               {() => null}
-            </NavLink>
+            </AsyncLink>
           </Router>,
           node
         );
@@ -613,7 +613,7 @@ describe("<NavLink>", () => {
 
       ReactDOM.render(
         <Router>
-          <NavLink name="Test">{() => null}</NavLink>
+          <AsyncLink name="Test">{() => null}</AsyncLink>
         </Router>,
         node
       );
@@ -652,7 +652,7 @@ describe("<NavLink>", () => {
 
       ReactDOM.render(
         <Router>
-          <NavLink name="Test">{() => null}</NavLink>
+          <AsyncLink name="Test">{() => null}</AsyncLink>
         </Router>,
         node
       );

--- a/packages/react-dom/types/Link.d.ts
+++ b/packages/react-dom/types/Link.d.ts
@@ -9,8 +9,8 @@ export interface BaseLinkProps extends RouteLocation {
 export interface LinkProps extends BaseLinkProps {
     children: React.ReactNode;
 }
-export interface NavLinkProps extends BaseLinkProps {
+export interface AsyncLinkProps extends BaseLinkProps {
     children: NavigatingChildren;
 }
 export declare const Link: React.ForwardRefExoticComponent<LinkProps & React.RefAttributes<any>>;
-export declare const NavLink: React.ForwardRefExoticComponent<NavLinkProps & React.RefAttributes<any>>;
+export declare const AsyncLink: React.ForwardRefExoticComponent<AsyncLinkProps & React.RefAttributes<any>>;

--- a/packages/react-dom/types/index.d.ts
+++ b/packages/react-dom/types/index.d.ts
@@ -1,6 +1,6 @@
-export { LinkProps, NavLinkProps } from "./Link";
+export { LinkProps, AsyncLinkProps } from "./Link";
 export { FocusHookProps } from "./hooks/useNavigationFocus";
 import useNavigationFocus from "./hooks/useNavigationFocus";
-import { Link, NavLink } from "./Link";
+import { Link, AsyncLink } from "./Link";
 export * from "@curi/react-universal";
-export { Link, NavLink, useNavigationFocus };
+export { Link, AsyncLink, useNavigationFocus };

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 2303,
-    "minified": 973,
-    "gzipped": 466,
+    "bundled": 2307,
+    "minified": 977,
+    "gzipped": 470,
     "treeshaked": {
       "rollup": {
         "code": 757,
@@ -14,8 +14,8 @@
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 2603,
-    "minified": 1213,
-    "gzipped": 566
+    "bundled": 2609,
+    "minified": 1219,
+    "gzipped": 568
   }
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Split `Link` into `Link` (regular `children`) and `NavLink` (`children` is a render-invoked function).
+* Split `Link` into `Link` (regular `children`) and `AsyncLink` (`children` is a render-invoked function).
 
 ## 2.0.0-alpha.1
 

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -21,7 +21,7 @@ export interface LinkProps extends BaseLinkProps {
   children: React.ReactNode;
 }
 
-export interface NavLinkProps extends BaseLinkProps {
+export interface AsyncLinkProps extends BaseLinkProps {
   children: NavigatingChildren;
 }
 
@@ -46,8 +46,8 @@ export const Link = React.forwardRef(
   }
 );
 
-export const NavLink = React.forwardRef(
-  (props: NavLinkProps, ref: React.Ref<any>) => {
+export const AsyncLink = React.forwardRef(
+  (props: AsyncLinkProps, ref: React.Ref<any>) => {
     const { eventHandler, navigating } = useStatefulNavigationHandler<
       GestureResponderEvent
     >(props, canNavigate);

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,7 +1,7 @@
-export { LinkProps, NavLinkProps } from "./Link";
+export { LinkProps, AsyncLinkProps } from "./Link";
 
 export * from "@curi/react-universal";
 
-import { Link, NavLink } from "./Link";
+import { Link, AsyncLink } from "./Link";
 
-export { Link, NavLink };
+export { Link, AsyncLink };

--- a/packages/react-native/tests/AsyncLink.spec.tsx
+++ b/packages/react-native/tests/AsyncLink.spec.tsx
@@ -6,9 +6,7 @@ import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 import { TouchableHighlight, Text } from "react-native";
 
-import { curiProvider, NavLink } from "@curi/react-native";
-
-import { NavType } from "@hickory/root";
+import { curiProvider, AsyncLink } from "@curi/react-native";
 
 // play nice
 function fakeEvent(props = {}) {
@@ -21,7 +19,7 @@ function fakeEvent(props = {}) {
   };
 }
 
-describe("<NavLink>", () => {
+describe("<AsyncLink>", () => {
   describe("anchor", () => {
     it("renders a <TouchableHighlight> by default", () => {
       const history = InMemory();
@@ -33,9 +31,9 @@ describe("<NavLink>", () => {
       const Router = curiProvider(router);
       const tree = renderer.create(
         <Router>
-          <NavLink name="Test">
+          <AsyncLink name="Test">
             {navigating => <Text>{navigating}</Text>}
-          </NavLink>
+          </AsyncLink>
         </Router>
       );
       const anchor = tree.root.findByType(TouchableHighlight);
@@ -57,9 +55,9 @@ describe("<NavLink>", () => {
 
       const tree = renderer.create(
         <Router>
-          <NavLink name="Test" anchor={StyledAnchor}>
+          <AsyncLink name="Test" anchor={StyledAnchor}>
             {navigating => <Text>{navigating}</Text>}
-          </NavLink>
+          </AsyncLink>
         </Router>
       );
       const anchor = tree.root.find(StyledAnchor);
@@ -79,9 +77,9 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name={null}>
+            <AsyncLink name={null}>
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -109,9 +107,9 @@ describe("<NavLink>", () => {
         const params = { name: "Glacier" };
         const tree = renderer.create(
           <Router>
-            <NavLink name="Park" params={params}>
+            <AsyncLink name="Park" params={params}>
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -130,9 +128,9 @@ describe("<NavLink>", () => {
         const params = { name: "Glacier" };
         const tree = renderer.create(
           <Router>
-            <NavLink name="Park" params={params}>
+            <AsyncLink name="Park" params={params}>
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -142,9 +140,9 @@ describe("<NavLink>", () => {
         const newParams = { name: "Yellowstone" };
         tree.update(
           <Router>
-            <NavLink name="Park" params={newParams}>
+            <AsyncLink name="Park" params={newParams}>
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         anchor.props.onPress(fakeEvent());
@@ -169,9 +167,9 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name="Test" query="one=two" hash="hashtag">
+            <AsyncLink name="Test" query="one=two" hash="hashtag">
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
 
@@ -201,9 +199,9 @@ describe("<NavLink>", () => {
       const style = { backgroundColor: "red" };
       const tree = renderer.create(
         <Router>
-          <NavLink name="Test" forward={{ style }}>
+          <AsyncLink name="Test" forward={{ style }}>
             {navigating => <Text>{navigating}</Text>}
-          </NavLink>
+          </AsyncLink>
         </Router>
       );
       const anchor = tree.root.findByType(TouchableHighlight);
@@ -226,9 +224,9 @@ describe("<NavLink>", () => {
       const ref = React.createRef();
       const tree = renderer.create(
         <Router>
-          <NavLink name="Parks" ref={ref}>
+          <AsyncLink name="Parks" ref={ref}>
             {navigating => <Text>{navigating}</Text>}
-          </NavLink>
+          </AsyncLink>
         </Router>
       );
       const anchor = tree.root.findByType(TouchableHighlight);
@@ -237,7 +235,7 @@ describe("<NavLink>", () => {
   });
 
   describe("children", () => {
-    it("is called with the <NavLink>'s current navigating state (false on mount)", () => {
+    it("is called with the <AsyncLink>'s current navigating state (false on mount)", () => {
       const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
@@ -248,12 +246,12 @@ describe("<NavLink>", () => {
 
       const tree = renderer.create(
         <Router>
-          <NavLink name="Test">
+          <AsyncLink name="Test">
             {navigating => {
               expect(navigating).toBe(false);
               return <Text>Test</Text>;
             }}
-          </NavLink>
+          </AsyncLink>
         </Router>
       );
     });
@@ -278,9 +276,9 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name="Test" method={"anchor"}>
+            <AsyncLink name="Test" method={"anchor"}>
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -298,9 +296,9 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name="Test" method={"push"}>
+            <AsyncLink name="Test" method={"push"}>
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -318,9 +316,9 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name="Test" method={"replace"}>
+            <AsyncLink name="Test" method={"replace"}>
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -354,11 +352,11 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name="Test">
+            <AsyncLink name="Test">
               {navigating => {
                 return <Text>{navigating.toString()}</Text>;
               }}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -398,16 +396,16 @@ describe("<NavLink>", () => {
         const tree = renderer.create(
           <Router>
             <React.Fragment>
-              <NavLink name="Slow">
+              <AsyncLink name="Slow">
                 {navigating => {
                   return <Text>{`Slow ${navigating.toString()}`}</Text>;
                 }}
-              </NavLink>
-              <NavLink name="Fast">
+              </AsyncLink>
+              <AsyncLink name="Fast">
                 {navigating => {
                   return <Text>{`Fast ${navigating.toString()}`}</Text>;
                 }}
-              </NavLink>
+              </AsyncLink>
             </React.Fragment>
           </Router>
         );
@@ -444,11 +442,11 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name="Loader">
+            <AsyncLink name="Loader">
               {navigating => {
                 return <Text>{navigating.toString()}</Text>;
               }}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -501,11 +499,11 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name="Blork">
+            <AsyncLink name="Blork">
               {navigating => {
                 return <Text>{navigating.toString()}</Text>;
               }}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -532,9 +530,9 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name="Test" onNav={onNav}>
+            <AsyncLink name="Test" onNav={onNav}>
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -561,9 +559,9 @@ describe("<NavLink>", () => {
 
         const tree = renderer.create(
           <Router>
-            <NavLink name="Test" onNav={onNav}>
+            <AsyncLink name="Test" onNav={onNav}>
               {navigating => <Text>{navigating}</Text>}
-            </NavLink>
+            </AsyncLink>
           </Router>
         );
         const anchor = tree.root.findByType(TouchableHighlight);
@@ -587,9 +585,9 @@ describe("<NavLink>", () => {
 
       const tree = renderer.create(
         <Router>
-          <NavLink name="Test">
+          <AsyncLink name="Test">
             {navigating => <Text>{navigating}</Text>}
-          </NavLink>
+          </AsyncLink>
         </Router>
       );
       const anchor = tree.root.findByType(TouchableHighlight);

--- a/packages/react-native/types/Link.d.ts
+++ b/packages/react-native/types/Link.d.ts
@@ -12,8 +12,8 @@ export interface BaseLinkProps extends RouteLocation {
 export interface LinkProps extends BaseLinkProps {
     children: React.ReactNode;
 }
-export interface NavLinkProps extends BaseLinkProps {
+export interface AsyncLinkProps extends BaseLinkProps {
     children: NavigatingChildren;
 }
 export declare const Link: React.ForwardRefExoticComponent<LinkProps & React.RefAttributes<any>>;
-export declare const NavLink: React.ForwardRefExoticComponent<NavLinkProps & React.RefAttributes<any>>;
+export declare const AsyncLink: React.ForwardRefExoticComponent<AsyncLinkProps & React.RefAttributes<any>>;

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -1,4 +1,4 @@
-export { LinkProps, NavLinkProps } from "./Link";
+export { LinkProps, AsyncLinkProps } from "./Link";
 export * from "@curi/react-universal";
-import { Link, NavLink } from "./Link";
-export { Link, NavLink };
+import { Link, AsyncLink } from "./Link";
+export { Link, AsyncLink };

--- a/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
+++ b/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
@@ -60,7 +60,7 @@ describe("useStatefulNavigationHandler", () => {
       const router = curi(history, routes);
       const Router = curiProvider(router);
 
-      function NavLink(props) {
+      function AsyncLink(props) {
         const { eventHandler, navigating } = useStatefulNavigationHandler(
           props
         );
@@ -73,9 +73,9 @@ describe("useStatefulNavigationHandler", () => {
 
       ReactDOM.render(
         <Router>
-          <NavLink name="Test" hash="thing" query="one=1" state="yo">
+          <AsyncLink name="Test" hash="thing" query="one=1" state="yo">
             {() => null}
-          </NavLink>
+          </AsyncLink>
         </Router>,
         node
       );
@@ -103,7 +103,7 @@ describe("useStatefulNavigationHandler", () => {
       const router = curi(history, routes);
       const Router = curiProvider(router);
 
-      function NavLink(props) {
+      function AsyncLink(props) {
         const { eventHandler, navigating } = useStatefulNavigationHandler(
           props
         );
@@ -116,9 +116,9 @@ describe("useStatefulNavigationHandler", () => {
 
       ReactDOM.render(
         <Router>
-          <NavLink name="Test" onNav={onNav}>
+          <AsyncLink name="Test" onNav={onNav}>
             {() => null}
-          </NavLink>
+          </AsyncLink>
         </Router>,
         node
       );
@@ -146,7 +146,7 @@ describe("useStatefulNavigationHandler", () => {
         const router = curi(history, routes);
         const Router = curiProvider(router);
 
-        function NavLink(props) {
+        function AsyncLink(props) {
           const { eventHandler, navigating } = useStatefulNavigationHandler(
             props,
             canNavigate
@@ -160,7 +160,7 @@ describe("useStatefulNavigationHandler", () => {
 
         ReactDOM.render(
           <Router>
-            <NavLink name="Test">{() => null}</NavLink>
+            <AsyncLink name="Test">{() => null}</AsyncLink>
           </Router>,
           node
         );
@@ -185,7 +185,7 @@ describe("useStatefulNavigationHandler", () => {
       const router = curi(history, routes);
       const Router = curiProvider(router);
 
-      function NavLink(props) {
+      function AsyncLink(props) {
         const { eventHandler, navigating } = useStatefulNavigationHandler(
           props
         );
@@ -199,7 +199,9 @@ describe("useStatefulNavigationHandler", () => {
 
       ReactDOM.render(
         <Router>
-          <NavLink name="Test">{navigating => navigating.toString()}</NavLink>
+          <AsyncLink name="Test">
+            {navigating => navigating.toString()}
+          </AsyncLink>
         </Router>,
         node
       );
@@ -231,7 +233,7 @@ describe("useStatefulNavigationHandler", () => {
       const router = curi(history, routes);
       const Router = curiProvider(router);
 
-      function NavLink(props) {
+      function AsyncLink(props) {
         const { eventHandler, navigating } = useStatefulNavigationHandler(
           props
         );
@@ -240,7 +242,9 @@ describe("useStatefulNavigationHandler", () => {
 
       ReactDOM.render(
         <Router>
-          <NavLink name="Slow">{navigating => navigating.toString()}</NavLink>
+          <AsyncLink name="Slow">
+            {navigating => navigating.toString()}
+          </AsyncLink>
         </Router>,
         node
       );
@@ -281,7 +285,7 @@ describe("useStatefulNavigationHandler", () => {
       const router = curi(history, routes);
       const Router = curiProvider(router);
 
-      function NavLink(props) {
+      function AsyncLink(props) {
         const { eventHandler, navigating } = useStatefulNavigationHandler(
           props
         );
@@ -290,7 +294,9 @@ describe("useStatefulNavigationHandler", () => {
 
       ReactDOM.render(
         <Router>
-          <NavLink name="Slow">{navigating => navigating.toString()}</NavLink>
+          <AsyncLink name="Slow">
+            {navigating => navigating.toString()}
+          </AsyncLink>
         </Router>,
         node
       );


### PR DESCRIPTION
I like the name `AsyncLink` slightly more because it refers to the link being used when navigating to async content.