### PR TITLE
Use pending history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2155,20 +2155,20 @@
       "requires": {
         "@curi/react-universal": "file:packages/react-universal",
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.4",
+        "@hickory/root": "^2.0.0-alpha.5",
         "@types/react": "^16.7.18",
         "@types/react-native": "^0.57.32"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.4"
+            "@hickory/location-utils": "^2.0.0-alpha.5"
           }
         }
       }
@@ -2177,19 +2177,19 @@
       "version": "file:packages/react-universal",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.4",
+        "@hickory/root": "^2.0.0-alpha.5",
         "@types/react": "^16.7.18"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.4"
+            "@hickory/location-utils": "^2.0.0-alpha.5"
           }
         }
       }
@@ -2198,18 +2198,18 @@
       "version": "file:packages/interactions/route-active",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.4"
+        "@hickory/root": "^2.0.0-alpha.5"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.4"
+            "@hickory/location-utils": "^2.0.0-alpha.5"
           }
         }
       }
@@ -2229,19 +2229,19 @@
     "@curi/router": {
       "version": "file:packages/router",
       "requires": {
-        "@hickory/root": "^2.0.0-alpha.4",
+        "@hickory/root": "^2.0.0-alpha.5",
         "path-to-regexp": "^2.1.0"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.4"
+            "@hickory/location-utils": "^2.0.0-alpha.5"
           }
         }
       }
@@ -2268,28 +2268,28 @@
       "version": "file:packages/static",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/in-memory": "^2.0.0-alpha.4",
+        "@hickory/in-memory": "^2.0.0-alpha.5",
         "@types/express": "^4.16.0",
         "@types/fs-extra": "^5.0.4",
         "fs-extra": "^7.0.0"
       },
       "dependencies": {
         "@hickory/in-memory": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true,
           "requires": {
-            "@hickory/root": "^2.0.0-alpha.4"
+            "@hickory/root": "^2.0.0-alpha.5"
           }
         },
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.4"
+            "@hickory/location-utils": "^2.0.0-alpha.5"
           }
         }
       }
@@ -2304,18 +2304,18 @@
       "version": "file:packages/vue",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.4"
+        "@hickory/root": "^2.0.0-alpha.5"
       },
       "dependencies": {
         "@hickory/location-utils": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true
         },
         "@hickory/root": {
-          "version": "2.0.0-alpha.4",
+          "version": "2.0.0-alpha.5",
           "bundled": true,
           "requires": {
-            "@hickory/location-utils": "^2.0.0-alpha.4"
+            "@hickory/location-utils": "^2.0.0-alpha.5"
           }
         }
       }
@@ -2429,27 +2429,27 @@
       "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA=="
     },
     "@hickory/in-memory": {
-      "version": "2.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-2.0.0-alpha.4.tgz",
-      "integrity": "sha512-g15Nx3pvBwcehy+O4dGHaSLt0Z/VcTlFwSIHbgd/jX+AVpFwkHuqYAajgPUuy6/IhXXPiLRWrBvpnhivmp03dg==",
+      "version": "2.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-2.0.0-alpha.5.tgz",
+      "integrity": "sha512-c8RWGBwu0sB/5sKZngDgNkeutsLlzkrrx4fn77g2bZWitaZh0SdqRGRLoGhprEK9FvEEg/4R3xWw0YgcE52ddQ==",
       "dev": true,
       "requires": {
-        "@hickory/root": "^2.0.0-alpha.4"
+        "@hickory/root": "^2.0.0-alpha.5"
       }
     },
     "@hickory/location-utils": {
-      "version": "2.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-2.0.0-alpha.4.tgz",
-      "integrity": "sha512-ctqTIAOWceNL8yYU9Po05lTIfeqqTTGEj4R7yxvf58YK4iNCrr5mcR1nT7sXZI6L2C5dm43Zm2nZtv7mgNpv1A==",
+      "version": "2.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-2.0.0-alpha.5.tgz",
+      "integrity": "sha512-qFIQUwLVZpTBVf9cphnPl4poCzrm0/WVSGSyjUsCBV20BP9+UqTq+dcicR5NswX2/Tg0S+VZNeawYTm9uyvULA==",
       "dev": true
     },
     "@hickory/root": {
-      "version": "2.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@hickory/root/-/root-2.0.0-alpha.4.tgz",
-      "integrity": "sha512-eX8ODQw3pv8M/o6Sls59StQqHTzCsi1j5tTb/YtVx+qKQGYv0apxZ22EXdchsvyTPcBeTuFPvP1luiynSAIjBg==",
+      "version": "2.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@hickory/root/-/root-2.0.0-alpha.5.tgz",
+      "integrity": "sha512-crPTOCdM+KOnRZo7Qt/0W446cV/cAcWZOa1mVygTvcXiKXqkveDAXWqMlYavy3g/NvOW4Jx2P/psdySw2EM6zw==",
       "dev": true,
       "requires": {
-        "@hickory/location-utils": "^2.0.0-alpha.4"
+        "@hickory/location-utils": "^2.0.0-alpha.5"
       }
     },
     "@lerna/add": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
