### PR TITLE
Update Hickory, use generic query types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2155,20 +2155,20 @@
       "requires": {
         "@curi/react-universal": "file:packages/react-universal",
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.1",
+        "@hickory/root": "^2.0.0-alpha.2",
         "@types/react": "^16.7.18",
         "@types/react-native": "^0.57.32"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.1"
+            "@hickory/location-utils": "^2.0.0-alpha.2"
           }
         }
       }
@@ -2177,19 +2177,19 @@
       "version": "file:packages/react-universal",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.1",
+        "@hickory/root": "^2.0.0-alpha.2",
         "@types/react": "^16.7.18"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.1"
+            "@hickory/location-utils": "^2.0.0-alpha.2"
           }
         }
       }
@@ -2198,18 +2198,18 @@
       "version": "file:packages/interactions/route-active",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.1"
+        "@hickory/root": "^2.0.0-alpha.2"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.1"
+            "@hickory/location-utils": "^2.0.0-alpha.2"
           }
         }
       }
@@ -2229,19 +2229,19 @@
     "@curi/router": {
       "version": "file:packages/router",
       "requires": {
-        "@hickory/root": "^2.0.0-alpha.1",
+        "@hickory/root": "^2.0.0-alpha.2",
         "path-to-regexp": "^2.1.0"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.1"
+            "@hickory/location-utils": "^2.0.0-alpha.2"
           }
         }
       }
@@ -2268,28 +2268,28 @@
       "version": "file:packages/static",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/in-memory": "^2.0.0-alpha.1",
+        "@hickory/in-memory": "^2.0.0-alpha.2",
         "@types/express": "^4.16.0",
         "@types/fs-extra": "^5.0.4",
         "fs-extra": "^7.0.0"
       },
       "dependencies": {
         "@hickory/in-memory": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true,
           "requires": {
-            "@hickory/root": "^2.0.0-alpha.1"
+            "@hickory/root": "^2.0.0-alpha.2"
           }
         },
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.1"
+            "@hickory/location-utils": "^2.0.0-alpha.2"
           }
         }
       }
@@ -2304,18 +2304,18 @@
       "version": "file:packages/vue",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.1"
+        "@hickory/root": "^2.0.0-alpha.2"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.1",
+          "version": "2.0.0-alpha.2",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.1"
+            "@hickory/location-utils": "^2.0.0-alpha.2"
           }
         }
       }
@@ -2429,27 +2429,27 @@
       "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA=="
     },
     "@hickory/in-memory": {
-      "version": "2.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-2.0.0-alpha.1.tgz",
-      "integrity": "sha512-zi/Igre08CvdhaUJVM83NQ/Fd7TriIBSZGug0Alp8cKEw6IqLydeHMbAR6xPnmx9T8WStOn4cm/MVp9HnL3L0Q==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-DDCRom+ZvbeHEaB+8k3sTHMpActxB5Mtk4NdEK3u/Wp8gzkIg39ptJlw7+bQT1iYRnsZs62DqPzbpBHPWCAd0g==",
       "dev": true,
       "requires": {
-        "@hickory/root": "^2.0.0-alpha.1"
+        "@hickory/root": "^2.0.0-alpha.2"
       }
     },
     "@hickory/location-utils": {
-      "version": "2.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-2.0.0-alpha.1.tgz",
-      "integrity": "sha512-hs1YC8Bl1j+71jTV/DGCsLLnce8EynbQqa3x3hiKmfVxmTUwrdb03/iBMv1wQ7BAtv17a4vdnRotmYLAWg7bAA==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-pm9jAHzXj9BqEt6NMrD9Kz1rQFnRI/2DGrYGBopGCKXu2Upd5k6hvq2Bdb6+WDIhtlHavjEWSguveA6PpjK87Q==",
       "dev": true
     },
     "@hickory/root": {
-      "version": "2.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@hickory/root/-/root-2.0.0-alpha.1.tgz",
-      "integrity": "sha512-I74ybFLPBge/IZytDn0inGERPEZBk30rurx3UGVUxLPGzkH1nGScNgQ0aXYpmkpWJaNWuj54yRXiBAGZI9XADg==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@hickory/root/-/root-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-qUjQgvqvu94Sk5V/alzlr8oKZoNvejY1mi2i23Mx5qDgYyN6uMF59gDadx6EqDzXF4iANULa4ujOcoO/uIUCtA==",
       "dev": true,
       "requires": {
-        "@hickory/location-utils": "^2.0.0-alpha.1"
+        "@hickory/location-utils": "^2.0.0-alpha.2"
       }
     },
     "@lerna/add": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