-    "@hickory/in-memory": "^2.0.0-alpha.4",
+    "@hickory/in-memory": "^2.0.0-alpha.5",
     "@types/fs-extra": "^5.0.4",
     "@types/jest": "^23.3.13",
     "@types/node": "^10.12.18",

--- a/packages/interactions/route-active/package.json
+++ b/packages/interactions/route-active/package.json
@@ -34,6 +34,6 @@
   "license": "MIT",
   "dependencies": {
     "@curi/router": "file:../../router",
-    "@hickory/root": "^2.0.0-alpha.4"
+    "@hickory/root": "^2.0.0-alpha.5"
   }
 }

--- a/packages/react-dom/tests/AsyncLink.spec.tsx
+++ b/packages/react-dom/tests/AsyncLink.spec.tsx
@@ -213,7 +213,7 @@ describe("<AsyncLink>", () => {
       ]);
       const router = curi(history, routes);
       const Router = curiProvider(router);
-      const children = jest.fn(() => null);
+      const children = jest.fn((a: boolean) => null);
       ReactDOM.render(
         <Router>
           <AsyncLink name="Test">{children}</AsyncLink>
@@ -228,13 +228,13 @@ describe("<AsyncLink>", () => {
   describe("clicking a link", () => {
     it("calls history.navigate", () => {
       const history = InMemory();
-      const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      const mockNavigate = jest.fn();
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
       ReactDOM.render(
         <Router>
@@ -483,12 +483,12 @@ describe("<AsyncLink>", () => {
     it("includes hash, query, and state in location passed to history.navigate", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       ReactDOM.render(
@@ -525,13 +525,13 @@ describe("<AsyncLink>", () => {
       it("calls onNav prop func if provided", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const onNav = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -562,7 +562,6 @@ describe("<AsyncLink>", () => {
       it("does not call history.navigate if onNav prevents default", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const onNav = jest.fn(event => {
           event.preventDefault();
         });
@@ -571,6 +570,7 @@ describe("<AsyncLink>", () => {
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -602,13 +602,12 @@ describe("<AsyncLink>", () => {
     it("doesn't call history.navigate for modified clicks", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
-
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       ReactDOM.render(
@@ -641,13 +640,12 @@ describe("<AsyncLink>", () => {
     it("doesn't call history.navigate if event.preventDefault has been called", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
-
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       ReactDOM.render(

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -230,13 +230,13 @@ describe("<Link>", () => {
       it("calls onNav prop func if provided", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const onNav = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -267,7 +267,6 @@ describe("<Link>", () => {
       it("does not call history.navigate if onNav prevents default", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const onNav = jest.fn(event => {
           event.preventDefault();
         });
@@ -276,6 +275,7 @@ describe("<Link>", () => {
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -307,13 +307,12 @@ describe("<Link>", () => {
     it("doesn't call history.navigate for modified clicks", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
-
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       ReactDOM.render(
@@ -346,13 +345,12 @@ describe("<Link>", () => {
     it("doesn't call history.navigate if event.preventDefault has been called", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
-
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       ReactDOM.render(

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@curi/react-universal": "file:../react-universal",
     "@curi/router": "file:../router",
-    "@hickory/root": "^2.0.0-alpha.4",
+    "@hickory/root": "^2.0.0-alpha.5",
     "@types/react": "^16.7.18",
     "@types/react-native": "^0.57.32"
   },

--- a/packages/react-native/tests/AsyncLink.spec.tsx
+++ b/packages/react-native/tests/AsyncLink.spec.tsx
@@ -70,9 +70,9 @@ describe("<AsyncLink>", () => {
       it("uses the pathname from current response's location if 'name' is not provided", () => {
         const history = InMemory({ locations: ["/the-initial-location"] });
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -99,9 +99,8 @@ describe("<AsyncLink>", () => {
       it("uses params to generate the location to navigate to", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
-
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const params = { name: "Glacier" };
@@ -120,9 +119,8 @@ describe("<AsyncLink>", () => {
       it("updates location to navigate to when props change", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
-
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const params = { name: "Glacier" };
@@ -156,13 +154,12 @@ describe("<AsyncLink>", () => {
       it("merges hash & query props with the pathname when creating href", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
-
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -188,12 +185,12 @@ describe("<AsyncLink>", () => {
     it("passes forward to the rendered anchor", () => {
       const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       const style = { backgroundColor: "red" };
@@ -213,12 +210,12 @@ describe("<AsyncLink>", () => {
     it("returns the anchor's ref, not the link's", () => {
       const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const routes = prepareRoutes([
         { name: "Parks", path: "parks" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       const ref = React.createRef();
@@ -259,19 +256,15 @@ describe("<AsyncLink>", () => {
 
   describe("pressing a link", () => {
     describe("navigation method", () => {
-      let history, mockNavigate, mockPush, mockReplace;
-
-      beforeEach(() => {
-        history = InMemory();
-        history.navigate = mockNavigate = jest.fn();
-      });
-
       it('method="anchor"', () => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -287,11 +280,14 @@ describe("<AsyncLink>", () => {
       });
 
       it('method="push"', () => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -307,11 +303,14 @@ describe("<AsyncLink>", () => {
       });
 
       it('method="replace"', () => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -518,14 +517,13 @@ describe("<AsyncLink>", () => {
       it("calls onNav prop func if provided", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const onNav = jest.fn();
-
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -545,16 +543,15 @@ describe("<AsyncLink>", () => {
       it("does not call history.navigate if onNav prevents default", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const onNav = jest.fn(event => {
           event.preventDefault();
         });
-
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -574,13 +571,12 @@ describe("<AsyncLink>", () => {
     it("doesn't call history.navigate if event.preventDefault has been called", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
-
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       const tree = renderer.create(

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -72,9 +72,9 @@ describe("<Link>", () => {
       it("uses the pathname from current response's location if 'name' is not provided", () => {
         const history = InMemory({ locations: ["/the-initial-location"] });
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -101,9 +101,8 @@ describe("<Link>", () => {
       it("uses params to generate the location to navigate to", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
-
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const params = { name: "Glacier" };
@@ -122,9 +121,8 @@ describe("<Link>", () => {
       it("updates location to navigate to when props change", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
-
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const params = { name: "Glacier" };
@@ -158,13 +156,12 @@ describe("<Link>", () => {
       it("merges hash & query props with the pathname when creating href", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
-
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -190,12 +187,12 @@ describe("<Link>", () => {
     it("passes forward to the rendered anchor", () => {
       const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       const style = { backgroundColor: "red" };
@@ -215,12 +212,12 @@ describe("<Link>", () => {
     it("returns the anchor's ref, not the link's", () => {
       const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const routes = prepareRoutes([
         { name: "Parks", path: "parks" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       const ref = React.createRef();
@@ -263,19 +260,15 @@ describe("<Link>", () => {
 
   describe("pressing a link", () => {
     describe("navigation method", () => {
-      let history, mockNavigate, mockPush, mockReplace;
-
-      beforeEach(() => {
-        history = InMemory();
-        history.navigate = mockNavigate = jest.fn();
-      });
-
       it('method="anchor"', () => {
+        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        const mockNavigate = jest.fn();
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -291,11 +284,14 @@ describe("<Link>", () => {
       });
 
       it('method="push"', () => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -311,11 +307,14 @@ describe("<Link>", () => {
       });
 
       it('method="replace"', () => {
+        const history = InMemory();
+        const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -335,14 +334,13 @@ describe("<Link>", () => {
       it("calls onNav prop func if provided", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const onNav = jest.fn();
-
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -362,16 +360,15 @@ describe("<Link>", () => {
       it("does not call history.navigate if onNav prevents default", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
         const onNav = jest.fn(event => {
           event.preventDefault();
         });
-
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -391,13 +388,12 @@ describe("<Link>", () => {
     it("doesn't call history.navigate if event.preventDefault has been called", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
-
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       const tree = renderer.create(

--- a/packages/react-universal/package.json
+++ b/packages/react-universal/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@curi/router": "file:../router",
-    "@hickory/root": "^2.0.0-alpha.4",
+    "@hickory/root": "^2.0.0-alpha.5",
     "@types/react": "^16.7.18"
   }
 }

--- a/packages/react-universal/tests/curiProvider.spec.tsx
+++ b/packages/react-universal/tests/curiProvider.spec.tsx
@@ -72,8 +72,6 @@ describe("curiProvider()", () => {
     it("re-renders when the location changes", async () => {
       const history = InMemory();
       const router = curi(history, routes);
-      let pushedHistory = false;
-      let firstCall = true;
 
       let currentResponse;
 
@@ -95,7 +93,7 @@ describe("curiProvider()", () => {
 
       await wait(15);
 
-      history.navigate("/about");
+      router.history.navigate("/about");
 
       expect(currentResponse.name).toBe("About");
     });

--- a/packages/react-universal/tests/curiProvider.spec.tsx
+++ b/packages/react-universal/tests/curiProvider.spec.tsx
@@ -93,7 +93,7 @@ describe("curiProvider()", () => {
 
       await wait(15);
 
-      router.history.navigate("/about");
+      router.navigate({ name: "About" });
 
       expect(currentResponse.name).toBe("About");
     });

--- a/packages/react-universal/tests/useNavigationHandler.spec.tsx
+++ b/packages/react-universal/tests/useNavigationHandler.spec.tsx
@@ -47,12 +47,12 @@ describe("useNavigationHandler", () => {
     it("it uses nav props (name, params, hash, query, and state) to generate nav location", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       function Link(props) {
@@ -87,13 +87,13 @@ describe("useNavigationHandler", () => {
     it("calls onNav prop func if provided", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const onNav = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       function Link(props) {
@@ -128,13 +128,12 @@ describe("useNavigationHandler", () => {
       it("does not call history.navigate if canNavigate returns false", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
-
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         function Link(props) {

--- a/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
+++ b/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
@@ -52,12 +52,12 @@ describe("useStatefulNavigationHandler", () => {
     it("it uses nav props (name, params, hash, query, and state) to generate nav location", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       function AsyncLink(props) {
@@ -94,13 +94,13 @@ describe("useStatefulNavigationHandler", () => {
     it("calls onNav prop func if provided", () => {
       const history = InMemory();
       const mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
       const onNav = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
       const router = curi(history, routes);
+      router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
       function AsyncLink(props) {
@@ -137,13 +137,12 @@ describe("useStatefulNavigationHandler", () => {
       it("does not call history.navigate if canNavigate returns false", () => {
         const history = InMemory();
         const mockNavigate = jest.fn();
-        history.navigate = mockNavigate;
-
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
         const router = curi(history, routes);
+        router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
         function AsyncLink(props) {

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 18038,
-    "minified": 6130,
-    "gzipped": 2440,
+    "bundled": 17808,
+    "minified": 6137,
+    "gzipped": 2435,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 18273,
-    "minified": 6320,
-    "gzipped": 2522
+    "bundled": 18043,
+    "minified": 6327,
+    "gzipped": 2515
   },
   "dist/curi-router.umd.js": {
-    "bundled": 29784,
-    "minified": 8910,
-    "gzipped": 3673
+    "bundled": 29548,
+    "minified": 8917,
+    "gzipped": 3668
   },
   "dist/curi-router.min.js": {
-    "bundled": 29744,
-    "minified": 8870,
-    "gzipped": 3656
+    "bundled": 29508,
+    "minified": 8877,
+    "gzipped": 3650
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -33,7 +33,7 @@
   "author": "Paul Sherman",
   "license": "MIT",
   "dependencies": {
-    "@hickory/root": "^2.0.0-alpha.4",
+    "@hickory/root": "^2.0.0-alpha.5",
     "path-to-regexp": "^2.1.0"
   }
 }

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -80,6 +80,7 @@ export default function createRouter(
         ? mostRecent.navigation.previous
         : null
       : mostRecent.response;
+    refreshing = false;
     const navigation: Navigation = {
       action: pendingNav.action,
       previous

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -449,7 +449,7 @@ describe("curi", () => {
         router.observe(r => {
           if (!navigated) {
             navigated = true;
-            router.history.navigate({ pathname: "/parent" });
+            router.navigate({ name: "Parent" });
             after();
             return;
           }
@@ -649,6 +649,7 @@ describe("curi", () => {
     it("returns a function to unsubscribe when called", () => {
       const routes = prepareRoutes([
         { name: "Home", path: "" },
+        { name: "Next", path: "next" },
         { name: "Not Found", path: "(.*)" }
       ]);
       const router = curi(history, routes);
@@ -664,7 +665,7 @@ describe("curi", () => {
       expect(sub1.mock.calls.length).toBe(0);
       expect(sub2.mock.calls.length).toBe(0);
       unsub1();
-      router.history.navigate({ pathname: "/next" });
+      router.navigate({ name: "Next" });
 
       expect(sub1.mock.calls.length).toBe(0);
       expect(sub2.mock.calls.length).toBe(1);
@@ -690,11 +691,14 @@ describe("curi", () => {
       });
 
       it("is called when response is emitted", () => {
-        const How = { name: "How", path: ":method" };
         const routes = prepareRoutes([
           { name: "Home", path: "" },
           { name: "About", path: "about" },
-          { name: "Contact", path: "contact", children: [How] }
+          {
+            name: "Contact",
+            path: "contact",
+            children: [{ name: "How", path: ":method" }]
+          }
         ]);
 
         const check = ({ response, navigation }) => {
@@ -713,7 +717,7 @@ describe("curi", () => {
         const router = curi(history, routes);
         // register before navigation, but don't call with existing response
         router.observe(check, { initial: false });
-        router.history.navigate("/contact/mail");
+        router.navigate({ name: "How", params: { method: "mail" } });
       });
 
       it("is re-called for new responses", done => {
@@ -821,8 +825,14 @@ describe("curi", () => {
           const history = InMemory({ locations: ["/contact/fax"] });
           const router = curi(history, routes);
           router.observe(check);
-          router.history.navigate("/contact/phone");
-          router.history.navigate("/contact/mail");
+          router.navigate({
+            name: "How",
+            params: { method: "phone" }
+          });
+          router.navigate({
+            name: "How",
+            params: { method: "mail" }
+          });
         });
       });
     });
@@ -895,17 +905,18 @@ describe("curi", () => {
         it("is called AFTER next navigation", done => {
           const routes = prepareRoutes([
             { name: "Home", path: "" },
+            { name: "About", path: "about" },
             { name: "Catch All", path: "(.*)" }
           ]);
           const everyTime = jest.fn(({ response }) => {
-            expect(response.name).toBe("Catch All");
+            expect(response.name).toBe("About");
             done();
           });
           const router = curi(history, routes);
           router.once(() => {
             router.observe(everyTime, { initial: false });
             expect(everyTime.mock.calls.length).toBe(0);
-            router.history.navigate("/somewhere-else");
+            router.navigate({ name: "About" });
           });
         });
       });
@@ -1057,8 +1068,14 @@ describe("curi", () => {
           const history = InMemory({ locations: ["/contact/fax"] });
           const router = curi(history, routes);
           router.once(check);
-          router.history.navigate("/contact/phone");
-          router.history.navigate("/contact/mail");
+          router.navigate({
+            name: "How",
+            params: { method: "phone" }
+          });
+          router.navigate({
+            name: "How",
+            params: { method: "mail" }
+          });
         });
       });
     });
@@ -1131,17 +1148,18 @@ describe("curi", () => {
         it("is called AFTER next navigation", done => {
           const routes = prepareRoutes([
             { name: "Home", path: "" },
+            { name: "About", path: "about" },
             { name: "Catch All", path: "(.*)" }
           ]);
           const oneTime = jest.fn(({ response }) => {
-            expect(response.name).toBe("Catch All");
+            expect(response.name).toBe("About");
             done();
           });
           const router = curi(history, routes);
           router.once(() => {
             router.once(oneTime, { initial: false });
             expect(oneTime.mock.calls.length).toBe(0);
-            router.history.navigate("/somewhere-else");
+            router.navigate({ name: "About" });
           });
         });
       });

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -222,7 +222,7 @@ describe("route matching/response generation", () => {
           const history = InMemory({ locations: ["/other-page"] });
           const router = curi(history, routes);
           const { response } = router.current();
-          expect(response.location).toBe(history.location);
+          expect(response.location).toBe(router.history.location);
         });
       });
 
@@ -699,7 +699,7 @@ describe("route matching/response generation", () => {
 
         const history = InMemory({ locations: ["/first"] });
         const router = curi(history, routes);
-        history.navigate("/second");
+        router.history.navigate("/second");
       });
 
       describe("resolved", () => {

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -699,7 +699,7 @@ describe("route matching/response generation", () => {
 
         const history = InMemory({ locations: ["/first"] });
         const router = curi(history, routes);
-        router.history.navigate("/second");
+        router.navigate({ name: "Second" });
       });
 
       describe("resolved", () => {

--- a/packages/router/types/curi.d.ts
+++ b/packages/router/types/curi.d.ts
@@ -1,4 +1,6 @@
-import { History } from "@hickory/root";
+import { History, PendingNavigation } from "@hickory/root";
 import { CompiledRouteArray } from "./types/route";
 import { CuriRouter, RouterOptions } from "./types/curi";
-export default function createRouter(history: History, routeArray: CompiledRouteArray, options?: RouterOptions): CuriRouter;
+declare type PendingHistory = (fn: (p: PendingNavigation) => void) => History;
+export default function createRouter(pendingHistory: PendingHistory, routeArray: CompiledRouteArray, options?: RouterOptions): CuriRouter;
+export {};

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@curi/router": "file:../router",
-    "@hickory/in-memory": "^2.0.0-alpha.4",
+    "@hickory/in-memory": "^2.0.0-alpha.5",
     "@types/express": "^4.16.0",
     "@types/fs-extra": "^5.0.4",
     "fs-extra": "^7.0.0"

--- a/packages/svelte/tests/cases/link/click/index.js
+++ b/packages/svelte/tests/cases/link/click/index.js
@@ -17,11 +17,12 @@ const store = curiStore(router);
 
 export default function render() {
   const target = document.createElement("div");
-  history.navigate = jest.fn();
+  const mockNavigate = jest.fn();
+  router.history.navigate = mockNavigate;
   new app({ target, store });
 
   const a = target.querySelector("a");
   const event = simulant("click");
   simulant.fire(a, event);
-  expect(history.navigate.mock.calls.length).toBe(1);
+  expect(mockNavigate.mock.calls.length).toBe(1);
 }

--- a/packages/svelte/tests/cases/link/mod-click/index.js
+++ b/packages/svelte/tests/cases/link/mod-click/index.js
@@ -17,7 +17,8 @@ const store = curiStore(router);
 
 export default function render() {
   const target = document.createElement("div");
-  history.navigate = jest.fn();
+  const mockNavigate = jest.fn();
+  router.history.navigate = mockNavigate;
   new app({ target, store });
 
   const a = target.querySelector("a");
@@ -25,6 +26,6 @@ export default function render() {
   const modifiers = ["metaKey", "altKey", "ctrlKey", "shiftKey"];
   modifiers.forEach(m => {
     simulant.fire(a, "click", { [m]: true });
-    expect(history.navigate.mock.calls.length).toBe(0);
+    expect(mockNavigate.mock.calls.length).toBe(0);
   });
 }

--- a/packages/svelte/tests/cases/link/not-left-click/index.js
+++ b/packages/svelte/tests/cases/link/not-left-click/index.js
@@ -17,11 +17,12 @@ const store = curiStore(router);
 
 export default function render() {
   const target = document.createElement("div");
-  history.navigate = jest.fn();
+  const mockNavigate = jest.fn();
+  router.history.navigate = mockNavigate;
   new app({ target, store });
 
   const a = target.querySelector("a");
   const event = simulant("click", { button: 1 });
   simulant.fire(a, event);
-  expect(history.navigate.mock.calls.length).toBe(0);
+  expect(mockNavigate.mock.calls.length).toBe(0);
 }

--- a/packages/svelte/tests/cases/link/prevent-click/index.js
+++ b/packages/svelte/tests/cases/link/prevent-click/index.js
@@ -17,12 +17,13 @@ const store = curiStore(router);
 
 export default function render() {
   const target = document.createElement("div");
-  history.navigate = jest.fn();
+  const mockNavigate = jest.fn();
+  router.history.navigate = mockNavigate;
   new app({ target, store });
 
   const a = target.querySelector("a");
   const event = simulant("click");
   event.preventDefault();
   simulant.fire(a, event);
-  expect(history.navigate.mock.calls.length).toBe(0);
+  expect(mockNavigate.mock.calls.length).toBe(0);
 }

--- a/packages/svelte/tests/store.spec.js
+++ b/packages/svelte/tests/store.spec.js
@@ -65,7 +65,7 @@ describe("curiStore", () => {
       navigation: initialNavigation
     });
 
-    history.navigate("/about");
+    router.navigate({ name: "About" });
 
     const { response: currentResponse } = router.current();
     const { response: aboutResponse } = store.get().curi;

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -35,6 +35,6 @@
   },
   "dependencies": {
     "@curi/router": "file:../router",
-    "@hickory/root": "^2.0.0-alpha.4"
+    "@hickory/root": "^2.0.0-alpha.5"
   }
 }

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -105,7 +105,7 @@ describe("<curi-link>", () => {
     let mockNavigate;
     beforeEach(() => {
       mockNavigate = jest.fn();
-      history.navigate = mockNavigate;
+      router.history.navigate = mockNavigate;
     });
 
     afterEach(() => {

--- a/website/package.json
+++ b/website/package.json
@@ -31,8 +31,8 @@
     "@curi/static": "file:../packages/static",
     "@emotion/core": "^10.0.6",
     "@emotion/styled": "^10.0.6",
-    "@hickory/browser": "^2.0.0-alpha.1",
-    "@hickory/in-memory": "^2.0.0-alpha.1",
+    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/in-memory": "^2.0.0-alpha.5",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }


### PR DESCRIPTION
The `curi` function is passed a pending history, not a history. This is only a breaking change if an application was using the `history` instance outside of the router. Any code can be adapted to use `router.history` (although any direct usage of the `history` object should be limited).