-    "@hickory/in-memory": "^2.0.0-alpha.1",
+    "@hickory/in-memory": "^2.0.0-alpha.2",
     "@types/fs-extra": "^5.0.4",
     "@types/jest": "^23.3.13",
     "@types/node": "^10.12.18",

--- a/packages/helpers/tests/once.spec.ts
+++ b/packages/helpers/tests/once.spec.ts
@@ -1,6 +1,5 @@
 import "jest";
 
-// @ts-ignore (resolved by jest)
 import { once } from "@curi/helpers";
 
 describe("once()", () => {

--- a/packages/helpers/tests/preferDefault.spec.ts
+++ b/packages/helpers/tests/preferDefault.spec.ts
@@ -1,6 +1,5 @@
 import "jest";
 
-// @ts-ignore (resolved by jest)
 import { preferDefault } from "@curi/helpers";
 
 describe("preferDefault()", () => {

--- a/packages/interactions/route-active/package.json
+++ b/packages/interactions/route-active/package.json
@@ -34,6 +34,6 @@
   "license": "MIT",
   "dependencies": {
     "@curi/router": "file:../../router",
-    "@hickory/root": "^2.0.0-alpha.1"
+    "@hickory/root": "^2.0.0-alpha.2"
   }
 }

--- a/packages/interactions/route-active/src/index.ts
+++ b/packages/interactions/route-active/src/index.ts
@@ -1,9 +1,9 @@
 import { Route, Response, Interaction, Params } from "@curi/router";
-import { HickoryLocation } from "@hickory/root";
+import { SessionLocation } from "@hickory/root";
 
-function acceptableRouteName(
+function acceptableRouteName<Q>(
   name: string,
-  response: Response,
+  response: Response<Q>,
   partial?: boolean
 ): boolean {
   return (
@@ -12,15 +12,15 @@ function acceptableRouteName(
   );
 }
 
-export type LocationCheck = (l: HickoryLocation) => boolean;
+export type LocationCheck<Q> = (l: SessionLocation<Q>) => boolean;
 
-export interface ActiveCheckOptions {
+export interface ActiveCheckOptions<Q> {
   params?: Params;
   partial?: boolean;
-  locationCheck?: LocationCheck;
+  locationCheck?: LocationCheck<Q>;
 }
 
-export default function checkIfActive(): Interaction {
+export default function checkIfActive<Q>(): Interaction {
   let routeParams: { [key: string]: Array<string> } = {};
 
   return {
@@ -38,8 +38,8 @@ export default function checkIfActive(): Interaction {
     },
     get: (
       name: string,
-      response: Response,
-      options: ActiveCheckOptions = {}
+      response: Response<Q>,
+      options: ActiveCheckOptions<Q> = {}
     ): boolean => {
       if (
         routeParams[name] == null ||

--- a/packages/interactions/route-active/types/index.d.ts
+++ b/packages/interactions/route-active/types/index.d.ts
@@ -1,9 +1,9 @@
 import { Interaction, Params } from "@curi/router";
-import { HickoryLocation } from "@hickory/root";
-export declare type LocationCheck = (l: HickoryLocation) => boolean;
-export interface ActiveCheckOptions {
+import { SessionLocation } from "@hickory/root";
+export declare type LocationCheck<Q> = (l: SessionLocation<Q>) => boolean;
+export interface ActiveCheckOptions<Q> {
     params?: Params;
     partial?: boolean;
-    locationCheck?: LocationCheck;
+    locationCheck?: LocationCheck<Q>;
 }
-export default function checkIfActive(): Interaction;
+export default function checkIfActive<Q>(): Interaction;

--- a/packages/interactions/route-ancestors/tests/ancestors.spec.ts
+++ b/packages/interactions/route-ancestors/tests/ancestors.spec.ts
@@ -2,7 +2,6 @@ import "jest";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import createAncestors from "@curi/route-ancestors";
 
 describe("ancestors route interaction", () => {

--- a/packages/interactions/route-prefetch/src/index.ts
+++ b/packages/interactions/route-prefetch/src/index.ts
@@ -7,12 +7,12 @@ import {
   AsyncMatchFn
 } from "@curi/router";
 
-export interface PrefetchCallOptions {
-  match?: MatchResponseProperties;
+export interface PrefetchCallOptions<Q> {
+  match?: MatchResponseProperties<Q>;
   external?: any;
 }
 
-export default function prefetchRoute(): Interaction {
+export default function prefetchRoute<Q>(): Interaction {
   let loaders: { [key: string]: AsyncMatchFn } = {};
 
   return {
@@ -28,7 +28,7 @@ export default function prefetchRoute(): Interaction {
     },
     get: (
       name: string,
-      options: PrefetchCallOptions = {}
+      options: PrefetchCallOptions<Q> = {}
     ): Promise<ResolveResults> => {
       if (loaders[name] == null) {
         return Promise.resolve({

--- a/packages/interactions/route-prefetch/types/index.d.ts
+++ b/packages/interactions/route-prefetch/types/index.d.ts
@@ -1,6 +1,6 @@
 import { Interaction, MatchResponseProperties } from "@curi/router";
-export interface PrefetchCallOptions {
-    match?: MatchResponseProperties;
+export interface PrefetchCallOptions<Q> {
+    match?: MatchResponseProperties<Q>;
     external?: any;
 }
-export default function prefetchRoute(): Interaction;
+export default function prefetchRoute<Q>(): Interaction;

--- a/packages/react-dom/tests/useNavigationFocus.spec.tsx
+++ b/packages/react-dom/tests/useNavigationFocus.spec.tsx
@@ -4,7 +4,6 @@ import ReactDOM from "react-dom";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, useNavigationFocus, useCuri } from "@curi/react-dom";
 
 jest.useFakeTimers();

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@curi/react-universal": "file:../react-universal",
     "@curi/router": "file:../router",
-    "@hickory/root": "^2.0.0-alpha.1",
+    "@hickory/root": "^2.0.0-alpha.2",
     "@types/react": "^16.7.18",
     "@types/react-native": "^0.57.32"
   },

--- a/packages/react-universal/package.json
+++ b/packages/react-universal/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@curi/router": "file:../router",
-    "@hickory/root": "^2.0.0-alpha.1",
+    "@hickory/root": "^2.0.0-alpha.2",
     "@types/react": "^16.7.18"
   }
 }

--- a/packages/react-universal/src/hooks/useActive.ts
+++ b/packages/react-universal/src/hooks/useActive.ts
@@ -1,18 +1,18 @@
 import useCuri from "./useCuri";
 
-import { HickoryLocation } from "@hickory/root";
+import { SessionLocation } from "@hickory/root";
 import { Params } from "@curi/router";
 
-export type LocationCheck = (l: HickoryLocation) => boolean;
+export type LocationCheck<Q> = (l: SessionLocation<Q>) => boolean;
 
-export interface ActiveHookProps {
+export interface ActiveHookProps<Q> {
   name: string;
   params?: Params;
   partial?: boolean;
-  locationCheck?: LocationCheck;
+  locationCheck?: LocationCheck<Q>;
 }
 
-export default function useActive(props: ActiveHookProps) {
+export default function useActive<Q>(props: ActiveHookProps<Q>) {
   const { router, response } = useCuri();
   if (process.env.NODE_ENV !== "production") {
     if (!router.route.active) {

--- a/packages/react-universal/src/hooks/useBlock.ts
+++ b/packages/react-universal/src/hooks/useBlock.ts
@@ -3,7 +3,10 @@ import useCuri from "./useCuri";
 
 import { ConfirmationFunction } from "@hickory/root";
 
-export default function useBlock(active: boolean, fn: ConfirmationFunction) {
+export default function useBlock<Q>(
+  active: boolean,
+  fn: ConfirmationFunction<Q>
+) {
   const { router } = useCuri();
   React.useEffect(() => {
     if (active) {

--- a/packages/react-universal/tests/Curious.spec.tsx
+++ b/packages/react-universal/tests/Curious.spec.tsx
@@ -4,7 +4,6 @@ import ReactDOM from "react-dom";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, Curious } from "@curi/react-universal";
 
 describe("<Curious>", () => {

--- a/packages/react-universal/tests/curiProvider.spec.tsx
+++ b/packages/react-universal/tests/curiProvider.spec.tsx
@@ -6,7 +6,6 @@ import { InMemory } from "@hickory/in-memory";
 
 import wait from "./utils/wait";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, useCuri } from "@curi/react-universal";
 
 describe("curiProvider()", () => {

--- a/packages/react-universal/tests/useActive.spec.tsx
+++ b/packages/react-universal/tests/useActive.spec.tsx
@@ -5,7 +5,6 @@ import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 import activeInteraction from "@curi/route-active";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, useActive, useCuri } from "@curi/react-universal";
 
 describe("useActive", () => {

--- a/packages/react-universal/tests/useBlock.spec.tsx
+++ b/packages/react-universal/tests/useBlock.spec.tsx
@@ -6,7 +6,6 @@ import { curi, prepareRoutes } from "@curi/router";
 
 import wait from "./utils/wait";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, useBlock } from "@curi/react-universal";
 
 describe("useBlock", () => {

--- a/packages/react-universal/tests/useCuri.spec.tsx
+++ b/packages/react-universal/tests/useCuri.spec.tsx
@@ -4,7 +4,6 @@ import ReactDOM from "react-dom";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, useCuri } from "@curi/react-universal";
 
 describe("useCuri", () => {

--- a/packages/react-universal/tests/useHref.spec.tsx
+++ b/packages/react-universal/tests/useHref.spec.tsx
@@ -5,7 +5,6 @@ import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 import * as qs from "qs";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, useHref } from "@curi/react-universal";
 
 describe("useHref", () => {

--- a/packages/react-universal/tests/useLocation.spec.tsx
+++ b/packages/react-universal/tests/useLocation.spec.tsx
@@ -4,7 +4,6 @@ import ReactDOM from "react-dom";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, useLocation } from "@curi/react-universal";
 
 describe("useLocation", () => {

--- a/packages/react-universal/tests/useNavigating.spec.tsx
+++ b/packages/react-universal/tests/useNavigating.spec.tsx
@@ -6,7 +6,6 @@ import { curi, prepareRoutes } from "@curi/router";
 
 import wait from "./utils/wait";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, useNavigating } from "@curi/react-universal";
 
 describe("useNavigating", () => {

--- a/packages/react-universal/tests/useNavigationHandler.spec.tsx
+++ b/packages/react-universal/tests/useNavigationHandler.spec.tsx
@@ -5,7 +5,6 @@ import { Simulate } from "react-dom/test-utils";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { curiProvider, useNavigationHandler } from "@curi/react-universal";
 
 function createClick(opts?: {}) {

--- a/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
+++ b/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
@@ -7,7 +7,6 @@ import { curi, prepareRoutes } from "@curi/router";
 
 import wait from "./utils/wait";
 
-// @ts-ignore (resolved by jest)
 import {
   curiProvider,
   useStatefulNavigationHandler

--- a/packages/react-universal/types/hooks/useActive.d.ts
+++ b/packages/react-universal/types/hooks/useActive.d.ts
@@ -1,10 +1,10 @@
-import { HickoryLocation } from "@hickory/root";
+import { SessionLocation } from "@hickory/root";
 import { Params } from "@curi/router";
-export declare type LocationCheck = (l: HickoryLocation) => boolean;
-export interface ActiveHookProps {
+export declare type LocationCheck<Q> = (l: SessionLocation<Q>) => boolean;
+export interface ActiveHookProps<Q> {
     name: string;
     params?: Params;
     partial?: boolean;
-    locationCheck?: LocationCheck;
+    locationCheck?: LocationCheck<Q>;
 }
-export default function useActive(props: ActiveHookProps): any;
+export default function useActive<Q>(props: ActiveHookProps<Q>): any;

--- a/packages/react-universal/types/hooks/useBlock.d.ts
+++ b/packages/react-universal/types/hooks/useBlock.d.ts
@@ -1,2 +1,2 @@
 import { ConfirmationFunction } from "@hickory/root";
-export default function useBlock(active: boolean, fn: ConfirmationFunction): void;
+export default function useBlock<Q>(active: boolean, fn: ConfirmationFunction<Q>): void;

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -33,7 +33,7 @@
   "author": "Paul Sherman",
   "license": "MIT",
   "dependencies": {
-    "@hickory/root": "^2.0.0-alpha.1",
+    "@hickory/root": "^2.0.0-alpha.2",
     "path-to-regexp": "^2.1.0"
   }
 }

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -29,8 +29,8 @@ import {
   CancelNavigateCallbacks
 } from "./types/curi";
 
-export default function createRouter(
-  history: History,
+export default function createRouter<Q>(
+  history: History<Q>,
   routeArray: CompiledRouteArray,
   options: RouterOptions = {}
 ): CuriRouter {
@@ -46,7 +46,7 @@ export default function createRouter(
   const routeInteractions: Interactions = {};
 
   // the navigation currently being processed
-  let activeNavigation: PendingNavigation | undefined;
+  let activeNavigation: PendingNavigation<Q> | undefined;
 
   // the last finish response & navigation
   const mostRecent: CurrentResponse = {
@@ -87,7 +87,7 @@ export default function createRouter(
     history.respondWith(navigationHandler);
   }
 
-  function navigationHandler(pendingNav: PendingNavigation): void {
+  function navigationHandler(pendingNav: PendingNavigation<Q>): void {
     cancelActiveNavigation(pendingNav.action);
     activeNavigation = pendingNav;
 
@@ -123,16 +123,16 @@ export default function createRouter(
     }
 
     if (match.route.sync) {
-      finalizeResponseAndEmit(match as Match, pendingNav, navigation, null);
+      finalizeResponseAndEmit(match as Match<Q>, pendingNav, navigation, null);
     } else {
       activateCancellers(pendingNav.action);
-      resolveMatchedRoute(match as Match, external).then(
+      resolveMatchedRoute(match as Match<Q>, external).then(
         (resolved: ResolveResults) => {
           if (pendingNav.cancelled) {
             return;
           }
           finalizeResponseAndEmit(
-            match as Match,
+            match as Match<Q>,
             pendingNav,
             navigation,
             resolved
@@ -143,8 +143,8 @@ export default function createRouter(
   }
 
   function finalizeResponseAndEmit(
-    match: Match,
-    pending: PendingNavigation,
+    match: Match<Q>,
+    pending: PendingNavigation<Q>,
     navigation: Navigation,
     resolved: ResolveResults | null
   ) {
@@ -181,7 +181,7 @@ export default function createRouter(
     });
   }
 
-  function emitImmediate(response: Response, navigation: Navigation) {
+  function emitImmediate(response: Response<Q>, navigation: Navigation) {
     if (finishCallback) {
       finishCallback();
     }

--- a/packages/router/src/finishResponse.ts
+++ b/packages/router/src/finishResponse.ts
@@ -8,11 +8,11 @@ import {
 import { ResolveResults } from "./types/route";
 import { Match } from "./types/match";
 
-function createRedirect(
+function createRedirect<Q>(
   redirectTo: any,
   interactions: Interactions,
-  history: History
-): RedirectLocation {
+  history: History<Q>
+): RedirectLocation<Q> {
   const { name, params, query, hash, state } = redirectTo;
   const pathname = interactions.pathname(name, params);
   return {
@@ -26,15 +26,15 @@ function createRedirect(
   };
 }
 
-export default function finishResponse(
-  routeMatch: Match,
+export default function finishResponse<Q>(
+  routeMatch: Match<Q>,
   interactions: Interactions,
   resolvedResults: ResolveResults | null,
-  history: History,
+  history: History<Q>,
   external: any
-): Response {
+): Response<Q> {
   const { route, match } = routeMatch;
-  const response: Response = match;
+  const response: Response<Q> = match;
   if (!route.response) {
     return response;
   }
@@ -53,7 +53,7 @@ export default function finishResponse(
   }
 
   const settableProperties: Array<
-    keyof Response & keyof SettableResponseProperties
+    keyof Response<Q> & keyof SettableResponseProperties
   > = ["status", "error", "body", "data", "title", "redirectTo"];
 
   // only merge the valid properties onto the response

--- a/packages/router/src/matchLocation.ts
+++ b/packages/router/src/matchLocation.ts
@@ -1,7 +1,7 @@
 import { withLeadingSlash } from "./utils/path";
 import parseParams from "./utils/parseParams";
 
-import { HickoryLocation } from "@hickory/root";
+import { SessionLocation } from "@hickory/root";
 import { CompiledRoute } from "./types/route";
 import { PossibleMatch, Match, MatchingRoute } from "./types/match";
 import { Params, RawParams } from "./types/response";
@@ -56,10 +56,10 @@ function matchRoute(
     : [];
 }
 
-function createMatch(
+function createMatch<Q>(
   routeMatches: Array<MatchingRoute>,
-  location: HickoryLocation
-): Match {
+  location: SessionLocation<Q>
+): Match<Q> {
   let partials: Array<string> = [];
   let params: Params = {};
 
@@ -86,10 +86,10 @@ function createMatch(
   };
 }
 
-export default function matchLocation(
-  location: HickoryLocation,
+export default function matchLocation<Q>(
+  location: SessionLocation<Q>,
   routes: Array<CompiledRoute>
-): PossibleMatch {
+): PossibleMatch<Q> {
   // determine which route(s) match, then use the exact match
   // as the matched route and the rest as partial routes
   const routeLength = routes.length;

--- a/packages/router/src/resolveMatchedRoute.ts
+++ b/packages/router/src/resolveMatchedRoute.ts
@@ -1,8 +1,8 @@
 import { Match } from "./types/match";
 import { ResolveResults, AsyncRoute } from "./types/route";
 
-export default function resolveRoute(
-  match: Match,
+export default function resolveRoute<Q>(
+  match: Match<Q>,
   global: any
 ): Promise<ResolveResults> {
   const { resolve } = <AsyncRoute>match.route.public;

--- a/packages/router/src/types/match.ts
+++ b/packages/router/src/types/match.ts
@@ -11,9 +11,9 @@ export interface MissMatch {
   match: undefined;
 }
 
-export interface Match {
+export interface Match<Q> {
   route: CompiledRoute;
-  match: MatchResponseProperties;
+  match: MatchResponseProperties<Q>;
 }
 
-export type PossibleMatch = Match | MissMatch;
+export type PossibleMatch<Q> = Match<Q> | MissMatch;

--- a/packages/router/src/types/response.ts
+++ b/packages/router/src/types/response.ts
@@ -1,11 +1,11 @@
-import { HickoryLocation, PartialLocation } from "@hickory/root";
+import { SessionLocation, PartialLocation } from "@hickory/root";
 import { RouteLocation } from "./location";
 
 export type RawParams = { [key: string]: string };
 export type Params = { [key: string]: any };
 
-export interface MatchResponseProperties {
-  location: HickoryLocation;
+export interface MatchResponseProperties<Q> {
+  location: SessionLocation<Q>;
   name: string;
   params: Params;
   partials: Array<string>;
@@ -20,19 +20,19 @@ export interface SettableResponseProperties {
   redirectTo?: RedirectProps;
 }
 
-export interface RedirectLocation extends PartialLocation {
+export interface RedirectLocation<Q> extends PartialLocation<Q> {
   name: string;
   params?: Params;
   url: string;
 }
 
-export interface Response extends MatchResponseProperties {
+export interface Response<Q> extends MatchResponseProperties<Q> {
   status?: number;
   error?: any;
   body?: any;
   data?: any;
   title?: string;
-  redirectTo?: RedirectLocation;
+  redirectTo?: RedirectLocation<Q>;
 }
 
 export interface RedirectProps extends RouteLocation {

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -3,7 +3,6 @@ import { InMemory } from "@hickory/in-memory";
 
 import { NavType } from "@hickory/root";
 
-// @ts-ignore (resolved by jest)
 import { curi, prepareRoutes } from "@curi/router";
 
 describe("curi", () => {

--- a/packages/router/tests/path.spec.ts
+++ b/packages/router/tests/path.spec.ts
@@ -1,7 +1,6 @@
 import "jest";
 import { InMemory } from "@hickory/in-memory";
 
-// @ts-ignore (resolved by jest)
 import { curi, prepareRoutes } from "@curi/router";
 
 describe("route.pathOptions matching", () => {

--- a/packages/router/tests/pathname-interaction.spec.ts
+++ b/packages/router/tests/pathname-interaction.spec.ts
@@ -1,7 +1,6 @@
 import "jest";
 import { InMemory } from "@hickory/in-memory";
 
-// @ts-ignore (resolved by jest)
 import { prepareRoutes, curi } from "@curi/router";
 
 describe("pathname route interaction", () => {

--- a/packages/router/tests/prepareRoutes.spec.ts
+++ b/packages/router/tests/prepareRoutes.spec.ts
@@ -1,6 +1,5 @@
 import "jest";
 
-// @ts-ignore (resolved by jest)
 import { prepareRoutes } from "@curi/router";
 
 describe("prepareRoutes()", () => {

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -1,7 +1,6 @@
 import "jest";
 import { InMemory } from "@hickory/in-memory";
 
-// @ts-ignore (resolved by jest)
 import { curi, prepareRoutes } from "@curi/router";
 
 describe("route matching/response generation", () => {

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -2,7 +2,6 @@ import "jest";
 import { Route, Interaction } from "../src/types";
 import { InMemory } from "@hickory/in-memory";
 
-// @ts-ignore (resolved by jest)
 import { curi, prepareRoutes } from "@curi/router";
 
 function PropertyReporter(): Interaction {

--- a/packages/router/types/curi.d.ts
+++ b/packages/router/types/curi.d.ts
@@ -1,4 +1,4 @@
 import { History } from "@hickory/root";
 import { CompiledRouteArray } from "./types/route";
 import { CuriRouter, RouterOptions } from "./types/curi";
-export default function createRouter(history: History, routeArray: CompiledRouteArray, options?: RouterOptions): CuriRouter;
+export default function createRouter<Q>(history: History<Q>, routeArray: CompiledRouteArray, options?: RouterOptions): CuriRouter;

--- a/packages/router/types/finishResponse.d.ts
+++ b/packages/router/types/finishResponse.d.ts
@@ -3,4 +3,4 @@ import { Interactions } from "./types/interaction";
 import { Response } from "./types/response";
 import { ResolveResults } from "./types/route";
 import { Match } from "./types/match";
-export default function finishResponse(routeMatch: Match, interactions: Interactions, resolvedResults: ResolveResults | null, history: History, external: any): Response;
+export default function finishResponse<Q>(routeMatch: Match<Q>, interactions: Interactions, resolvedResults: ResolveResults | null, history: History<Q>, external: any): Response<Q>;

--- a/packages/router/types/matchLocation.d.ts
+++ b/packages/router/types/matchLocation.d.ts
@@ -1,4 +1,4 @@
-import { HickoryLocation } from "@hickory/root";
+import { SessionLocation } from "@hickory/root";
 import { CompiledRoute } from "./types/route";
 import { PossibleMatch } from "./types/match";
-export default function matchLocation(location: HickoryLocation, routes: Array<CompiledRoute>): PossibleMatch;
+export default function matchLocation<Q>(location: SessionLocation<Q>, routes: Array<CompiledRoute>): PossibleMatch<Q>;

--- a/packages/router/types/resolveMatchedRoute.d.ts
+++ b/packages/router/types/resolveMatchedRoute.d.ts
@@ -1,3 +1,3 @@
 import { Match } from "./types/match";
 import { ResolveResults } from "./types/route";
-export default function resolveRoute(match: Match, global: any): Promise<ResolveResults>;
+export default function resolveRoute<Q>(match: Match<Q>, global: any): Promise<ResolveResults>;

--- a/packages/router/types/types/match.d.ts
+++ b/packages/router/types/types/match.d.ts
@@ -8,8 +8,8 @@ export interface MissMatch {
     route: undefined;
     match: undefined;
 }
-export interface Match {
+export interface Match<Q> {
     route: CompiledRoute;
-    match: MatchResponseProperties;
+    match: MatchResponseProperties<Q>;
 }
-export declare type PossibleMatch = Match | MissMatch;
+export declare type PossibleMatch<Q> = Match<Q> | MissMatch;

--- a/packages/router/types/types/response.d.ts
+++ b/packages/router/types/types/response.d.ts
@@ -1,4 +1,4 @@
-import { HickoryLocation, PartialLocation } from "@hickory/root";
+import { SessionLocation, PartialLocation } from "@hickory/root";
 import { RouteLocation } from "./location";
 export declare type RawParams = {
     [key: string]: string;
@@ -6,8 +6,8 @@ export declare type RawParams = {
 export declare type Params = {
     [key: string]: any;
 };
-export interface MatchResponseProperties {
-    location: HickoryLocation;
+export interface MatchResponseProperties<Q> {
+    location: SessionLocation<Q>;
     name: string;
     params: Params;
     partials: Array<string>;
@@ -20,18 +20,18 @@ export interface SettableResponseProperties {
     title?: string;
     redirectTo?: RedirectProps;
 }
-export interface RedirectLocation extends PartialLocation {
+export interface RedirectLocation<Q> extends PartialLocation<Q> {
     name: string;
     params?: Params;
     url: string;
 }
-export interface Response extends MatchResponseProperties {
+export interface Response<Q> extends MatchResponseProperties<Q> {
     status?: number;
     error?: any;
     body?: any;
     data?: any;
     title?: string;
-    redirectTo?: RedirectLocation;
+    redirectTo?: RedirectLocation<Q>;
 }
 export interface RedirectProps extends RouteLocation {
     name: string;

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@curi/router": "file:../router",
-    "@hickory/in-memory": "^2.0.0-alpha.1",
+    "@hickory/in-memory": "^2.0.0-alpha.2",
     "@types/express": "^4.16.0",
     "@types/fs-extra": "^5.0.4",
     "fs-extra": "^7.0.0"

--- a/packages/static/tests/pathnames.spec.ts
+++ b/packages/static/tests/pathnames.spec.ts
@@ -1,7 +1,6 @@
 import "jest";
 import { prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { pathnames } from "@curi/static";
 
 describe("pathnames()", () => {

--- a/packages/static/tests/staticFiles.spec.ts
+++ b/packages/static/tests/staticFiles.spec.ts
@@ -3,7 +3,6 @@ import { ensureDir, remove, existsSync } from "fs-extra";
 import { join } from "path";
 import { prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { staticFiles } from "@curi/static";
 
 import { Emitted } from "@curi/router";

--- a/packages/vue/.size-snapshot.json
+++ b/packages/vue/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/curi-vue.es.js": {
-    "bundled": 5274,
+    "bundled": 5357,
     "minified": 2579,
     "gzipped": 1134,
     "treeshaked": {
@@ -14,17 +14,17 @@
     }
   },
   "dist/curi-vue.js": {
-    "bundled": 5499,
+    "bundled": 5582,
     "minified": 2757,
     "gzipped": 1197
   },
   "dist/curi-vue.umd.js": {
-    "bundled": 6073,
+    "bundled": 6160,
     "minified": 2781,
     "gzipped": 1228
   },
   "dist/curi-vue.min.js": {
-    "bundled": 6063,
+    "bundled": 6150,
     "minified": 2771,
     "gzipped": 1214
   }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -35,6 +35,6 @@
   },
   "dependencies": {
     "@curi/router": "file:../router",
-    "@hickory/root": "^2.0.0-alpha.1"
+    "@hickory/root": "^2.0.0-alpha.2"
   }
 }

--- a/packages/vue/src/Block.ts
+++ b/packages/vue/src/Block.ts
@@ -1,16 +1,17 @@
-import Vue, { CreateElement, ComponentOptions } from 'vue';
-import { ConfirmationFunction } from '@hickory/root';
+import Vue, { CreateElement, ComponentOptions } from "vue";
+import { ConfirmationFunction } from "@hickory/root";
 
-export interface BlockComponent extends Vue {
+export interface BlockComponent<Q> extends Vue {
   active?: boolean;
-  confirm: ConfirmationFunction;
+  confirm: ConfirmationFunction<Q>;
   on(): void;
   off(): void;
   update(): void;
 }
 
-const Block: ComponentOptions<BlockComponent> = {
-  name: 'curi-block',
+// TODO: restrict BlockComponent generic
+const Block: ComponentOptions<BlockComponent<any>> = {
+  name: "curi-block",
 
   props: {
     active: {

--- a/packages/vue/src/Link.ts
+++ b/packages/vue/src/Link.ts
@@ -1,13 +1,13 @@
 import Vue, { CreateElement, ComponentOptions } from "vue";
-import { HickoryLocation } from "@hickory/root";
+import { SessionLocation } from "@hickory/root";
 
-export interface LinkComponent extends Vue {
+export interface LinkComponent<Q> extends Vue {
   to: string;
   params?: object;
   hash?: string;
   query?: any;
   state?: any;
-  location: HickoryLocation;
+  location: SessionLocation<Q>;
   href: string;
   click(e: MouseEvent): void;
   navigating: boolean;
@@ -21,7 +21,8 @@ const canNavigate = (event: MouseEvent) => {
   );
 };
 
-const Link: ComponentOptions<LinkComponent> = {
+// TODO: restrict LinkComponent generic
+const Link: ComponentOptions<LinkComponent<any>> = {
   name: "curi-link",
 
   props: ["to", "params", "hash", "query", "state", "click"],

--- a/packages/vue/tests/Block.spec.ts
+++ b/packages/vue/tests/Block.spec.ts
@@ -3,7 +3,6 @@ import { createLocalVue } from "@vue/test-utils";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("<curi-block>", () => {

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -3,7 +3,6 @@ import { createLocalVue } from "@vue/test-utils";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("<curi-link>", () => {

--- a/packages/vue/tests/focus.spec.ts
+++ b/packages/vue/tests/focus.spec.ts
@@ -3,7 +3,6 @@ import { createLocalVue } from "@vue/test-utils";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("curi-focus directive", () => {

--- a/packages/vue/tests/plugin.spec.ts
+++ b/packages/vue/tests/plugin.spec.ts
@@ -3,7 +3,6 @@ import { createLocalVue } from "@vue/test-utils";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import { CuriPlugin } from "@curi/vue";
 
 describe("CuriPlugin", () => {

--- a/packages/vue/types/Block.d.ts
+++ b/packages/vue/types/Block.d.ts
@@ -1,11 +1,11 @@
 import Vue, { ComponentOptions } from 'vue';
 import { ConfirmationFunction } from '@hickory/root';
-export interface BlockComponent extends Vue {
+export interface BlockComponent<Q> extends Vue {
     active?: boolean;
-    confirm: ConfirmationFunction;
+    confirm: ConfirmationFunction<Q>;
     on(): void;
     off(): void;
     update(): void;
 }
-declare const Block: ComponentOptions<BlockComponent>;
+declare const Block: ComponentOptions<BlockComponent<any>>;
 export default Block;

--- a/packages/vue/types/Link.d.ts
+++ b/packages/vue/types/Link.d.ts
@@ -1,15 +1,15 @@
 import Vue, { ComponentOptions } from "vue";
-import { HickoryLocation } from "@hickory/root";
-export interface LinkComponent extends Vue {
+import { SessionLocation } from "@hickory/root";
+export interface LinkComponent<Q> extends Vue {
     to: string;
     params?: object;
     hash?: string;
     query?: any;
     state?: any;
-    location: HickoryLocation;
+    location: SessionLocation<Q>;
     href: string;
     click(e: MouseEvent): void;
     navigating: boolean;
 }
-declare const Link: ComponentOptions<LinkComponent>;
+declare const Link: ComponentOptions<LinkComponent<any>>;
 export default Link;


### PR DESCRIPTION
Hickory v2 introduces a generic `query` type. This PR updates the various packages to use the generic `query`.

The only package that I'm iffy on is `@curi/vue`, but that package is also on hiatus waiting for Vue v3, so I'm not too worried about it for the time being.

I'm not yet sure if some of the generic `query` types should be given a default value. For now, no default values are set.