### PR TITLE
Use hickory constructors when creating router

### DIFF
--- a/examples/misc/code-splitting/package.json
+++ b/examples/misc/code-splitting/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/examples/misc/code-splitting/src/index.js
+++ b/examples/misc/code-splitting/src/index.js
@@ -8,8 +8,7 @@ import { curi } from "@curi/router";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 const Router = curiProvider(router);
 
 router.once(() => {

--- a/examples/misc/server-rendering/package.json
+++ b/examples/misc/server-rendering/package.json
@@ -19,7 +19,7 @@
     "@babel/register": "^7.0.0",
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "@hickory/in-memory": "2.0.0-alpha.5",
     "express": "^4.16.2",
     "react": "^16.8.0-alpha.1",

--- a/examples/misc/server-rendering/renderer.js
+++ b/examples/misc/server-rendering/renderer.js
@@ -7,9 +7,11 @@ import routes from "./src/routes";
 import App from "./src/components/App";
 
 export default function(req, res) {
-  const history = InMemory({ locations: [req.url] });
-  const router = curi(history, routes, {
-    automaticRedirects: false
+  const router = curi(InMemory, routes, {
+    automaticRedirects: false,
+    history: {
+      locations: [req.url]
+    }
   });
   const Router = curiProvider(router);
   router.once(({ response }) => {

--- a/examples/misc/server-rendering/src/index.js
+++ b/examples/misc/server-rendering/src/index.js
@@ -7,12 +7,10 @@ import { curiProvider } from "@curi/react-dom";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   emitRedirects: false
 });
 const Router = curiProvider(router);
-const root = document.getElementById("root");
 
 router.once(() => {
   ReactDOM.hydrate(

--- a/examples/misc/side-effect/package.json
+++ b/examples/misc/side-effect/package.json
@@ -13,7 +13,7 @@
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
     "@curi/side-effect-title": "file:../../../packages/side-effects/side-effect-title",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/examples/misc/side-effect/src/index.js
+++ b/examples/misc/side-effect/src/index.js
@@ -11,8 +11,7 @@ import App from "./components/App";
 const setTitle = createTitleSideEffect(
   ({ response }) => `${response.title} | Side Effect Example`
 );
-const history = Browser();
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   sideEffects: [setTitle]
 });
 const Router = curiProvider(router);

--- a/examples/misc/umd-example/public/index.html
+++ b/examples/misc/umd-example/public/index.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>UMD Example</title>
-</head>
-<body>
-  <div id="root"></div>
+  <head>
+    <title>UMD Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
 
-  <script src="https://unpkg.com/react@16.3.2/umd/react.production.min.js"></script>
-  <script src="https://unpkg.com/react-dom@16.3.2/umd/react-dom.production.min.js"></script>
-  <script src="https://unpkg.com/@hickory/hash/dist/hickory-hash.min.js"></script>
-  <script src="https://unpkg.com/@curi/router/dist/curi.min.js"></script>
-  <script src="https://unpkg.com/@curi/react-dom/dist/curi-react.min.js"></script>
-  <script src="./index.js"></script>
-</body>
+    <script src="https://unpkg.com/react@16.8.0/umd/react.production.min.js"></script>
+    <script src="https://unpkg.com/react-dom@16.8.0/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/@hickory/hash/dist/hickory-hash.min.js"></script>
+    <script src="https://unpkg.com/@curi/router/dist/curi.min.js"></script>
+    <script src="https://unpkg.com/@curi/react-dom/dist/curi-react.min.js"></script>
+    <script src="./index.js"></script>
+  </body>
 </html>

--- a/examples/misc/umd-example/public/index.js
+++ b/examples/misc/umd-example/public/index.js
@@ -14,7 +14,6 @@ const Nav = () =>
     )
   );
 
-const hashHistory = HickoryHash();
 const routes = [
   {
     name: "Home",
@@ -36,7 +35,7 @@ const routes = [
   }
 ];
 
-const router = Curi.curi(hashHistory, routes);
+const router = Curi.curi(HickoryHash, routes);
 const Router = CuriReactDOM.curiProvider(router);
 const root = document.getElementById("root");
 

--- a/examples/misc/updating-routes/package.json
+++ b/examples/misc/updating-routes/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/examples/misc/updating-routes/src/index.js
+++ b/examples/misc/updating-routes/src/index.js
@@ -7,8 +7,7 @@ import { curiProvider } from "@curi/react-dom";
 import App from "./components/App";
 import { baseRoutes } from "./routes";
 
-const history = Browser();
-const router = curi(history, baseRoutes);
+const router = curi(Browser, baseRoutes);
 const Router = curiProvider(router);
 
 ReactDOM.render(

--- a/examples/react/accessibility/package.json
+++ b/examples/react/accessibility/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/examples/react/accessibility/src/index.js
+++ b/examples/react/accessibility/src/index.js
@@ -7,8 +7,7 @@ import { curiProvider } from "@curi/react-dom";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 const Router = curiProvider(router);
 
 ReactDOM.render(

--- a/examples/react/active-links/package.json
+++ b/examples/react/active-links/package.json
@@ -15,7 +15,7 @@
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/route-active": "file:../../../packages/interactions/route-active",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/examples/react/active-links/src/index.js
+++ b/examples/react/active-links/src/index.js
@@ -8,9 +8,7 @@ import { curiProvider } from "@curi/react-dom";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   route: [active()]
 });
 const Router = curiProvider(router);

--- a/examples/react/async-nav/package.json
+++ b/examples/react/async-nav/package.json
@@ -15,7 +15,7 @@
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/route-prefetch": "file:../../../packages/interactions/route-prefetch",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1",
     "react-spinkit": "^3.0.0"

--- a/examples/react/async-nav/src/index.js
+++ b/examples/react/async-nav/src/index.js
@@ -8,8 +8,7 @@ import routes from "./routes";
 import Controls from "./components/Controls";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 const Router = curiProvider(router);
 
 router.once(() => {

--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/examples/react/basic/src/index.js
+++ b/examples/react/basic/src/index.js
@@ -7,8 +7,7 @@ import { curiProvider } from "@curi/react-dom";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 const Router = curiProvider(router);
 
 ReactDOM.render(

--- a/examples/react/breadcrumbs/package.json
+++ b/examples/react/breadcrumbs/package.json
@@ -15,7 +15,7 @@
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/route-ancestors": "file:../../../packages/interactions/route-ancestors",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/examples/react/breadcrumbs/src/index.js
+++ b/examples/react/breadcrumbs/src/index.js
@@ -34,8 +34,7 @@ function titleText() {
   };
 }
 
-const history = Browser();
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   route: [ancestors(), titleText()]
 });
 const Router = curiProvider(router);

--- a/examples/react/data-loading/package.json
+++ b/examples/react/data-loading/package.json
@@ -15,7 +15,7 @@
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/route-prefetch": "file:../../../packages/interactions/route-prefetch",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/examples/react/data-loading/src/index.js
+++ b/examples/react/data-loading/src/index.js
@@ -8,9 +8,7 @@ import prefetch from "@curi/route-prefetch";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   route: [prefetch()]
 });
 const Router = curiProvider(router);

--- a/examples/react/modal/package.json
+++ b/examples/react/modal/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/examples/react/modal/src/index.js
+++ b/examples/react/modal/src/index.js
@@ -7,8 +7,7 @@ import { curiProvider } from "@curi/react-dom";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 const Router = curiProvider(router);
 
 ReactDOM.render(

--- a/examples/react/multi-body/package.json
+++ b/examples/react/multi-body/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "prop-types": "^15.6.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"

--- a/examples/react/multi-body/src/index.js
+++ b/examples/react/multi-body/src/index.js
@@ -7,8 +7,7 @@ import { curiProvider } from "@curi/react-dom";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 const Router = curiProvider(router);
 
 ReactDOM.render(

--- a/examples/react/redirects/package.json
+++ b/examples/react/redirects/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "qs": "^6.4.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"

--- a/examples/react/redirects/src/index.js
+++ b/examples/react/redirects/src/index.js
@@ -11,7 +11,7 @@ import App from "./components/App";
 const history = Browser({
   query: { parse, stringify }
 });
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   emitRedirects: false
 });
 const Router = curiProvider(router);

--- a/examples/react/transitions/package.json
+++ b/examples/react/transitions/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/react-dom": "file:../../../packages/react-dom",
     "@curi/router": "file:../../../packages/router",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1",
     "react-transition-group": "^2.2.1"

--- a/examples/react/transitions/src/index.js
+++ b/examples/react/transitions/src/index.js
@@ -7,8 +7,7 @@ import { curiProvider } from "@curi/react-dom";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 const Router = curiProvider(router);
 
 ReactDOM.render(

--- a/examples/svelte/active-links/src/index.js
+++ b/examples/svelte/active-links/src/index.js
@@ -1,14 +1,12 @@
 import { Browser } from "@hickory/browser";
 import { curi } from "@curi/router";
 import { curiStore } from "@curi/svelte";
-import { Store } from "svelte/store";
 import active from "@curi/route-active";
 
 import routes from "./routes";
 import app from "./components/App.html";
 
-const history = Browser();
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   route: [active()]
 });
 const store = curiStore(router);

--- a/examples/svelte/async-nav/package.json
+++ b/examples/svelte/async-nav/package.json
@@ -13,7 +13,7 @@
     "@curi/route-prefetch": "file:../../../packages/interactions/route-prefetch",
     "@curi/router": "file:../../../packages/router",
     "@curi/svelte": "file:../../../packages/svelte",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "svelte-spinner": "^1.0.0"
   }
 }

--- a/examples/svelte/async-nav/src/index.js
+++ b/examples/svelte/async-nav/src/index.js
@@ -1,13 +1,11 @@
 import { Browser } from "@hickory/browser";
 import { curi } from "@curi/router";
 import { curiStore } from "@curi/svelte";
-import { Store } from "svelte/store";
 
 import routes from "./routes";
 import app from "./components/App.html";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 const store = curiStore(router);
 
 const target = document.getElementById("root");

--- a/examples/svelte/basic/src/index.js
+++ b/examples/svelte/basic/src/index.js
@@ -1,13 +1,11 @@
 import { Browser } from "@hickory/browser";
 import { curi } from "@curi/router";
 import { curiStore } from "@curi/svelte";
-import { Store } from "svelte/store";
 
 import routes from "./routes";
 import app from "./components/App.html";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 const store = curiStore(router);
 
 const target = document.getElementById("root");

--- a/examples/svelte/breadcrumbs/src/index.js
+++ b/examples/svelte/breadcrumbs/src/index.js
@@ -1,7 +1,6 @@
 import { Browser } from "@hickory/browser";
 import { curi } from "@curi/router";
 import { curiStore } from "@curi/svelte";
-import { Store } from "svelte/store";
 import ancestors from "@curi/route-ancestors";
 
 import routes from "./routes";
@@ -33,8 +32,7 @@ function titleText() {
   };
 }
 
-const history = Browser();
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   route: [ancestors(), titleText()]
 });
 

--- a/examples/svelte/redirects/package.json
+++ b/examples/svelte/redirects/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "file:../../../packages/router",
     "@curi/svelte": "file:../../../packages/svelte",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "qs": "^6.4.0"
   }
 }

--- a/examples/svelte/redirects/src/index.js
+++ b/examples/svelte/redirects/src/index.js
@@ -10,7 +10,7 @@ import app from "./components/App.html";
 const history = Browser({
   query: { parse, stringify }
 });
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   emitRedirects: false
 });
 const store = curiStore(router);

--- a/examples/vue/accessibility/package.json
+++ b/examples/vue/accessibility/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "file:../../../packages/router",
     "@curi/vue": "file:../../../packages/vue",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/accessibility/src/index.js
+++ b/examples/vue/accessibility/src/index.js
@@ -6,8 +6,7 @@ import { Browser } from "@hickory/browser";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 
 Vue.use(CuriPlugin, { router });
 

--- a/examples/vue/active-links/package.json
+++ b/examples/vue/active-links/package.json
@@ -19,7 +19,7 @@
     "@curi/route-active": "file:../../../packages/interactions/route-active",
     "@curi/router": "file:../../../packages/router",
     "@curi/vue": "file:../../../packages/vue",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/active-links/src/index.js
+++ b/examples/vue/active-links/src/index.js
@@ -7,9 +7,7 @@ import active from "@curi/route-active";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   route: [active()]
 });
 

--- a/examples/vue/async-nav/package.json
+++ b/examples/vue/async-nav/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@curi/router": "file:../../../packages/router",
     "@curi/vue": "file:../../../packages/vue",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "epic-spinners": "^1.0.3",
     "vue": "^2.5.22"
   }

--- a/examples/vue/async-nav/src/index.js
+++ b/examples/vue/async-nav/src/index.js
@@ -6,8 +6,7 @@ import { CuriPlugin } from "@curi/vue";
 import routes from "./routes";
 import app from "./components/app";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 
 Vue.use(CuriPlugin, { router });
 

--- a/examples/vue/basic/package.json
+++ b/examples/vue/basic/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "file:../../../packages/router",
     "@curi/vue": "file:../../../packages/vue",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/basic/src/index.js
+++ b/examples/vue/basic/src/index.js
@@ -6,8 +6,7 @@ import { Browser } from "@hickory/browser";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 
 Vue.use(CuriPlugin, { router });
 

--- a/examples/vue/breadcrumbs/package.json
+++ b/examples/vue/breadcrumbs/package.json
@@ -15,7 +15,7 @@
     "@curi/route-ancestors": "file:../../../packages/interactions/route-ancestors",
     "@curi/router": "file:../../../packages/router",
     "@curi/vue": "file:../../../packages/vue",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/breadcrumbs/src/index.js
+++ b/examples/vue/breadcrumbs/src/index.js
@@ -34,8 +34,7 @@ function titleText() {
   };
 }
 
-const history = Browser();
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   route: [ancestors(), titleText()]
 });
 

--- a/examples/vue/modal/package.json
+++ b/examples/vue/modal/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@curi/router": "file:../../../packages/router",
     "@curi/vue": "file:../../../packages/vue",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/modal/src/index.js
+++ b/examples/vue/modal/src/index.js
@@ -6,8 +6,7 @@ import { Browser } from "@hickory/browser";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 
 Vue.use(CuriPlugin, { router });
 

--- a/examples/vue/redirects/package.json
+++ b/examples/vue/redirects/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "file:../../../packages/router",
     "@curi/vue": "file:../../../packages/vue",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "qs": "^6.4.0",
     "vue": "^2.5.22",
     "vuex": "^3.0.1"

--- a/examples/vue/redirects/src/index.js
+++ b/examples/vue/redirects/src/index.js
@@ -11,7 +11,7 @@ import App from "./components/App";
 const history = Browser({
   query: { parse, stringify }
 });
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 
 Vue.use(CuriPlugin, { router });
 

--- a/examples/vue/transitions/package.json
+++ b/examples/vue/transitions/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "file:../../../packages/router",
     "@curi/vue": "file:../../../packages/vue",
-    "@hickory/browser": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/transitions/src/index.js
+++ b/examples/vue/transitions/src/index.js
@@ -6,8 +6,7 @@ import { CuriPlugin } from "@curi/vue";
 import routes from "./routes";
 import App from "./components/App";
 
-const history = Browser();
-const router = curi(history, routes);
+const router = curi(Browser, routes);
 
 Vue.use(CuriPlugin, { router });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1071,8 +1071,8 @@
         "@curi/static": "file:packages/static",
         "@emotion/core": "^10.0.6",
         "@emotion/styled": "^10.0.6",
-        "@hickory/browser": "^2.0.0-alpha.5",
-        "@hickory/in-memory": "^2.0.0-alpha.5",
+        "@hickory/browser": "^2.0.0-beta.0",
+        "@hickory/in-memory": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1080,18 +1080,18 @@
     "@curi-example/accessibility": {
       "version": "file:examples/vue/accessibility",
       "requires": {
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/vue": "1.0.0-beta.26",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/router": "file:packages/router",
+        "@curi/vue": "file:packages/vue",
+        "@hickory/browser": "^2.0.0-beta.0",
         "vue": "^2.5.22"
       }
     },
     "@curi-example/accessibility-react": {
       "version": "file:examples/react/accessibility",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1099,19 +1099,19 @@
     "@curi-example/acive-links-svelte": {
       "version": "file:examples/svelte/active-links",
       "requires": {
-        "@curi/route-active": "2.0.0-alpha.1",
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/svelte": "1.0.0-beta.13",
+        "@curi/route-active": "file:packages/interactions/route-active",
+        "@curi/router": "file:packages/router",
+        "@curi/svelte": "file:packages/svelte",
         "@hickory/browser": "^2.0.0-alpha.1"
       }
     },
     "@curi-example/active-links-react": {
       "version": "file:examples/react/active-links",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/route-active": "2.0.0-alpha.1",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/route-active": "file:packages/interactions/route-active",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1119,20 +1119,20 @@
     "@curi-example/active-links-vue": {
       "version": "file:examples/vue/active-links",
       "requires": {
-        "@curi/route-active": "2.0.0-alpha.1",
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/vue": "1.0.0-beta.26",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/route-active": "file:packages/interactions/route-active",
+        "@curi/router": "file:packages/router",
+        "@curi/vue": "file:packages/vue",
+        "@hickory/browser": "^2.0.0-beta.0",
         "vue": "^2.5.22"
       }
     },
     "@curi-example/async-nav-react": {
       "version": "file:examples/react/async-nav",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/route-prefetch": "2.0.0-alpha.0",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/route-prefetch": "file:packages/interactions/route-prefetch",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1",
         "react-spinkit": "^3.0.0"
@@ -1141,19 +1141,19 @@
     "@curi-example/async-nav-svelte": {
       "version": "file:examples/svelte/async-nav",
       "requires": {
-        "@curi/route-prefetch": "2.0.0-alpha.0",
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/svelte": "1.0.0-beta.13",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/route-prefetch": "file:packages/interactions/route-prefetch",
+        "@curi/router": "file:packages/router",
+        "@curi/svelte": "file:packages/svelte",
+        "@hickory/browser": "^2.0.0-beta.0",
         "svelte-spinner": "^1.0.0"
       }
     },
     "@curi-example/async-nav-vue": {
       "version": "file:examples/vue/async-nav",
       "requires": {
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/vue": "1.0.0-beta.26",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/router": "file:packages/router",
+        "@curi/vue": "file:packages/vue",
+        "@hickory/browser": "^2.0.0-beta.0",
         "epic-spinners": "^1.0.3",
         "vue": "^2.5.22"
       }
@@ -1161,9 +1161,9 @@
     "@curi-example/authentication-react": {
       "version": "file:examples/react/redirects",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "qs": "^6.4.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
@@ -1172,18 +1172,18 @@
     "@curi-example/authentication-svelte": {
       "version": "file:examples/svelte/redirects",
       "requires": {
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/svelte": "1.0.0-beta.13",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/router": "file:packages/router",
+        "@curi/svelte": "file:packages/svelte",
+        "@hickory/browser": "^2.0.0-beta.0",
         "qs": "^6.4.0"
       }
     },
     "@curi-example/authentication-vue": {
       "version": "file:examples/vue/redirects",
       "requires": {
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/vue": "1.0.0-beta.26",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/router": "file:packages/router",
+        "@curi/vue": "file:packages/vue",
+        "@hickory/browser": "^2.0.0-beta.0",
         "qs": "^6.4.0",
         "vue": "^2.5.22",
         "vuex": "^3.0.1"
@@ -1192,9 +1192,9 @@
     "@curi-example/basic-react": {
       "version": "file:examples/react/basic",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1202,27 +1202,27 @@
     "@curi-example/basic-svelte": {
       "version": "file:examples/svelte/basic",
       "requires": {
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/svelte": "1.0.0-beta.13",
+        "@curi/router": "file:packages/router",
+        "@curi/svelte": "file:packages/svelte",
         "@hickory/browser": "^2.0.0-alpha.1"
       }
     },
     "@curi-example/basic-vue": {
       "version": "file:examples/vue/basic",
       "requires": {
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/vue": "1.0.0-beta.26",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/router": "file:packages/router",
+        "@curi/vue": "file:packages/vue",
+        "@hickory/browser": "^2.0.0-beta.0",
         "vue": "^2.5.22"
       }
     },
     "@curi-example/breadcrumbs-react": {
       "version": "file:examples/react/breadcrumbs",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/route-ancestors": "1.1.0",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/route-ancestors": "file:packages/interactions/route-ancestors",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1230,28 +1230,28 @@
     "@curi-example/breadcrumbs-svelte": {
       "version": "file:examples/svelte/breadcrumbs",
       "requires": {
-        "@curi/route-ancestors": "1.1.0",
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/svelte": "1.0.0-beta.13",
+        "@curi/route-ancestors": "file:packages/interactions/route-ancestors",
+        "@curi/router": "file:packages/router",
+        "@curi/svelte": "file:packages/svelte",
         "@hickory/browser": "^2.0.0-alpha.1"
       }
     },
     "@curi-example/breadcrumbs-vue": {
       "version": "file:examples/vue/breadcrumbs",
       "requires": {
-        "@curi/route-ancestors": "1.1.0",
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/vue": "1.0.0-beta.26",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/route-ancestors": "file:packages/interactions/route-ancestors",
+        "@curi/router": "file:packages/router",
+        "@curi/vue": "file:packages/vue",
+        "@hickory/browser": "^2.0.0-beta.0",
         "vue": "^2.5.22"
       }
     },
     "@curi-example/code-splitting": {
       "version": "file:examples/misc/code-splitting",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1259,10 +1259,10 @@
     "@curi-example/data-loading-react": {
       "version": "file:examples/react/data-loading",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/route-prefetch": "2.0.0-alpha.0",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/route-prefetch": "file:packages/interactions/route-prefetch",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1270,9 +1270,9 @@
     "@curi-example/modal-react": {
       "version": "file:examples/react/modal",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1280,18 +1280,18 @@
     "@curi-example/modal-vue": {
       "version": "file:examples/vue/modal",
       "requires": {
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/vue": "1.0.0-beta.26",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/router": "file:packages/router",
+        "@curi/vue": "file:packages/vue",
+        "@hickory/browser": "^2.0.0-beta.0",
         "vue": "^2.5.22"
       }
     },
     "@curi-example/multi-body-react": {
       "version": "file:examples/react/multi-body",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "prop-types": "^15.6.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
@@ -1307,22 +1307,31 @@
       "version": "file:examples/misc/server-rendering",
       "requires": {
         "@babel/register": "^7.0.0",
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "@hickory/in-memory": "2.0.0-alpha.5",
         "express": "^4.16.2",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
+      },
+      "dependencies": {
+        "@hickory/in-memory": {
+          "version": "2.0.0-alpha.5",
+          "bundled": true,
+          "requires": {
+            "@hickory/root": "^2.0.0-alpha.5"
+          }
+        }
       }
     },
     "@curi-example/side-effect": {
       "version": "file:examples/misc/side-effect",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/side-effect-title": "1.0.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@curi/side-effect-title": "file:packages/side-effects/side-effect-title",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1330,9 +1339,9 @@
     "@curi-example/transitions-react": {
       "version": "file:examples/react/transitions",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1",
         "react-transition-group": "^2.2.1"
@@ -1341,18 +1350,18 @@
     "@curi-example/transitions-vue": {
       "version": "file:examples/vue/transitions",
       "requires": {
-        "@curi/router": "2.0.0-alpha.1",
-        "@curi/vue": "1.0.0-beta.26",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/router": "file:packages/router",
+        "@curi/vue": "file:packages/vue",
+        "@hickory/browser": "^2.0.0-beta.0",
         "vue": "^2.5.22"
       }
     },
     "@curi-example/updating-routes": {
       "version": "file:examples/misc/updating-routes",
       "requires": {
-        "@curi/react-dom": "2.0.0-alpha.2",
-        "@curi/router": "2.0.0-alpha.1",
-        "@hickory/browser": "^2.0.0-alpha.5",
+        "@curi/react-dom": "file:packages/react-dom",
+        "@curi/router": "file:packages/router",
+        "@hickory/browser": "^2.0.0-beta.0",
         "react": "^16.8.0-alpha.1",
         "react-dom": "^16.8.0-alpha.1"
       }
@@ -1373,7 +1382,7 @@
       "requires": {
         "@curi/react-universal": "file:packages/react-universal",
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.5",
+        "@hickory/root": "^2.0.0-beta.0",
         "@types/react": "^16.7.18",
         "@types/react-native": "^0.57.32"
       }
@@ -1382,7 +1391,7 @@
       "version": "file:packages/react-universal",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.5",
+        "@hickory/root": "^2.0.0-beta.0",
         "@types/react": "^16.7.18"
       }
     },
@@ -1390,7 +1399,7 @@
       "version": "file:packages/interactions/route-active",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.5"
+        "@hickory/root": "^2.0.0-beta.0"
       }
     },
     "@curi/route-ancestors": {
@@ -1408,7 +1417,7 @@
     "@curi/router": {
       "version": "file:packages/router",
       "requires": {
-        "@hickory/root": "^2.0.0-alpha.5",
+        "@hickory/root": "^2.0.0-beta.0",
         "path-to-regexp": "^2.1.0"
       }
     },
@@ -1434,7 +1443,7 @@
       "version": "file:packages/static",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/in-memory": "^2.0.0-alpha.5",
+        "@hickory/in-memory": "^2.0.0-beta.0",
         "@types/express": "^4.16.0",
         "@types/fs-extra": "^5.0.4",
         "fs-extra": "^7.0.0"
@@ -1450,7 +1459,7 @@
       "version": "file:packages/vue",
       "requires": {
         "@curi/router": "file:packages/router",
-        "@hickory/root": "^2.0.0-alpha.5"
+        "@hickory/root": "^2.0.0-beta.0"
       }
     },
     "@emotion/cache": {
@@ -1562,38 +1571,38 @@
       "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA=="
     },
     "@hickory/browser": {
-      "version": "2.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@hickory/browser/-/browser-2.0.0-alpha.5.tgz",
-      "integrity": "sha512-Al6tfAIo8KtEXUelYLFPLGpVUAhMxeIivs/I+Cz051nPv/AEqSICuZlS4+Evd1osC0Ji/l0BaVtFPD3F1CP+JA==",
+      "version": "2.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@hickory/browser/-/browser-2.0.0-beta.0.tgz",
+      "integrity": "sha512-SLqmuAZnLj0s25YBrfmMYJNdIafYVghp7YBnwdtaClI5NL0nHKfDTNg8/wkfUzyfRPsu2c4m7tkVT9otwcYe5Q==",
       "requires": {
-        "@hickory/dom-utils": "^2.0.0-alpha.5",
-        "@hickory/root": "^2.0.0-alpha.5"
+        "@hickory/dom-utils": "^2.0.0-beta.0",
+        "@hickory/root": "^2.0.0-beta.0"
       }
     },
     "@hickory/dom-utils": {
-      "version": "2.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@hickory/dom-utils/-/dom-utils-2.0.0-alpha.5.tgz",
-      "integrity": "sha512-VVDWmw1m7MM1jPzh/36gQJCvAzV6CIA5GovhhlsfbNiEONtcZDyJn2HXJeLpCHxKSRomrPxGFR365sDpVovIEA=="
+      "version": "2.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@hickory/dom-utils/-/dom-utils-2.0.0-beta.0.tgz",
+      "integrity": "sha512-nC8nDenHohyJkFbZ4WRCQIYJF1hHzJIt6QVGWlvEISkzdoN/wT0jG9KQ1tjQEVJHMBzU197TALO+tpyD9DlIyA=="
     },
     "@hickory/in-memory": {
-      "version": "2.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-2.0.0-alpha.5.tgz",
-      "integrity": "sha512-c8RWGBwu0sB/5sKZngDgNkeutsLlzkrrx4fn77g2bZWitaZh0SdqRGRLoGhprEK9FvEEg/4R3xWw0YgcE52ddQ==",
+      "version": "2.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-2.0.0-beta.0.tgz",
+      "integrity": "sha512-VtKZ+CtkZyC5Kan0HlUOzYiXjEz3QREZLg7ULE1QfawulaBlG7ZAShUzIrfjfGeDGCRX1Adu+x90SkWtjIjbjQ==",
       "requires": {
-        "@hickory/root": "^2.0.0-alpha.5"
+        "@hickory/root": "^2.0.0-beta.0"
       }
     },
     "@hickory/location-utils": {
-      "version": "2.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-2.0.0-alpha.5.tgz",
-      "integrity": "sha512-qFIQUwLVZpTBVf9cphnPl4poCzrm0/WVSGSyjUsCBV20BP9+UqTq+dcicR5NswX2/Tg0S+VZNeawYTm9uyvULA=="
+      "version": "2.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-2.0.0-beta.0.tgz",
+      "integrity": "sha512-UqNtTXLagWLpWJTBYTMXTyj0ZFIhEAab82Kr38gGHKqmLv777VS7johmQ7WPooj/y2BSaDAMbnhvqwgFQ+Tv0w=="
     },
     "@hickory/root": {
-      "version": "2.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@hickory/root/-/root-2.0.0-alpha.5.tgz",
-      "integrity": "sha512-crPTOCdM+KOnRZo7Qt/0W446cV/cAcWZOa1mVygTvcXiKXqkveDAXWqMlYavy3g/NvOW4Jx2P/psdySw2EM6zw==",
+      "version": "2.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@hickory/root/-/root-2.0.0-beta.0.tgz",
+      "integrity": "sha512-4yxDdPea3iLm9BiJIjUNP4EsX35RqMRIxSzujqfND/Bcj1/iPWYj63qOurJN4MDM62DqI2jLjm0gsjA6nIVRNA==",
       "requires": {
-        "@hickory/location-utils": "^2.0.0-alpha.5"
+        "@hickory/location-utils": "^2.0.0-beta.0"
       }
     },
     "@lerna/add": {
@@ -2466,6 +2475,15 @@
         "octokit-pagination-methods": "^1.1.0",
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+      "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
       }
     },
     "@types/body-parser": {
@@ -3685,10 +3703,13 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.1.0.tgz",
-      "integrity": "sha512-gljYrZz8w1b6fJzKcsfKsipSru2DU2DmQ39aB6nV3xQ0DDv3zpIzKGortA5gknrhNnPN8DweaEgrnZdmbGmhnw==",
-      "dev": true
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.2.0.tgz",
+      "integrity": "sha512-U63Kx0ZbB6TFjcmRRZvkQfkBlh8beJ1q8CsO+cl4uAlr7bLZM0isvQP369fUEZeJJr/1yqRplzHj14TAmQ1r0Q==",
+      "dev": true,
+      "requires": {
+        "@types/babel__traverse": "^7.0.6"
+      }
     },
     "babel-plugin-macros": {
       "version": "2.5.0",
@@ -4695,9 +4716,9 @@
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camelcase": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.1.0.tgz",
-      "integrity": "sha512-WP9f9OBL/TAbwOFBJL79FoS9UKUmnp82RWnhlwTgrAJeMq7lytHhe0Jzc6/P7Zq0+2oviXJuPlvkZalWUug9gg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+      "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
       "dev": true
     },
     "camelcase-keys": {
@@ -4720,9 +4741,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000940",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000940.tgz",
-      "integrity": "sha512-rp/086IBUfCsNgBpko6DGQv674jRjeXPesDatDB2kxrkmDfD+S5Gesw+uT8YjpRWvLKLMRBy72SLRZ8I0EgQFw==",
+      "version": "1.0.30000941",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000941.tgz",
+      "integrity": "sha512-4vzGb2MfZcO20VMPj1j6nRAixhmtlhkypM4fL4zhgzEucQIYiRzSqPcWIu1OF8i0FETD93FMIPWfUJCAcFvrqA==",
       "dev": true
     },
     "capture-exit": {
@@ -5520,9 +5541,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
-      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
+      "integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -5861,9 +5882,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.0.0.tgz",
-      "integrity": "sha512-46OkIuVGBBnrC0soO/4LHu5LHGHx0uhP65OVz8XOrAJpqiCB2aVIuESvjI1F9oqebuvY8lekS1pt6TN7vt7qsw==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.2.0.tgz",
+      "integrity": "sha512-yvZNXjhIhe9DwBOKfdr1HKmvld95EzQkZOUjlZlPzzIBy01TM8oDweo2PT9WJmaHd8+J7DC8etgbJGHWWuVJxQ==",
       "dev": true
     },
     "diffie-hellman": {
@@ -9272,9 +9293,9 @@
       }
     },
     "jest-docblock": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.0.0.tgz",
-      "integrity": "sha512-KfAKZ4SN7CFOZpWg4i7g7MSlY0M+mq7K0aMqENaG2vHuhC9fc3vkpU/iNN9sOus7v3h3Y48uEjqz3+Gdn2iptA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.2.0.tgz",
+      "integrity": "sha512-BCo9v+rB61Hte9r2WUS2YHIsKVjW3oGnY2BhWZtSks2gxQjuDVR5QMGKVAywQtOCwmH92O9p2NgNpfpeu4MY8A==",
       "dev": true,
       "requires": {
         "detect-newline": "^2.1.0"
@@ -9314,9 +9335,9 @@
       }
     },
     "jest-get-type": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.0.0.tgz",
-      "integrity": "sha512-z6/Eyf6s9ZDGz7eOvl+fzpuJmN9i0KyTt1no37/dHu8galssxz5ZEgnc1KaV8R31q1khxyhB4ui/X5ZjjPk77w==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.2.0.tgz",
+      "integrity": "sha512-IWrgF05BU05R7vXs+UfL9NbPfInotQWZMWv5T/jU3h/wH7qg2GGZ/hqR7zA/+n6TtWvT/E2vBxCkB/3s6pHrIg==",
       "dev": true
     },
     "jest-haste-map": {
@@ -9396,9 +9417,9 @@
       "dev": true
     },
     "jest-regex-util": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.0.0.tgz",
-      "integrity": "sha512-Jv/uOTCuC+PY7WpJl2mpoI+WbY2ut73qwwO9ByJJNwOCwr1qWhEW2Lyi2S9ZewUdJqeVpEBisdEVZSI+Zxo58Q==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.2.0.tgz",
+      "integrity": "sha512-6zXSsbUdAPIbtThixsYMN+YsDW9yJ+ZOg5DfkdyPrk/I7CVkaXwD0eouNRWA3vD1NZXlgTbpoLXMYYC0gr0GYw==",
       "dev": true
     },
     "jest-resolve": {
@@ -12867,9 +12888,9 @@
       "dev": true
     },
     "react-devtools-core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.6.0.tgz",
-      "integrity": "sha512-picLP5RMESANerl2Ieo2rcMmVBqTG5QgIkSGcoJqvT5V4+HpLRjz5QW8xC85i+bXLdJmjoi3ZE9qDpNa5m7S4A==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.6.1.tgz",
+      "integrity": "sha512-I/LSX+tpeTrGKaF1wXSfJ/kP+6iaP2JfshEjW8LtQBdz6c6HhzOJtjZXhqOUrAdysuey8M1/JgPY1flSVVt8Ig==",
       "dev": true,
       "requires": {
         "shell-quote": "^1.6.1",
@@ -13633,9 +13654,9 @@
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
-      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.0.tgz",
+      "integrity": "sha512-tlYkVh6F/QXtosuyOZV2SkOtA248fjMAUWjGf8aYBvQK1ZMarbMvFBvkguSt93HhdXh20m15sc4b5EIBxXLHQQ==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0"
@@ -13681,17 +13702,17 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
-      "integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.2.tgz",
+      "integrity": "sha512-CgGxXmuX0Cf57z7KahSHe4kaNY8gBRCFFEretQ5AHsnlLx/5VdCrQOoOz1POxLdZjPbwE5ncTspPJwp2WHPcHA==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^7.0.0",
+        "regenerate-unicode-properties": "^8.0.0",
         "regjsgen": "^0.5.0",
         "regjsparser": "^0.6.0",
         "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.0.2"
+        "unicode-match-property-value-ecmascript": "^1.1.0"
       }
     },
     "regjsgen": {
@@ -15758,15 +15779,15 @@
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
-    "@hickory/in-memory": "^2.0.0-alpha.5",
+    "@hickory/in-memory": "^2.0.0-beta.0",
     "@types/fs-extra": "^5.0.4",
     "@types/jest": "^23.3.13",
     "@types/node": "^10.12.18",

--- a/packages/interactions/route-active/package.json
+++ b/packages/interactions/route-active/package.json
@@ -34,6 +34,6 @@
   "license": "MIT",
   "dependencies": {
     "@curi/router": "file:../../router",
-    "@hickory/root": "^2.0.0-alpha.5"
+    "@hickory/root": "^2.0.0-beta.0"
   }
 }

--- a/packages/interactions/route-active/tests/active.spec.ts
+++ b/packages/interactions/route-active/tests/active.spec.ts
@@ -2,15 +2,14 @@ import "jest";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-// @ts-ignore (resolved by jest)
 import createActive from "@curi/route-active";
 
-describe("active route interaction", () => {
-  const history = InMemory();
+import { InMemoryOptions } from "@hickory/in-memory";
 
+describe("active route interaction", () => {
   it("is called using router.route.active()", () => {
     const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-    const router = curi(history, routes, {
+    const router = curi(InMemory, routes, {
       route: [createActive()]
     });
     expect(router.route.active).toBeDefined();
@@ -18,9 +17,6 @@ describe("active route interaction", () => {
 
   describe("get", () => {
     it("returns false if the route is not registered", () => {
-      const history = InMemory({
-        locations: ["/"]
-      });
       const routes = prepareRoutes([
         {
           name: "Player",
@@ -28,8 +24,11 @@ describe("active route interaction", () => {
         },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes, {
-        route: [createActive()]
+      const router = curi<InMemoryOptions>(InMemory, routes, {
+        route: [createActive()],
+        history: {
+          locations: ["/"]
+        }
       });
 
       const { response } = router.current();
@@ -40,9 +39,6 @@ describe("active route interaction", () => {
     });
 
     it("returns false when name does not match", () => {
-      const history = InMemory({
-        locations: ["/"]
-      });
       const routes = prepareRoutes([
         {
           name: "Player",
@@ -50,8 +46,11 @@ describe("active route interaction", () => {
         },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes, {
-        route: [createActive()]
+      const router = curi<InMemoryOptions>(InMemory, routes, {
+        route: [createActive()],
+        history: {
+          locations: ["/"]
+        }
       });
 
       const { response } = router.current();
@@ -63,9 +62,6 @@ describe("active route interaction", () => {
 
     describe("optional args", () => {
       it("works without getting passed optional object", () => {
-        const history = InMemory({
-          locations: ["/"]
-        });
         const routes = prepareRoutes([
           {
             name: "Home",
@@ -73,8 +69,11 @@ describe("active route interaction", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes, {
-          route: [createActive()]
+        const router = curi<InMemoryOptions>(InMemory, routes, {
+          route: [createActive()],
+          history: {
+            locations: ["/"]
+          }
         });
 
         const { response } = router.current();
@@ -84,9 +83,6 @@ describe("active route interaction", () => {
 
       describe("params", () => {
         it("returns true when name matches and params match", () => {
-          const history = InMemory({
-            locations: ["/player/7"]
-          });
           const routes = prepareRoutes([
             {
               name: "Player",
@@ -94,8 +90,11 @@ describe("active route interaction", () => {
             },
             { name: "Catch All", path: "(.*)" }
           ]);
-          const router = curi(history, routes, {
-            route: [createActive()]
+          const router = curi<InMemoryOptions>(InMemory, routes, {
+            route: [createActive()],
+            history: {
+              locations: ["/player/7"]
+            }
           });
 
           const { response } = router.current();
@@ -106,9 +105,6 @@ describe("active route interaction", () => {
         });
 
         it("returns false when name matches but params do not", () => {
-          const history = InMemory({
-            locations: ["/player/7"]
-          });
           const routes = prepareRoutes([
             {
               name: "Player",
@@ -116,8 +112,11 @@ describe("active route interaction", () => {
             },
             { name: "Catch All", path: "(.*)" }
           ]);
-          const router = curi(history, routes, {
-            route: [createActive()]
+          const router = curi<InMemoryOptions>(InMemory, routes, {
+            route: [createActive()],
+            history: {
+              locations: ["/player/7"]
+            }
           });
 
           const { response } = router.current();
@@ -130,9 +129,6 @@ describe("active route interaction", () => {
 
       describe("partial", () => {
         it("defaults to false (returns false when name is partial match but partial is not provided)", () => {
-          const history = InMemory({
-            locations: ["/player/6/coach"]
-          });
           const routes = prepareRoutes([
             {
               name: "Player",
@@ -146,8 +142,11 @@ describe("active route interaction", () => {
             },
             { name: "Catch All", path: "(.*)" }
           ]);
-          const router = curi(history, routes, {
-            route: [createActive()]
+          const router = curi<InMemoryOptions>(InMemory, routes, {
+            route: [createActive()],
+            history: {
+              locations: ["/player/6/coach"]
+            }
           });
 
           const { response } = router.current();
@@ -158,9 +157,6 @@ describe("active route interaction", () => {
         });
 
         it("returns false when name is partial match but partial is not true", () => {
-          const history = InMemory({
-            locations: ["/player/6/coach"]
-          });
           const routes = prepareRoutes([
             {
               name: "Player",
@@ -174,8 +170,11 @@ describe("active route interaction", () => {
             },
             { name: "Catch All", path: "(.*)" }
           ]);
-          const router = curi(history, routes, {
-            route: [createActive()]
+          const router = curi<InMemoryOptions>(InMemory, routes, {
+            route: [createActive()],
+            history: {
+              locations: ["/player/6/coach"]
+            }
           });
 
           const { response } = router.current();
@@ -187,9 +186,6 @@ describe("active route interaction", () => {
         });
 
         it("returns true when name is partial match and partial is true", () => {
-          const history = InMemory({
-            locations: ["/player/6/coach"]
-          });
           const routes = prepareRoutes([
             {
               name: "Player",
@@ -203,8 +199,11 @@ describe("active route interaction", () => {
             },
             { name: "Catch All", path: "(.*)" }
           ]);
-          const router = curi(history, routes, {
-            route: [createActive()]
+          const router = curi<InMemoryOptions>(InMemory, routes, {
+            route: [createActive()],
+            history: {
+              locations: ["/player/6/coach"]
+            }
           });
 
           const { response } = router.current();
@@ -218,9 +217,6 @@ describe("active route interaction", () => {
 
       describe("locationCheck", () => {
         it("returns true when route matches and locationCheck returns true", () => {
-          const history = InMemory({
-            locations: ["/#test"]
-          });
           const routes = prepareRoutes([
             {
               name: "Home",
@@ -228,8 +224,11 @@ describe("active route interaction", () => {
             },
             { name: "Catch All", path: "(.*)" }
           ]);
-          const router = curi(history, routes, {
-            route: [createActive()]
+          const router = curi<InMemoryOptions>(InMemory, routes, {
+            route: [createActive()],
+            history: {
+              locations: ["/#test"]
+            }
           });
 
           const { response } = router.current();
@@ -240,9 +239,6 @@ describe("active route interaction", () => {
         });
 
         it("returns false when route matches but locationCheck returns false", () => {
-          const history = InMemory({
-            locations: ["/#test"]
-          });
           const routes = prepareRoutes([
             {
               name: "Home",
@@ -250,8 +246,11 @@ describe("active route interaction", () => {
             },
             { name: "Catch All", path: "(.*)" }
           ]);
-          const router = curi(history, routes, {
-            route: [createActive()]
+          const router = curi<InMemoryOptions>(InMemory, routes, {
+            route: [createActive()],
+            history: {
+              locations: ["/#test"]
+            }
           });
 
           const { response } = router.current();
@@ -262,9 +261,6 @@ describe("active route interaction", () => {
         });
 
         it("doesn't call locationCheck if route doesn't match", () => {
-          const history = InMemory({
-            locations: ["/not-a#test"]
-          });
           const routes = prepareRoutes([
             {
               name: "Home",
@@ -272,8 +268,11 @@ describe("active route interaction", () => {
             },
             { name: "Catch All", path: "(.*)" }
           ]);
-          const router = curi(history, routes, {
-            route: [createActive()]
+          const router = curi<InMemoryOptions>(InMemory, routes, {
+            route: [createActive()],
+            history: {
+              locations: ["/not-a#test"]
+            }
           });
           const locationCheck = jest.fn(() => true);
           const { response } = router.current();
@@ -289,9 +288,6 @@ describe("active route interaction", () => {
 
   describe("reset", () => {
     it("resetting removes the registered routes", () => {
-      const history = InMemory({
-        locations: ["/player/7"]
-      });
       const routes = prepareRoutes([
         {
           name: "Player",
@@ -301,8 +297,11 @@ describe("active route interaction", () => {
       ]);
       const emptyRoutes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
 
-      const router = curi(history, routes, {
-        route: [createActive()]
+      const router = curi<InMemoryOptions>(InMemory, routes, {
+        route: [createActive()],
+        history: {
+          locations: ["/player/7"]
+        }
       });
 
       const playerIsActive = router.route.active(

--- a/packages/interactions/route-ancestors/tests/ancestors.spec.ts
+++ b/packages/interactions/route-ancestors/tests/ancestors.spec.ts
@@ -6,11 +6,9 @@ import { curi, prepareRoutes } from "@curi/router";
 import createAncestors from "@curi/route-ancestors";
 
 describe("ancestors route interaction", () => {
-  const history = InMemory();
-
   it("is called using router.route.ancestors()", () => {
     const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-    const router = curi(history, routes, {
+    const router = curi(InMemory, routes, {
       route: [createAncestors()]
     });
     expect(router.route.ancestors).toBeDefined();
@@ -36,7 +34,7 @@ describe("ancestors route interaction", () => {
       },
       { name: "Catch All", path: "(.*)" }
     ]);
-    const router = curi(history, routes, {
+    const router = curi(InMemory, routes, {
       route: [createAncestors()]
     });
 
@@ -89,7 +87,7 @@ describe("ancestors route interaction", () => {
       },
       { name: "Catch All", path: "(.*)" }
     ]);
-    const router = curi(history, routes, {
+    const router = curi(InMemory, routes, {
       route: [createAncestors()]
     });
     const emptyRoutes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);

--- a/packages/interactions/route-prefetch/tests/prefetch.spec.ts
+++ b/packages/interactions/route-prefetch/tests/prefetch.spec.ts
@@ -2,16 +2,14 @@ import "jest";
 import { InMemory } from "@hickory/in-memory";
 import { curi, prepareRoutes } from "@curi/router";
 
-import { HickoryLocation } from "@hickory/root";
+import { SessionLocation } from "@hickory/root";
 
 import createPrefetch from "@curi/route-prefetch";
 
 describe("prefetch route interaction", () => {
-  const history = InMemory();
-
   it("is called using router.route.prefetch()", () => {
     const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-    const router = curi(history, routes, {
+    const router = curi(InMemory, routes, {
       route: [createPrefetch()]
     });
     expect(router.route.prefetch).toBeDefined();
@@ -29,7 +27,7 @@ describe("prefetch route interaction", () => {
         },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes, {
+      const router = curi(InMemory, routes, {
         route: [createPrefetch()]
       });
       expect(router.route.prefetch("Player")).toBeDefined();
@@ -40,7 +38,7 @@ describe("prefetch route interaction", () => {
         { name: "None", path: "player" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes, {
+      const router = curi(InMemory, routes, {
         route: [createPrefetch()]
       });
       // This is a bit roundabout, but we verify that the paths did not register
@@ -66,7 +64,7 @@ describe("prefetch route interaction", () => {
         },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes, {
+      const router = curi(InMemory, routes, {
         route: [createPrefetch()]
       });
       expect(router.route.prefetch("Player").then).toBeDefined();
@@ -76,7 +74,7 @@ describe("prefetch route interaction", () => {
       const name = "Anonymous";
 
       const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-      const router = curi(history, routes, {
+      const router = curi(InMemory, routes, {
         route: [createPrefetch()]
       });
 
@@ -105,7 +103,7 @@ describe("prefetch route interaction", () => {
         },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes, {
+      const router = curi(InMemory, routes, {
         route: [createPrefetch()]
       });
 
@@ -135,11 +133,11 @@ describe("prefetch route interaction", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes, {
+        const router = curi(InMemory, routes, {
           route: [createPrefetch()]
         });
         const paramsToPass = { id: 1 };
-        const locationToPass = {} as HickoryLocation;
+        const locationToPass = {} as SessionLocation;
         router.route.prefetch("Player", {
           match: {
             name: "Player",
@@ -166,7 +164,7 @@ describe("prefetch route interaction", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes, {
+        const router = curi(InMemory, routes, {
           route: [createPrefetch()],
           external
         });
@@ -186,7 +184,7 @@ describe("prefetch route interaction", () => {
       },
       { name: "Catch All", path: "(.*)" }
     ]);
-    const router = curi(history, routes, {
+    const router = curi(InMemory, routes, {
       route: [createPrefetch()]
     });
 

--- a/packages/react-dom/tests/AsyncLink.spec.tsx
+++ b/packages/react-dom/tests/AsyncLink.spec.tsx
@@ -9,7 +9,7 @@ import { curiProvider, AsyncLink } from "@curi/react-dom";
 
 describe("<AsyncLink>", () => {
   let node;
-  let history, router, Router: React.FunctionComponent;
+  let router, Router: React.FunctionComponent;
   const routes = prepareRoutes([
     { name: "Test", path: "" },
     { name: "Best", path: "best" },
@@ -18,8 +18,7 @@ describe("<AsyncLink>", () => {
 
   beforeEach(() => {
     node = document.createElement("div");
-    history = InMemory();
-    router = curi(history, routes);
+    router = curi(InMemory, routes);
     Router = curiProvider(router);
   });
 
@@ -71,11 +70,12 @@ describe("<AsyncLink>", () => {
       });
 
       it("creates a relative link if 'to' is undefined", () => {
-        const history = InMemory({
-          locations: ["/the-initial-location"]
-        });
         const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/the-initial-location"]
+          }
+        });
         const Router = curiProvider(router);
         ReactDOM.render(
           <Router>
@@ -89,15 +89,14 @@ describe("<AsyncLink>", () => {
     });
 
     describe("params", () => {
-      let history, router, Router;
+      let router, Router;
       const routes = prepareRoutes([
         { name: "Park", path: "park/:name" },
         { name: "Catch All", path: "(.*)" }
       ]);
 
       beforeEach(() => {
-        history = InMemory();
-        router = curi(history, routes);
+        router = curi(InMemory, routes);
         Router = curiProvider(router);
       });
 
@@ -144,12 +143,11 @@ describe("<AsyncLink>", () => {
 
     describe("hash & query", () => {
       it("merges hash & query props with the pathname when creating href", () => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
         ReactDOM.render(
           <Router>
@@ -183,12 +181,11 @@ describe("<AsyncLink>", () => {
 
   describe("ref", () => {
     it("returns the anchor's ref, not the link's", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
       const ref = React.createRef();
       ReactDOM.render(
@@ -206,12 +203,11 @@ describe("<AsyncLink>", () => {
 
   describe("children", () => {
     it("is called with the <AsyncLink>'s current navigating state (false on mount)", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
       const children = jest.fn((a: boolean) => null);
       ReactDOM.render(
@@ -227,12 +223,11 @@ describe("<AsyncLink>", () => {
 
   describe("clicking a link", () => {
     it("calls history.navigate", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const mockNavigate = jest.fn();
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
@@ -263,7 +258,6 @@ describe("<AsyncLink>", () => {
         // if a link has no on methods, finished will be called almost
         // immediately (although this style should only be used for routes
         // with on methods)
-        const history = InMemory();
         const routes = prepareRoutes([
           {
             name: "Test",
@@ -278,7 +272,7 @@ describe("<AsyncLink>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -309,7 +303,6 @@ describe("<AsyncLink>", () => {
       });
 
       it("children(false) when navigation is cancelled", () => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
@@ -330,7 +323,7 @@ describe("<AsyncLink>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -371,7 +364,6 @@ describe("<AsyncLink>", () => {
       });
 
       it("children(false) when navigation is finished", done => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
@@ -383,7 +375,7 @@ describe("<AsyncLink>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -426,7 +418,6 @@ describe("<AsyncLink>", () => {
         const mockError = jest.fn();
         console.error = mockError;
 
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
@@ -447,7 +438,7 @@ describe("<AsyncLink>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         ReactDOM.render(
@@ -481,13 +472,12 @@ describe("<AsyncLink>", () => {
     });
 
     it("includes hash, query, and state in location passed to history.navigate", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -523,14 +513,13 @@ describe("<AsyncLink>", () => {
 
     describe("onNav", () => {
       it("calls onNav prop func if provided", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const onNav = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -560,7 +549,6 @@ describe("<AsyncLink>", () => {
       });
 
       it("does not call history.navigate if onNav prevents default", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const onNav = jest.fn(event => {
           event.preventDefault();
@@ -569,7 +557,7 @@ describe("<AsyncLink>", () => {
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -600,13 +588,12 @@ describe("<AsyncLink>", () => {
     });
 
     it("doesn't call history.navigate for modified clicks", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -638,13 +625,12 @@ describe("<AsyncLink>", () => {
     });
 
     it("doesn't call history.navigate if event.preventDefault has been called", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -9,7 +9,7 @@ import { curiProvider, Link } from "@curi/react-dom";
 
 describe("<Link>", () => {
   let node;
-  let history, router, Router: React.FunctionComponent;
+  let router, Router: React.FunctionComponent;
   const routes = prepareRoutes([
     { name: "Test", path: "" },
     { name: "Best", path: "best" },
@@ -18,8 +18,7 @@ describe("<Link>", () => {
 
   beforeEach(() => {
     node = document.createElement("div");
-    history = InMemory();
-    router = curi(history, routes);
+    router = curi(InMemory, routes);
     Router = curiProvider(router);
   });
 
@@ -71,11 +70,12 @@ describe("<Link>", () => {
       });
 
       it("creates a relative link if 'name' is undefined", () => {
-        const history = InMemory({
-          locations: ["/the-initial-location"]
-        });
         const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/the-initial-location"]
+          }
+        });
         const Router = curiProvider(router);
         ReactDOM.render(
           <Router>
@@ -89,15 +89,14 @@ describe("<Link>", () => {
     });
 
     describe("params", () => {
-      let history, router, Router;
+      let router, Router;
       const routes = prepareRoutes([
         { name: "Park", path: "park/:name" },
         { name: "Catch All", path: "(.*)" }
       ]);
 
       beforeEach(() => {
-        history = InMemory();
-        router = curi(history, routes);
+        router = curi(InMemory, routes);
         Router = curiProvider(router);
       });
 
@@ -144,12 +143,11 @@ describe("<Link>", () => {
 
     describe("hash & query", () => {
       it("merges hash & query props with the pathname when creating href", () => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
         ReactDOM.render(
           <Router>
@@ -183,12 +181,11 @@ describe("<Link>", () => {
 
   describe("ref", () => {
     it("returns the anchor's ref, not the link's", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
       const ref = React.createRef();
       ReactDOM.render(
@@ -206,12 +203,11 @@ describe("<Link>", () => {
 
   describe("children", () => {
     it("renders the provided children", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
       const children = "Test Value";
       ReactDOM.render(
@@ -228,14 +224,13 @@ describe("<Link>", () => {
   describe("clicking a link", () => {
     describe("onNav", () => {
       it("calls onNav prop func if provided", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const onNav = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -265,7 +260,6 @@ describe("<Link>", () => {
       });
 
       it("does not call history.navigate if onNav prevents default", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const onNav = jest.fn(event => {
           event.preventDefault();
@@ -274,7 +268,7 @@ describe("<Link>", () => {
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -305,13 +299,12 @@ describe("<Link>", () => {
     });
 
     it("doesn't call history.navigate for modified clicks", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -343,13 +336,12 @@ describe("<Link>", () => {
     });
 
     it("doesn't call history.navigate if event.preventDefault has been called", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 

--- a/packages/react-dom/tests/useNavigationFocus.spec.tsx
+++ b/packages/react-dom/tests/useNavigationFocus.spec.tsx
@@ -11,7 +11,7 @@ jest.useFakeTimers();
 
 describe("useNavigationFocus", () => {
   let node;
-  let history, router, Router;
+  let router, Router;
   const routes = prepareRoutes([
     { name: "Home", path: "" },
     { name: "About", path: "about" }
@@ -20,8 +20,7 @@ describe("useNavigationFocus", () => {
   beforeEach(() => {
     node = document.createElement("div");
     document.body.appendChild(node);
-    history = InMemory();
-    router = curi(history, routes);
+    router = curi(InMemory, routes);
     Router = curiProvider(router);
   });
 
@@ -62,8 +61,7 @@ describe("useNavigationFocus", () => {
         }
       ]);
 
-      const history = InMemory();
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
 
       function Focuser() {
@@ -206,8 +204,7 @@ describe("useNavigationFocus", () => {
           }
         ]);
 
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         function Focuser() {
@@ -270,8 +267,7 @@ describe("useNavigationFocus", () => {
           }
         ]);
 
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         function Focuser() {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@curi/react-universal": "file:../react-universal",
     "@curi/router": "file:../router",
-    "@hickory/root": "^2.0.0-alpha.5",
+    "@hickory/root": "^2.0.0-beta.0",
     "@types/react": "^16.7.18",
     "@types/react-native": "^0.57.32"
   },

--- a/packages/react-native/tests/AsyncLink.spec.tsx
+++ b/packages/react-native/tests/AsyncLink.spec.tsx
@@ -22,12 +22,11 @@ function fakeEvent(props = {}) {
 describe("<AsyncLink>", () => {
   describe("anchor", () => {
     it("renders a <TouchableHighlight> by default", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
       const tree = renderer.create(
         <Router>
@@ -41,12 +40,11 @@ describe("<AsyncLink>", () => {
     });
 
     it("when provided, it renders the component instead of an anchor", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
 
       const StyledAnchor = props => (
@@ -68,10 +66,13 @@ describe("<AsyncLink>", () => {
   describe("navigation location", () => {
     describe("name", () => {
       it("uses the pathname from current response's location if 'name' is not provided", () => {
-        const history = InMemory({ locations: ["/the-initial-location"] });
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/the-initial-location"]
+          }
+        });
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -97,9 +98,8 @@ describe("<AsyncLink>", () => {
       ]);
 
       it("uses params to generate the location to navigate to", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -117,9 +117,8 @@ describe("<AsyncLink>", () => {
       });
 
       it("updates location to navigate to when props change", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -152,13 +151,12 @@ describe("<AsyncLink>", () => {
 
     describe("hash & query", () => {
       it("merges hash & query props with the pathname when creating href", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -183,13 +181,16 @@ describe("<AsyncLink>", () => {
 
   describe("forward", () => {
     it("passes forward to the rendered anchor", () => {
-      const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/the-initial-location"]
+        }
+      });
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -208,13 +209,16 @@ describe("<AsyncLink>", () => {
 
   describe("ref", () => {
     it("returns the anchor's ref, not the link's", () => {
-      const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Parks", path: "parks" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/the-initial-location"]
+        }
+      });
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -233,12 +237,11 @@ describe("<AsyncLink>", () => {
 
   describe("children", () => {
     it("is called with the <AsyncLink>'s current navigating state (false on mount)", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
 
       const tree = renderer.create(
@@ -257,13 +260,12 @@ describe("<AsyncLink>", () => {
   describe("pressing a link", () => {
     describe("navigation method", () => {
       it('method="anchor"', () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -280,13 +282,12 @@ describe("<AsyncLink>", () => {
       });
 
       it('method="push"', () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -303,13 +304,12 @@ describe("<AsyncLink>", () => {
       });
 
       it('method="replace"', () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -331,7 +331,6 @@ describe("<AsyncLink>", () => {
         // if a link has no on methods, finished will be called almost
         // immediately (although this style should only be used for routes
         // with resolve methods)
-        const history = InMemory();
         const routes = prepareRoutes([
           {
             name: "Test",
@@ -346,7 +345,7 @@ describe("<AsyncLink>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -368,7 +367,6 @@ describe("<AsyncLink>", () => {
       });
 
       it("children(false) when navigation is cancelled", () => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
@@ -389,7 +387,7 @@ describe("<AsyncLink>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -424,7 +422,6 @@ describe("<AsyncLink>", () => {
       });
 
       it("children(false) when navigation is finished", done => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
@@ -436,7 +433,7 @@ describe("<AsyncLink>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -471,7 +468,6 @@ describe("<AsyncLink>", () => {
         const mockError = jest.fn();
         console.error = mockError;
 
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           {
@@ -493,7 +489,7 @@ describe("<AsyncLink>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         const tree = renderer.create(
@@ -515,14 +511,13 @@ describe("<AsyncLink>", () => {
 
     describe("onNav", () => {
       it("calls onNav prop func if provided", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const onNav = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -541,7 +536,6 @@ describe("<AsyncLink>", () => {
       });
 
       it("does not call history.navigate if onNav prevents default", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const onNav = jest.fn(event => {
           event.preventDefault();
@@ -550,7 +544,7 @@ describe("<AsyncLink>", () => {
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -569,13 +563,12 @@ describe("<AsyncLink>", () => {
     });
 
     it("doesn't call history.navigate if event.preventDefault has been called", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -24,12 +24,11 @@ function fakeEvent(props = {}) {
 describe("<Link>", () => {
   describe("anchor", () => {
     it("renders a <TouchableHighlight> by default", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
       const tree = renderer.create(
         <Router>
@@ -43,12 +42,11 @@ describe("<Link>", () => {
     });
 
     it("when provided, it renders the component instead of an anchor", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
 
       const StyledAnchor = props => (
@@ -70,10 +68,13 @@ describe("<Link>", () => {
   describe("navigation location", () => {
     describe("name", () => {
       it("uses the pathname from current response's location if 'name' is not provided", () => {
-        const history = InMemory({ locations: ["/the-initial-location"] });
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/the-initial-location"]
+          }
+        });
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -99,9 +100,8 @@ describe("<Link>", () => {
       ]);
 
       it("uses params to generate the location to navigate to", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -119,9 +119,8 @@ describe("<Link>", () => {
       });
 
       it("updates location to navigate to when props change", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -154,13 +153,12 @@ describe("<Link>", () => {
 
     describe("hash & query", () => {
       it("merges hash & query props with the pathname when creating href", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -185,13 +183,16 @@ describe("<Link>", () => {
 
   describe("forward", () => {
     it("passes forward to the rendered anchor", () => {
-      const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/the-initial-location"]
+        }
+      });
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -210,13 +211,16 @@ describe("<Link>", () => {
 
   describe("ref", () => {
     it("returns the anchor's ref, not the link's", () => {
-      const history = InMemory({ locations: ["/the-initial-location"] });
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Parks", path: "parks" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/the-initial-location"]
+        }
+      });
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -235,12 +239,11 @@ describe("<Link>", () => {
 
   describe("children", () => {
     it("renders the provided children value(s)", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
 
       const children = "Test Value";
@@ -261,12 +264,11 @@ describe("<Link>", () => {
   describe("pressing a link", () => {
     describe("navigation method", () => {
       it('method="anchor"', () => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const mockNavigate = jest.fn();
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
@@ -284,13 +286,12 @@ describe("<Link>", () => {
       });
 
       it('method="push"', () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -307,13 +308,12 @@ describe("<Link>", () => {
       });
 
       it('method="replace"', () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -332,14 +332,13 @@ describe("<Link>", () => {
 
     describe("onNav", () => {
       it("calls onNav prop func if provided", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const onNav = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -358,7 +357,6 @@ describe("<Link>", () => {
       });
 
       it("does not call history.navigate if onNav prevents default", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const onNav = jest.fn(event => {
           event.preventDefault();
@@ -367,7 +365,7 @@ describe("<Link>", () => {
           { name: "Test", path: "" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -386,13 +384,12 @@ describe("<Link>", () => {
     });
 
     it("doesn't call history.navigate if event.preventDefault has been called", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 

--- a/packages/react-universal/package.json
+++ b/packages/react-universal/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@curi/router": "file:../router",
-    "@hickory/root": "^2.0.0-alpha.5",
+    "@hickory/root": "^2.0.0-beta.0",
     "@types/react": "^16.7.18"
   }
 }

--- a/packages/react-universal/tests/Curious.spec.tsx
+++ b/packages/react-universal/tests/Curious.spec.tsx
@@ -17,8 +17,7 @@ describe("<Curious>", () => {
 
   beforeEach(() => {
     node = document.createElement("div");
-    history = InMemory();
-    router = curi(history, routes);
+    router = curi(InMemory, routes);
     Router = curiProvider(router);
   });
 

--- a/packages/react-universal/tests/curiProvider.spec.tsx
+++ b/packages/react-universal/tests/curiProvider.spec.tsx
@@ -29,9 +29,8 @@ describe("curiProvider()", () => {
 
   describe("children prop", () => {
     it("renders children", () => {
-      const history = InMemory();
       const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
 
       const App = jest.fn(() => {
         return null;
@@ -47,9 +46,8 @@ describe("curiProvider()", () => {
     });
 
     it("works with multiple children", () => {
-      const history = InMemory();
       const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
 
       const One = jest.fn(() => {
         return null;
@@ -70,8 +68,7 @@ describe("curiProvider()", () => {
     });
 
     it("re-renders when the location changes", async () => {
-      const history = InMemory();
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
 
       let currentResponse;
 
@@ -101,8 +98,7 @@ describe("curiProvider()", () => {
 
   describe("context", () => {
     it("makes response, navigation, and router available on content", () => {
-      const history = InMemory();
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
 
       const ContextLogger: React.ComponentType = () => {
         const {

--- a/packages/react-universal/tests/useActive.spec.tsx
+++ b/packages/react-universal/tests/useActive.spec.tsx
@@ -10,7 +10,6 @@ import { curiProvider, useActive, useCuri } from "@curi/react-universal";
 
 describe("useActive", () => {
   let node;
-  let history;
   let router, Router;
   const routes = prepareRoutes([
     { name: "Home", path: "" },
@@ -23,8 +22,7 @@ describe("useActive", () => {
 
   beforeEach(() => {
     node = document.createElement("div");
-    history = InMemory();
-    router = curi(history, routes, {
+    router = curi(InMemory, routes, {
       route: [activeInteraction()]
     });
     Router = curiProvider(router);
@@ -36,7 +34,7 @@ describe("useActive", () => {
 
   describe("no route.active()", () => {
     it('throws if attempting to use in a Curi router without the "active" route interaction', () => {
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
 
       const realError = console.error;
       console.error = jest.fn();
@@ -87,9 +85,11 @@ const router = curi(history, routes, {
 
   describe("params", () => {
     it('uses the "params" to determine if it is active', () => {
-      const history = InMemory({ locations: ["/contact/email"] });
-      const router = curi(history, routes, {
-        route: [activeInteraction()]
+      const router = curi(InMemory, routes, {
+        route: [activeInteraction()],
+        history: {
+          locations: ["/contact/email"]
+        }
       });
       const Router = curiProvider(router);
       function App() {
@@ -111,9 +111,11 @@ const router = curi(history, routes, {
 
   describe("partial", () => {
     it("returns true for partial matches when partial=true", () => {
-      const history = InMemory({ locations: ["/contact/email"] });
-      const router = curi(history, routes, {
-        route: [activeInteraction()]
+      const router = curi(InMemory, routes, {
+        route: [activeInteraction()],
+        history: {
+          locations: ["/contact/email"]
+        }
       });
       const Router = curiProvider(router);
       function App() {
@@ -132,9 +134,11 @@ const router = curi(history, routes, {
 
   describe("locationCheck", () => {
     it("is called with location if route is active", () => {
-      const history = InMemory({ locations: ["/contact"] });
-      const router = curi(history, routes, {
-        route: [activeInteraction()]
+      const router = curi(InMemory, routes, {
+        route: [activeInteraction()],
+        history: {
+          locations: ["/contact"]
+        }
       });
       const locCheck = jest.fn();
       let theLocation;
@@ -156,9 +160,11 @@ const router = curi(history, routes, {
     });
 
     it("is not called if route is not active", () => {
-      const history = InMemory({ locations: ["/"] });
-      const router = curi(history, routes, {
-        route: [activeInteraction()]
+      const router = curi(InMemory, routes, {
+        route: [activeInteraction()],
+        history: {
+          locations: ["/"]
+        }
       });
       const locCheck = jest.fn();
       let theResponse;
@@ -179,9 +185,11 @@ const router = curi(history, routes, {
     });
 
     it("returns true if route matches and response check returns true", () => {
-      const history = InMemory({ locations: ["/contact/email"] });
-      const router = curi(history, routes, {
-        route: [activeInteraction()]
+      const router = curi(InMemory, routes, {
+        route: [activeInteraction()],
+        history: {
+          locations: ["/contact/email"]
+        }
       });
       const Router = curiProvider(router);
       function App() {
@@ -202,9 +210,11 @@ const router = curi(history, routes, {
     });
 
     it("returns false if route matches, but location check returns false", () => {
-      const history = InMemory({ locations: ["/contact/email"] });
-      const router = curi(history, routes, {
-        route: [activeInteraction()]
+      const router = curi(InMemory, routes, {
+        route: [activeInteraction()],
+        history: {
+          locations: ["/contact/email"]
+        }
       });
       const Router = curiProvider(router);
       function App() {

--- a/packages/react-universal/tests/useCuri.spec.tsx
+++ b/packages/react-universal/tests/useCuri.spec.tsx
@@ -9,7 +9,7 @@ import { curiProvider, useCuri } from "@curi/react-universal";
 
 describe("useCuri", () => {
   let node;
-  let history, router, Router;
+  let router, Router;
   const routes = prepareRoutes([
     { name: "Home", path: "" },
     { name: "Catch All", path: "(.*)" }
@@ -17,8 +17,7 @@ describe("useCuri", () => {
 
   beforeEach(() => {
     node = document.createElement("div");
-    history = InMemory();
-    router = curi(history, routes);
+    router = curi(InMemory, routes);
     Router = curiProvider(router);
   });
 

--- a/packages/react-universal/tests/useHref.spec.tsx
+++ b/packages/react-universal/tests/useHref.spec.tsx
@@ -10,7 +10,7 @@ import { curiProvider, useHref } from "@curi/react-universal";
 
 describe("useHref", () => {
   let node;
-  let history, router, Router;
+  let router, Router;
   const routes = prepareRoutes([
     { name: "Home", path: "" },
     { name: "User", path: "u/:id" },
@@ -19,8 +19,7 @@ describe("useHref", () => {
 
   beforeEach(() => {
     node = document.createElement("div");
-    history = InMemory();
-    router = curi(history, routes);
+    router = curi(InMemory, routes);
     Router = curiProvider(router);
   });
 
@@ -88,13 +87,14 @@ describe("useHref", () => {
     });
 
     it("works with custom history parse/stringifiers", () => {
-      const history = InMemory({
-        query: {
-          parse: qs.parse,
-          stringify: qs.stringify
+      const router = curi(InMemory, routes, {
+        history: {
+          query: {
+            parse: qs.parse,
+            stringify: qs.stringify
+          }
         }
       });
-      const router = curi(history, routes);
       const Router = curiProvider(router);
 
       function App() {

--- a/packages/react-universal/tests/useLocation.spec.tsx
+++ b/packages/react-universal/tests/useLocation.spec.tsx
@@ -9,7 +9,7 @@ import { curiProvider, useLocation } from "@curi/react-universal";
 
 describe("useLocation", () => {
   let node;
-  let history, router, Router;
+  let router, Router;
   const routes = prepareRoutes([
     { name: "Home", path: "" },
     { name: "User", path: "u/:id" },
@@ -18,8 +18,7 @@ describe("useLocation", () => {
 
   beforeEach(() => {
     node = document.createElement("div");
-    history = InMemory();
-    router = curi(history, routes);
+    router = curi(InMemory, routes);
     Router = curiProvider(router);
   });
 

--- a/packages/react-universal/tests/useNavigating.spec.tsx
+++ b/packages/react-universal/tests/useNavigating.spec.tsx
@@ -45,8 +45,7 @@ describe("useNavigating", () => {
 
   describe("mount", () => {
     it("cancel is undefined", () => {
-      const history = InMemory();
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
 
       function Nav() {
@@ -66,8 +65,7 @@ describe("useNavigating", () => {
   describe("while navigating", () => {
     describe("to synchronous routes", () => {
       it("cancel is undefined", async () => {
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         const children = jest.fn(() => null);
@@ -99,8 +97,7 @@ describe("useNavigating", () => {
 
     describe("to asynchronous routes", () => {
       it("cancel is a function", async () => {
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
 
         const children = jest.fn(() => null);
@@ -125,8 +122,7 @@ describe("useNavigating", () => {
       });
 
       it("is undefined once navigation finishes", async done => {
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Router = curiProvider(router);
         const children = jest.fn(() => null);
         function Nav() {
@@ -161,8 +157,7 @@ describe("useNavigating", () => {
 
   describe("calling the cancel function", () => {
     it("cancels the navigation", async done => {
-      const history = InMemory();
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
       let cancelFn;
       const children = jest.fn(cancel => {
@@ -202,8 +197,7 @@ describe("useNavigating", () => {
     });
 
     it("does nothing if calling function after navigation finishes", async done => {
-      const history = InMemory();
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
       let cancelFn;
       const children = jest.fn(cancel => {

--- a/packages/react-universal/tests/useNavigationHandler.spec.tsx
+++ b/packages/react-universal/tests/useNavigationHandler.spec.tsx
@@ -25,18 +25,9 @@ function createClick(opts?: {}) {
 
 describe("useNavigationHandler", () => {
   let node;
-  let history, router, Router: React.FunctionComponent;
-  const routes = prepareRoutes([
-    { name: "Test", path: "" },
-    { name: "Best", path: "best" },
-    { name: "Catch All", path: "(.*)" }
-  ]);
 
   beforeEach(() => {
     node = document.createElement("div");
-    history = InMemory();
-    router = curi(history, routes);
-    Router = curiProvider(router);
   });
 
   afterEach(() => {
@@ -45,13 +36,12 @@ describe("useNavigationHandler", () => {
 
   describe("event handler", () => {
     it("it uses nav props (name, params, hash, query, and state) to generate nav location", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -85,14 +75,13 @@ describe("useNavigationHandler", () => {
     });
 
     it("calls onNav prop func if provided", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const onNav = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -126,13 +115,12 @@ describe("useNavigationHandler", () => {
       }
 
       it("does not call history.navigate if canNavigate returns false", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 

--- a/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
+++ b/packages/react-universal/tests/useStatefulNavigationHandler.spec.tsx
@@ -30,18 +30,9 @@ function createClick(opts?: {}) {
 
 describe("useStatefulNavigationHandler", () => {
   let node;
-  let history, router, Router: React.FunctionComponent;
-  const routes = prepareRoutes([
-    { name: "Test", path: "" },
-    { name: "Best", path: "best" },
-    { name: "Catch All", path: "(.*)" }
-  ]);
 
   beforeEach(() => {
     node = document.createElement("div");
-    history = InMemory();
-    router = curi(history, routes);
-    Router = curiProvider(router);
   });
 
   afterEach(() => {
@@ -50,13 +41,12 @@ describe("useStatefulNavigationHandler", () => {
 
   describe("event handler", () => {
     it("it uses nav props (name, params, hash, query, and state) to generate nav location", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -92,14 +82,13 @@ describe("useStatefulNavigationHandler", () => {
     });
 
     it("calls onNav prop func if provided", () => {
-      const history = InMemory();
       const mockNavigate = jest.fn();
       const onNav = jest.fn();
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.history.navigate = mockNavigate;
       const Router = curiProvider(router);
 
@@ -135,13 +124,12 @@ describe("useStatefulNavigationHandler", () => {
       }
 
       it("does not call history.navigate if canNavigate returns false", () => {
-        const history = InMemory();
         const mockNavigate = jest.fn();
         const routes = prepareRoutes([
           { name: "Test", path: "test" },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.history.navigate = mockNavigate;
         const Router = curiProvider(router);
 
@@ -175,13 +163,11 @@ describe("useStatefulNavigationHandler", () => {
 
   describe("navigating", () => {
     it("is false on initial render", () => {
-      const history = InMemory();
-
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
 
       function AsyncLink(props) {
@@ -207,8 +193,6 @@ describe("useStatefulNavigationHandler", () => {
     });
 
     it("is true when navigation starts", () => {
-      const history = InMemory();
-
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         {
@@ -229,7 +213,7 @@ describe("useStatefulNavigationHandler", () => {
         },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
 
       function AsyncLink(props) {
@@ -259,8 +243,6 @@ describe("useStatefulNavigationHandler", () => {
     });
 
     it("is false when navigation finishes", async () => {
-      const history = InMemory();
-
       const routes = prepareRoutes([
         { name: "Test", path: "test" },
         {
@@ -281,7 +263,7 @@ describe("useStatefulNavigationHandler", () => {
         },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const Router = curiProvider(router);
 
       function AsyncLink(props) {

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 17837,
-    "minified": 6146,
-    "gzipped": 2436,
+    "bundled": 17925,
+    "minified": 6174,
+    "gzipped": 2451,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 18072,
-    "minified": 6336,
-    "gzipped": 2516
+    "bundled": 18160,
+    "minified": 6364,
+    "gzipped": 2533
   },
   "dist/curi-router.umd.js": {
-    "bundled": 29579,
-    "minified": 8926,
-    "gzipped": 3673
+    "bundled": 29667,
+    "minified": 8954,
+    "gzipped": 3686
   },
   "dist/curi-router.min.js": {
-    "bundled": 29539,
-    "minified": 8886,
-    "gzipped": 3653
+    "bundled": 29627,
+    "minified": 8914,
+    "gzipped": 3670
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+* First argument to `curi` is a history constructor.
+* Add `history` option to `curi` options for history object configuration.
+
 ## 2.0.0-alpha.1
 
 * `curi` receives a pending history function.

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -33,7 +33,7 @@
   "author": "Paul Sherman",
   "license": "MIT",
   "dependencies": {
-    "@hickory/root": "^2.0.0-alpha.5",
+    "@hickory/root": "^2.0.0-beta.0",
     "path-to-regexp": "^2.1.0"
   }
 }

--- a/packages/router/src/curi.ts
+++ b/packages/router/src/curi.ts
@@ -4,7 +4,7 @@ import finishResponse from "./finishResponse";
 import matchLocation from "./matchLocation";
 import resolveMatchedRoute from "./resolveMatchedRoute";
 
-import { History, PendingNavigation } from "@hickory/root";
+import { HistoryConstructor, PendingNavigation } from "@hickory/root";
 
 import { CompiledRouteArray, ResolveResults } from "./types/route";
 import { Response } from "./types/response";
@@ -26,22 +26,21 @@ import {
   CancelNavigateCallbacks
 } from "./types/curi";
 
-type PendingHistory = (fn: (p: PendingNavigation) => void) => History;
-
-export default function createRouter(
-  pendingHistory: PendingHistory,
+export default function createRouter<O>(
+  historyConstructor: HistoryConstructor,
   routeArray: CompiledRouteArray,
-  options: RouterOptions = {}
+  options: RouterOptions<O> = {}
 ): CuriRouter {
   const {
     route: userInteractions = [],
     sideEffects = [],
     emitRedirects = true,
     automaticRedirects = true,
-    external
+    external,
+    history: historyOptions = {}
   } = options;
 
-  const history = pendingHistory(navigationHandler);
+  const history = historyConstructor(navigationHandler, historyOptions);
 
   // the last finished response & navigation
   const mostRecent: CurrentResponse = {

--- a/packages/router/src/types/curi.ts
+++ b/packages/router/src/types/curi.ts
@@ -1,9 +1,9 @@
-import { History, Action, NavType } from "@hickory/root";
+import { History, Action, NavType, HistoryOptions } from "@hickory/root";
 import { PathFunctionOptions } from "path-to-regexp";
 
 import { Interaction, Interactions } from "./interaction";
 import { CompiledRouteArray } from "./route";
-import { Response, Params } from "./response";
+import { Response } from "./response";
 import { RouteLocation } from "./location";
 
 export interface Navigation {
@@ -28,13 +28,14 @@ export type CancelActiveNavigation = () => void;
 export type Cancellable = (cancelActive?: CancelActiveNavigation) => void;
 export type RemoveCancellable = () => void;
 
-export interface RouterOptions {
+export interface RouterOptions<O = HistoryOptions> {
   route?: Array<Interaction>;
   sideEffects?: Array<Observer>;
   pathnameOptions?: PathFunctionOptions;
   emitRedirects?: boolean;
   automaticRedirects?: boolean;
   external?: any;
+  history?: O;
 }
 
 export interface CurrentResponse {

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -7,12 +7,6 @@ import { NavType } from "@hickory/root";
 import { curi, prepareRoutes } from "@curi/router";
 
 describe("curi", () => {
-  let history;
-
-  beforeEach(() => {
-    history = InMemory();
-  });
-
   describe("constructor", () => {
     // these tests rely on the fact that the pathname generator
     // is a default interaction
@@ -22,7 +16,7 @@ describe("curi", () => {
         { name: "About", path: "about" },
         { name: "Contact", path: "contact" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
 
       const names = ["Home", "About", "Contact"];
       names.forEach(n => {
@@ -43,7 +37,7 @@ describe("curi", () => {
           ]
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const names = ["Email", "Phone"];
       names.forEach(n => {
         expect(router.route.pathname(n)).toBeDefined();
@@ -58,7 +52,7 @@ describe("curi", () => {
         reset: () => {},
         get: () => {}
       });
-      const router = curi(history, routes, {
+      const router = curi(InMemory, routes, {
         route: [createfakeInteraction()]
       });
       expect(router.route.fake).toBeDefined();
@@ -68,7 +62,7 @@ describe("curi", () => {
       describe("interactions", () => {
         it("includes pathname interaction by default", () => {
           const routes = prepareRoutes([{ name: "Home", path: "" }]);
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           expect(router.route.pathname).toBeDefined();
         });
 
@@ -86,7 +80,7 @@ describe("curi", () => {
           };
 
           const routes = prepareRoutes([{ name: "Home", path: "" }]);
-          const router = curi(history, routes, {
+          const router = curi(InMemory, routes, {
             route: [createfirstInteraction()]
           });
           expect(router.route.pathname).toBeDefined();
@@ -139,9 +133,11 @@ describe("curi", () => {
               path: "cousin"
             }
           ]);
-          const history = InMemory({ locations: ["/grandparent"] });
-          const router = curi(history, routes, {
-            route: [createfirstInteraction(), createsecondInteraction()]
+          const router = curi(InMemory, routes, {
+            route: [createfirstInteraction(), createsecondInteraction()],
+            history: {
+              locations: ["/grandparent"]
+            }
           });
           const expected = {
             Grandparent: {
@@ -174,7 +170,7 @@ describe("curi", () => {
           const routes = prepareRoutes([{ name: "All", path: "(.*)" }]);
           const sideEffect = jest.fn();
 
-          const router = curi(history, routes, {
+          const router = curi(InMemory, routes, {
             sideEffects: [sideEffect]
           });
           router.once(({ response, navigation }) => {
@@ -200,7 +196,7 @@ describe("curi", () => {
             done();
           };
 
-          const router = curi(history, routes, {
+          const router = curi(InMemory, routes, {
             sideEffects: [sideEffect]
           });
         });
@@ -232,7 +228,7 @@ describe("curi", () => {
               firstCall = false;
             }
           };
-          const router = curi(history, routes, {
+          const router = curi(InMemory, routes, {
             sideEffects: [logger]
           });
         });
@@ -256,7 +252,7 @@ describe("curi", () => {
             }
           ]);
 
-          const router = curi(history, routes, {
+          const router = curi(InMemory, routes, {
             emitRedirects: false
           });
           // the first emitted response is the location that was redirected to
@@ -286,7 +282,7 @@ describe("curi", () => {
               path: "other"
             }
           ]);
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           // because the routes are not asynchronous, an automatic redirect
           // will be triggered before once is called, so its response
           // will be for the redirected location
@@ -321,7 +317,7 @@ describe("curi", () => {
               path: "other"
             }
           ]);
-          const router = curi(history, routes, {
+          const router = curi(InMemory, routes, {
             automaticRedirects: false
           });
           router.once(({ response, navigation }) => {
@@ -338,7 +334,6 @@ describe("curi", () => {
 
       describe("external", () => {
         it("gets passed to resolve functions", done => {
-          const history = InMemory();
           const external = "hey!";
           const routes = prepareRoutes([
             {
@@ -359,11 +354,10 @@ describe("curi", () => {
               path: "(.*)"
             }
           ]);
-          const router = curi(history, routes, { external });
+          const router = curi(InMemory, routes, { external });
         });
 
         it("gets passed to response function", () => {
-          const history = InMemory();
           const external = "hey!";
           const routes = prepareRoutes([
             {
@@ -379,11 +373,10 @@ describe("curi", () => {
               path: "(.*)"
             }
           ]);
-          const router = curi(history, routes, { external });
+          const router = curi(InMemory, routes, { external });
         });
 
         it("is available from the router", () => {
-          const history = InMemory();
           const external = "hey!";
           const routes = prepareRoutes([
             {
@@ -391,7 +384,7 @@ describe("curi", () => {
               path: "(.*)"
             }
           ]);
-          const router = curi(history, routes, { external });
+          const router = curi(InMemory, routes, { external });
           expect(router.external).toBe(external);
         });
       });
@@ -400,7 +393,7 @@ describe("curi", () => {
     describe("sync/async matching", () => {
       it("does synchronous matching by default", () => {
         const routes = prepareRoutes([{ name: "Home", path: "" }]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const after = jest.fn();
         router.once(r => {
           expect(after.mock.calls.length).toBe(0);
@@ -418,7 +411,7 @@ describe("curi", () => {
             }
           }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const after = jest.fn();
         router.once(r => {
           expect(after.mock.calls.length).toBe(1);
@@ -442,8 +435,11 @@ describe("curi", () => {
             ]
           }
         ]);
-        const history = InMemory({ locations: ["/parent/child"] });
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/parent/child"]
+          }
+        });
         const after = jest.fn();
         let navigated = false;
         router.observe(r => {
@@ -464,7 +460,7 @@ describe("curi", () => {
     describe("sync", () => {
       it("initial value is an object with resolved response and navigation properties", () => {
         const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         expect(router.current()).toMatchObject({
           response: { name: "Catch All" },
           navigation: { action: "push" }
@@ -483,7 +479,7 @@ describe("curi", () => {
             }
           }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         expect(router.current()).toMatchObject({
           response: null,
           navigation: null
@@ -493,7 +489,7 @@ describe("curi", () => {
 
     it("response and navigation are the last resolved response and navigation", () => {
       const routes = prepareRoutes([{ name: "Home", path: "" }]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       router.once(({ response, navigation }) => {
         expect(router.current()).toMatchObject({
           response,
@@ -507,7 +503,7 @@ describe("curi", () => {
         { name: "Home", path: "" },
         { name: "About", path: "about" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       let calls = 0;
       router.observe(({ response, navigation }) => {
         calls++;
@@ -547,7 +543,7 @@ describe("curi", () => {
         { name: "Contacto", path: "contacto" }
       ]);
 
-      const router = curi(history, englishRoutes);
+      const router = curi(InMemory, englishRoutes);
 
       router.refresh(spanishRoutes);
 
@@ -563,9 +559,6 @@ describe("curi", () => {
     });
 
     it("emits a new response handler for new routes", () => {
-      const history = InMemory({
-        locations: ["/admin"]
-      });
       const nonAuthRoutes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "Not Found", path: "(.*)" }
@@ -576,7 +569,11 @@ describe("curi", () => {
         { name: "Not Found", path: "(.*)" }
       ]);
 
-      const router = curi(history, nonAuthRoutes);
+      const router = curi(InMemory, nonAuthRoutes, {
+        history: {
+          locations: ["/admin"]
+        }
+      });
 
       const { response: initialResponse } = router.current();
       expect(initialResponse.name).toBe("Not Found");
@@ -593,8 +590,11 @@ describe("curi", () => {
         { name: "About", path: "about" },
         { name: "Contact", path: "contact" }
       ]);
-      const history = InMemory({ locations: ["/about"] });
-      const router = curi(history, englishRoutes);
+      const router = curi(InMemory, englishRoutes, {
+        history: {
+          locations: ["/about"]
+        }
+      });
 
       const { response: initialResponse } = router.current();
 
@@ -620,8 +620,11 @@ describe("curi", () => {
         { name: "About", path: "about" },
         { name: "Contact", path: "contact" }
       ]);
-      const history = InMemory({ locations: ["/about"] });
-      const router = curi(history, englishRoutes);
+      const router = curi(InMemory, englishRoutes, {
+        history: {
+          locations: ["/about"]
+        }
+      });
 
       const { navigation: initialNavigation } = router.current();
 
@@ -641,18 +644,13 @@ describe("curi", () => {
   });
 
   describe("observe(fn)", () => {
-    let history;
-    beforeEach(() => {
-      history = InMemory({ locations: ["/"] });
-    });
-
     it("returns a function to unsubscribe when called", () => {
       const routes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "Next", path: "next" },
         { name: "Not Found", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
 
       const sub1 = jest.fn();
       const sub2 = jest.fn();
@@ -685,8 +683,7 @@ describe("curi", () => {
           expect(router).toBe(router);
           done();
         };
-
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.observe(responseHandler);
       });
 
@@ -714,7 +711,7 @@ describe("curi", () => {
           });
         };
 
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         // register before navigation, but don't call with existing response
         router.observe(check, { initial: false });
         router.navigate({ name: "How", params: { method: "mail" } });
@@ -740,7 +737,7 @@ describe("curi", () => {
             router.navigate({ name: "Contact" });
           }
         });
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.observe(everyTime);
         router.observe(responseHandler);
       });
@@ -764,7 +761,7 @@ describe("curi", () => {
           expect(oneTime.mock.calls.length).toBe(0);
           done();
         });
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.once(oneTime);
         router.observe(responseHandler);
       });
@@ -795,8 +792,11 @@ describe("curi", () => {
             expect(promiseResolved).toBe(true);
             done();
           };
-          const history = InMemory({ locations: ["/contact/phone"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/contact/phone"]
+            }
+          });
           router.observe(check);
         });
 
@@ -822,8 +822,11 @@ describe("curi", () => {
             expect(response.params.method).toBe("mail");
             done();
           };
-          const history = InMemory({ locations: ["/contact/fax"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/contact/fax"]
+            }
+          });
           router.observe(check);
           router.navigate({
             name: "How",
@@ -842,7 +845,7 @@ describe("curi", () => {
         it("immediately called with most recent response/navigation", () => {
           const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const sub = jest.fn();
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           const { response, navigation } = router.current();
           router.observe(sub, { initial: true });
           expect(sub.mock.calls.length).toBe(1);
@@ -865,7 +868,7 @@ describe("curi", () => {
             }
           ]);
           const sub = jest.fn();
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           router.once(() => {
             router.observe(sub, { initial: true });
             expect(sub.mock.calls.length).toBe(1);
@@ -884,7 +887,7 @@ describe("curi", () => {
             }
           ]);
           const sub = jest.fn();
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           router.observe(sub, { initial: true });
           expect(sub.mock.calls.length).toBe(0);
         });
@@ -894,7 +897,7 @@ describe("curi", () => {
         it("has response, is not immediately called", done => {
           const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const everyTime = jest.fn();
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           router.once(() => {
             router.observe(everyTime, { initial: false });
             expect(everyTime.mock.calls.length).toBe(0);
@@ -912,7 +915,7 @@ describe("curi", () => {
             expect(response.name).toBe("About");
             done();
           });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           router.once(() => {
             router.observe(everyTime, { initial: false });
             expect(everyTime.mock.calls.length).toBe(0);
@@ -924,11 +927,6 @@ describe("curi", () => {
   });
 
   describe("once(fn)", () => {
-    let history;
-    beforeEach(() => {
-      history = InMemory({ locations: ["/"] });
-    });
-
     describe("response handler", () => {
       it("is passed object with response, navigation, and router", done => {
         const routes = prepareRoutes([{ name: "All", path: "(.*)" }]);
@@ -944,7 +942,7 @@ describe("curi", () => {
           done();
         };
 
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.once(responseHandler);
       });
 
@@ -955,7 +953,7 @@ describe("curi", () => {
           { name: "Not Found", path: "(.*)" }
         ]);
         const oneTime = jest.fn();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.once(oneTime);
         expect(oneTime.mock.calls.length).toBe(1);
       });
@@ -969,7 +967,7 @@ describe("curi", () => {
         ]);
         const firstOnce = jest.fn();
         const secondOnce = jest.fn();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.once(firstOnce);
         expect(firstOnce.mock.calls.length).toBe(1);
         expect(firstOnce.mock.calls[0][0].response).toMatchObject({
@@ -1007,7 +1005,7 @@ describe("curi", () => {
         });
         let called = false;
         const responseHandler = jest.fn();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         router.once(oneTime);
         router.observe(responseHandler);
       });
@@ -1038,8 +1036,11 @@ describe("curi", () => {
             expect(promiseResolved).toBe(true);
             done();
           };
-          const history = InMemory({ locations: ["/contact/phone"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/contact/phone"]
+            }
+          });
           router.once(check);
         });
 
@@ -1065,8 +1066,11 @@ describe("curi", () => {
             expect(response.params.method).toBe("mail");
             done();
           };
-          const history = InMemory({ locations: ["/contact/fax"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/contact/fax"]
+            }
+          });
           router.once(check);
           router.navigate({
             name: "How",
@@ -1085,7 +1089,7 @@ describe("curi", () => {
         it("immediately called with most recent response/navigation", () => {
           const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const sub = jest.fn();
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           const { response, navigation } = router.current();
           router.once(sub, { initial: true });
           expect(sub.mock.calls.length).toBe(1);
@@ -1108,7 +1112,7 @@ describe("curi", () => {
             }
           ]);
           const sub = jest.fn();
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           router.once(() => {
             router.once(sub, { initial: true });
             expect(sub.mock.calls.length).toBe(1);
@@ -1127,7 +1131,7 @@ describe("curi", () => {
             }
           ]);
           const sub = jest.fn();
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           router.once(sub, { initial: true });
           expect(sub.mock.calls.length).toBe(0);
         });
@@ -1137,7 +1141,7 @@ describe("curi", () => {
         it("has response, is not immediately called", done => {
           const routes = prepareRoutes([{ name: "Home", path: "" }]);
           const oneTime = jest.fn();
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           router.once(() => {
             router.once(oneTime, { initial: false });
             expect(oneTime.mock.calls.length).toBe(0);
@@ -1155,7 +1159,7 @@ describe("curi", () => {
             expect(response.name).toBe("About");
             done();
           });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes);
           router.once(() => {
             router.once(oneTime, { initial: false });
             expect(oneTime.mock.calls.length).toBe(0);
@@ -1176,8 +1180,7 @@ describe("curi", () => {
       },
       { name: "Catch All", path: "(.*)" }
     ]);
-    const history = InMemory();
-    const router = curi(history, routes);
+    const router = curi(InMemory, routes);
     const mockNavigate = jest.fn();
     router.history.navigate = mockNavigate;
 
@@ -1187,8 +1190,7 @@ describe("curi", () => {
 
     describe("navigation method", () => {
       it("lets the history object decide if no method is provided", () => {
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         expect(() => {
           router.navigate({ name: "Contact" });
         }).not.toThrow();
@@ -1210,8 +1212,7 @@ describe("curi", () => {
       });
 
       it("throws if given a bad navigation type", () => {
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         expect(() => {
           router.navigate({ name: "Contact", method: "BAAAAAAD" as NavType });
         }).toThrow();
@@ -1234,8 +1235,11 @@ describe("curi", () => {
       });
 
       it("re-uses current pathname if no name is provided", () => {
-        const history = InMemory({ locations: ["/reuse"] });
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/reuse"]
+          }
+        });
         const mockNavigate = jest.fn();
         router.history.navigate = mockNavigate;
         router.navigate({});
@@ -1292,8 +1296,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const cancelled = jest.fn();
         router.navigate({
           name: "Slow",
@@ -1316,8 +1319,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const cancelled = jest.fn();
         router.navigate({
           name: "Loader",
@@ -1367,8 +1369,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const finished = jest.fn();
         router.navigate({
           name: "Slow",
@@ -1390,8 +1391,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const finished = jest.fn();
         router.navigate({
           name: "Loader",
@@ -1424,8 +1424,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const finished = jest.fn();
         const cancelCallbacks = router.navigate({
           name: "Loader",
@@ -1470,8 +1469,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const history = InMemory();
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const cancelled = jest.fn();
         const cancelCallbacks = router.navigate({
           name: "Slow",
@@ -1486,13 +1484,12 @@ describe("curi", () => {
 
   describe("cancel(fn)", () => {
     it("does not call function for sync routes", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Home", path: "" },
         { name: "About", path: "about" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const cancellable = jest.fn();
       router.cancel(cancellable);
 
@@ -1505,7 +1502,6 @@ describe("curi", () => {
     });
 
     it("calls function with cancel fn when navigating to async routes", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Home", path: "" },
         {
@@ -1517,7 +1513,7 @@ describe("curi", () => {
         },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const cancellable = jest.fn();
       router.cancel(cancellable);
 
@@ -1529,7 +1525,6 @@ describe("curi", () => {
 
     describe("another navigation", () => {
       it("stays active when a second async navigation starts", () => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Home", path: "" },
           {
@@ -1556,7 +1551,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const cancellable = jest.fn();
         router.cancel(cancellable);
 
@@ -1567,7 +1562,6 @@ describe("curi", () => {
       });
 
       it("is cancelled when a sync navigation starts", () => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Home", path: "" },
           {
@@ -1587,7 +1581,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const cancellable = jest.fn();
         router.cancel(cancellable);
 
@@ -1602,7 +1596,6 @@ describe("curi", () => {
 
     describe("non-cancelled navigation", () => {
       it("calls function with no args once async actions are complete", done => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Home", path: "" },
           {
@@ -1614,7 +1607,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const cancellable = jest.fn();
         router.cancel(cancellable);
 
@@ -1635,7 +1628,6 @@ describe("curi", () => {
 
     describe("cancelling active navigation", () => {
       it("deactivates immediately if cancel function is called", () => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Home", path: "" },
           {
@@ -1647,7 +1639,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         let cancel;
         const cancellable = jest.fn(cancelFn => {
           cancel = cancelFn;
@@ -1663,7 +1655,6 @@ describe("curi", () => {
       });
 
       it("doesn't change locations", () => {
-        const history = InMemory();
         const routes = prepareRoutes([
           { name: "Home", path: "" },
           {
@@ -1675,7 +1666,7 @@ describe("curi", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         let cancel;
         const cancellable = jest.fn(cancelFn => {
           cancel = cancelFn;
@@ -1694,7 +1685,6 @@ describe("curi", () => {
     });
 
     it("returns a function to stop being called", () => {
-      const history = InMemory();
       const routes = prepareRoutes([
         { name: "Home", path: "" },
         {
@@ -1713,7 +1703,7 @@ describe("curi", () => {
         },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const cancellable = jest.fn();
       const stopCancelling = router.cancel(cancellable);
 
@@ -1748,7 +1738,7 @@ describe("curi", () => {
         }
       ]);
       let calls = 0;
-      const router = curi(history, routes, {
+      const router = curi(InMemory, routes, {
         sideEffects: [
           ({ response, navigation }) => {
             switch (calls++) {

--- a/packages/router/tests/path.spec.ts
+++ b/packages/router/tests/path.spec.ts
@@ -7,7 +7,6 @@ import { curi, prepareRoutes } from "@curi/router";
 describe("route.pathOptions matching", () => {
   describe("default options", () => {
     it("sensitive = false", () => {
-      const history = InMemory({ locations: ["/Here"] });
       const routes = prepareRoutes([
         {
           name: "Test",
@@ -18,13 +17,16 @@ describe("route.pathOptions matching", () => {
           path: "(.*)"
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/Here"]
+        }
+      });
       const { response } = router.current();
       expect(response.name).toBe("Test");
     });
 
     it("strict = false", () => {
-      const history = InMemory({ locations: ["/here/"] });
       const routes = prepareRoutes([
         {
           name: "Test",
@@ -35,13 +37,16 @@ describe("route.pathOptions matching", () => {
           path: "(.*)"
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/here/"]
+        }
+      });
       const { response } = router.current();
       expect(response.name).toBe("Test");
     });
 
     it("end = true", () => {
-      const history = InMemory({ locations: ["/here/again"] });
       const routes = prepareRoutes([
         {
           name: "Test",
@@ -52,7 +57,11 @@ describe("route.pathOptions matching", () => {
           path: "(.*)"
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/here/again"]
+        }
+      });
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
     });
@@ -60,7 +69,6 @@ describe("route.pathOptions matching", () => {
 
   describe("user provided options", () => {
     it("sensitive = true", () => {
-      const history = InMemory({ locations: ["/Here"] });
       const routes = prepareRoutes([
         {
           name: "Test",
@@ -72,13 +80,16 @@ describe("route.pathOptions matching", () => {
           path: "(.*)"
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/Here"]
+        }
+      });
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
     });
 
     it("strict = true", () => {
-      const history = InMemory({ locations: ["/here/"] });
       const routes = prepareRoutes([
         {
           name: "Test",
@@ -90,13 +101,16 @@ describe("route.pathOptions matching", () => {
           path: "(.*)"
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/here/"]
+        }
+      });
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
     });
 
     it("end = false", () => {
-      const history = InMemory({ locations: ["/here/again"] });
       const routes = prepareRoutes([
         {
           name: "Test",
@@ -108,7 +122,11 @@ describe("route.pathOptions matching", () => {
           path: "(.*)"
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/here/again"]
+        }
+      });
       const { response } = router.current();
       expect(response.name).toBe("Test");
     });

--- a/packages/router/tests/pathname-interaction.spec.ts
+++ b/packages/router/tests/pathname-interaction.spec.ts
@@ -5,12 +5,10 @@ import { InMemory } from "@hickory/in-memory";
 import { prepareRoutes, curi } from "@curi/router";
 
 describe("pathname route interaction", () => {
-  const history = InMemory();
-
   describe("calling", () => {
     it("it is accessed through route.name()", () => {
       const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       expect(router.route.pathname).toBeDefined();
     });
   });
@@ -22,7 +20,7 @@ describe("pathname route interaction", () => {
         { name: "Static", path: "this/has/no/params" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const output = router.route.pathname("Static");
       expect(output).toBe("/this/has/no/params");
     });
@@ -32,7 +30,7 @@ describe("pathname route interaction", () => {
         { name: "Player", path: "player/:id" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const output = router.route.pathname("Player", { id: 17 });
       expect(output).toBe("/player/17");
     });
@@ -46,7 +44,7 @@ describe("pathname route interaction", () => {
         { name: "Player", path: "player/:id" },
         { name: "Catch All", path: "(.*)" }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes);
       const output = router.route.pathname("Anonymous", { id: 123 });
 
       expect(output).toBe(undefined);

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -7,20 +7,22 @@ import { curi, prepareRoutes } from "@curi/router";
 describe("route matching/response generation", () => {
   describe("route matching", () => {
     it("ignores leading slash on the pathname", () => {
-      const history = InMemory({ locations: ["/test"] });
       const routes = prepareRoutes([
         {
           name: "Test",
           path: "test"
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/test"]
+        }
+      });
       const { response } = router.current();
       expect(response.name).toBe("Test");
     });
 
     it("does exact matching", () => {
-      const history = InMemory({ locations: ["/test/leftovers"] });
       const routes = prepareRoutes([
         {
           name: "Test",
@@ -31,7 +33,11 @@ describe("route matching/response generation", () => {
           path: "(.*)"
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/test/leftovers"]
+        }
+      });
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
     });
@@ -45,9 +51,12 @@ describe("route matching/response generation", () => {
       });
 
       it("no response is emitted", () => {
-        const history = InMemory({ locations: ["/test"] });
         const routes = prepareRoutes([]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/test"]
+          }
+        });
 
         const observer = jest.fn();
         router.once(observer);
@@ -55,9 +64,12 @@ describe("route matching/response generation", () => {
       });
 
       it("warns that no route matched", () => {
-        const history = InMemory({ locations: ["/test"] });
         const routes = prepareRoutes([]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/test"]
+          }
+        });
         const observer = jest.fn();
 
         router.once(observer);
@@ -69,7 +81,6 @@ describe("route matching/response generation", () => {
 
     describe("nested routes", () => {
       it("includes parent in partials if a child matches", () => {
-        const history = InMemory({ locations: ["/ND/Fargo"] });
         const routes = prepareRoutes([
           {
             name: "State",
@@ -82,14 +93,17 @@ describe("route matching/response generation", () => {
             ]
           }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/ND/Fargo"]
+          }
+        });
         const { response } = router.current();
         expect(response.name).toBe("City");
         expect(response.partials).toEqual(["State"]);
       });
 
       it("matches children when parent has trailing slash", () => {
-        const history = InMemory({ locations: ["/ND/Fargo/"] });
         const routes = prepareRoutes([
           {
             name: "State",
@@ -106,13 +120,16 @@ describe("route matching/response generation", () => {
             path: "(.*)"
           }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/ND/Fargo/"]
+          }
+        });
         const { response } = router.current();
         expect(response.name).toBe("City");
       });
 
       it("does non-end parent matching when there are child routes, even if pathOptions.end=true", () => {
-        const history = InMemory({ locations: ["/ND/Fargo"] });
         const routes = prepareRoutes([
           {
             name: "State",
@@ -126,14 +143,17 @@ describe("route matching/response generation", () => {
             ]
           }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/ND/Fargo"]
+          }
+        });
         const { response } = router.current();
         expect(response.name).toBe("City");
         expect(response.partials).toEqual(["State"]);
       });
 
       it("skips parent match if no children match", () => {
-        const history = InMemory({ locations: ["/MT/Bozeman"] });
         const routes = prepareRoutes([
           {
             name: "State",
@@ -150,7 +170,11 @@ describe("route matching/response generation", () => {
             path: "(.*)"
           }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/MT/Bozeman"]
+          }
+        });
         const { response } = router.current();
         expect(response.name).toBe("Not Found");
         expect(response.partials).toEqual([]);
@@ -158,7 +182,6 @@ describe("route matching/response generation", () => {
     });
 
     it("matches partial routes if route.pathOptions.end=false", () => {
-      const history = InMemory({ locations: ["/SD/Sioux City"] });
       const routes = prepareRoutes([
         {
           name: "State",
@@ -170,14 +193,17 @@ describe("route matching/response generation", () => {
           path: "(.*)"
         }
       ]);
-      const router = curi(history, routes);
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/SD/Sioux City"]
+        }
+      });
       const { response } = router.current();
       expect(response.name).toBe("State");
     });
 
     describe("optional path parameters", () => {
       it("works when optional param is included", () => {
-        const history = InMemory({ locations: ["/NY/about"] });
         const routes = prepareRoutes([
           {
             name: "State",
@@ -189,13 +215,16 @@ describe("route matching/response generation", () => {
             path: "(.*)"
           }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/NY/about"]
+          }
+        });
         const { response } = router.current();
         expect(response.name).toBe("State");
       });
 
       it("works when optional param is NOT included", () => {
-        const history = InMemory({ locations: ["/about"] });
         const routes = prepareRoutes([
           {
             name: "State",
@@ -207,7 +236,11 @@ describe("route matching/response generation", () => {
             path: "(.*)"
           }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/about"]
+          }
+        });
         const { response } = router.current();
         expect(response.name).toBe("State");
       });
@@ -219,8 +252,11 @@ describe("route matching/response generation", () => {
       describe("location", () => {
         it("is the location used to match routes", () => {
           const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-          const history = InMemory({ locations: ["/other-page"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/other-page"]
+            }
+          });
           const { response } = router.current();
           expect(response.location).toBe(router.history.location);
         });
@@ -228,20 +264,22 @@ describe("route matching/response generation", () => {
 
       describe("body", () => {
         it("is undefined if not set by route.response()", () => {
-          const history = InMemory({ locations: ["/test"] });
           const routes = prepareRoutes([
             {
               name: "Test",
               path: "test"
             }
           ]);
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/test"]
+            }
+          });
           const { response } = router.current();
           expect(response.body).toBeUndefined();
         });
 
         it("is the body value of the object returned by route.response()", () => {
-          const history = InMemory({ locations: ["/test"] });
           const body = () => "anybody out there?";
           const routes = prepareRoutes([
             {
@@ -254,7 +292,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/test"]
+            }
+          });
           const { response } = router.current();
           expect(response.body).toBe(body);
         });
@@ -272,8 +314,11 @@ describe("route matching/response generation", () => {
               ]
             }
           ]);
-          const history = InMemory({ locations: ["/contact"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/contact"]
+            }
+          });
           const { response } = router.current();
           expect(response.status).toBeUndefined();
         });
@@ -290,8 +335,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-          const history = InMemory({ locations: ["/"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/"]
+            }
+          });
           const { response } = router.current();
           expect(response.status).toBe(451);
         });
@@ -305,8 +353,11 @@ describe("route matching/response generation", () => {
               path: ""
             }
           ]);
-          const history = InMemory({ locations: ["/"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/"]
+            }
+          });
           const { response } = router.current();
           expect(response.data).toBeUndefined();
         });
@@ -325,8 +376,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-          const history = InMemory({ locations: ["/"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/"]
+            }
+          });
           const { response } = router.current();
           expect(response.data).toMatchObject({ test: "value" });
         });
@@ -340,8 +394,11 @@ describe("route matching/response generation", () => {
               path: ":state"
             }
           ]);
-          const history = InMemory({ locations: ["/AZ"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/AZ"]
+            }
+          });
 
           const { response } = router.current();
           expect(response.title).toBeUndefined();
@@ -359,8 +416,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-          const history = InMemory({ locations: ["/VA"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/VA"]
+            }
+          });
 
           const { response } = router.current();
           expect(response.title).toBe("A State");
@@ -375,8 +435,11 @@ describe("route matching/response generation", () => {
               path: "a-route"
             }
           ]);
-          const history = InMemory({ locations: ["/a-route"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/a-route"]
+            }
+          });
           const { response } = router.current();
           expect(response.name).toBe("A Route");
         });
@@ -384,7 +447,6 @@ describe("route matching/response generation", () => {
 
       describe("partials", () => {
         it("is set using the names of all partially matching routes", () => {
-          const history = InMemory({ locations: ["/TX/Austin"] });
           const routes = prepareRoutes([
             {
               name: "State",
@@ -397,7 +459,11 @@ describe("route matching/response generation", () => {
               ]
             }
           ]);
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/TX/Austin"]
+            }
+          });
           const { response } = router.current();
           expect(response.partials).toEqual(["State"]);
         });
@@ -405,7 +471,6 @@ describe("route matching/response generation", () => {
 
       describe("params", () => {
         it("includes params from partially matched routes", () => {
-          const history = InMemory({ locations: ["/MT/Bozeman"] });
           const routes = prepareRoutes([
             {
               name: "State",
@@ -418,7 +483,11 @@ describe("route matching/response generation", () => {
               ]
             }
           ]);
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/MT/Bozeman"]
+            }
+          });
           const { response } = router.current();
           expect(response.params).toEqual({
             state: "MT",
@@ -427,7 +496,6 @@ describe("route matching/response generation", () => {
         });
 
         it("overwrites param name conflicts", () => {
-          const history = InMemory({ locations: ["/1/2"] });
           const routes = prepareRoutes([
             {
               name: "One",
@@ -435,14 +503,17 @@ describe("route matching/response generation", () => {
               children: [{ name: "Two", path: ":id" }]
             }
           ]);
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/1/2"]
+            }
+          });
           const { response } = router.current();
           expect(response.params["id"]).toBe("2");
         });
 
         describe("parsing params", () => {
           it("uses route.params to parse params", () => {
-            const history = InMemory({ locations: ["/123"] });
             const routes = prepareRoutes([
               {
                 name: "number",
@@ -452,13 +523,16 @@ describe("route matching/response generation", () => {
                 }
               }
             ]);
-            const router = curi(history, routes);
+            const router = curi(InMemory, routes, {
+              history: {
+                locations: ["/123"]
+              }
+            });
             const { response } = router.current();
             expect(response.params).toEqual({ num: 123 });
           });
 
           it("parses params from parent routes", () => {
-            const history = InMemory({ locations: ["/123/456"] });
             const routes = prepareRoutes([
               {
                 name: "first",
@@ -477,7 +551,11 @@ describe("route matching/response generation", () => {
                 }
               }
             ]);
-            const router = curi(history, routes);
+            const router = curi(InMemory, routes, {
+              history: {
+                locations: ["/123/456"]
+              }
+            });
             const { response } = router.current();
             expect(response.params).toEqual({
               first: 123,
@@ -486,7 +564,6 @@ describe("route matching/response generation", () => {
           });
 
           it("uses string for any params not in route.params", () => {
-            const history = InMemory({ locations: ["/123/456"] });
             const routes = prepareRoutes([
               {
                 name: "combo",
@@ -496,7 +573,11 @@ describe("route matching/response generation", () => {
                 }
               }
             ]);
-            const router = curi(history, routes);
+            const router = curi(InMemory, routes, {
+              history: {
+                locations: ["/123/456"]
+              }
+            });
             const { response } = router.current();
             expect(response.params).toEqual({
               first: 123,
@@ -509,7 +590,6 @@ describe("route matching/response generation", () => {
             const errorMock = jest.fn();
             console.error = errorMock;
 
-            const history = InMemory({ locations: ["/123"] });
             const routes = prepareRoutes([
               {
                 name: "number",
@@ -521,7 +601,11 @@ describe("route matching/response generation", () => {
                 }
               }
             ]);
-            const router = curi(history, routes);
+            const router = curi(InMemory, routes, {
+              history: {
+                locations: ["/123"]
+              }
+            });
             const { response } = router.current();
             expect(response.params).toEqual({
               num: "123"
@@ -536,10 +620,11 @@ describe("route matching/response generation", () => {
       describe("error", () => {
         it("is undefined for good responses", () => {
           const routes = prepareRoutes([{ name: "Contact", path: "contact" }]);
-          const history = InMemory({
-            locations: ["/contact"]
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/contact"]
+            }
           });
-          const router = curi(history, routes);
           const { response } = router.current();
           expect(response.error).toBeUndefined();
         });
@@ -556,8 +641,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-          const history = InMemory({ locations: ["/"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/"]
+            }
+          });
           const { response } = router.current();
           expect(response.error).toBe("woops");
         });
@@ -565,7 +653,6 @@ describe("route matching/response generation", () => {
 
       describe("redirectTo", () => {
         it("contains the expected properties", () => {
-          const history = InMemory({ locations: ["/"] });
           const routes = prepareRoutes([
             {
               name: "A Route",
@@ -603,8 +690,11 @@ describe("route matching/response generation", () => {
               firstCall = false;
             }
           };
-          const router = curi(history, routes, {
-            sideEffects: [logger]
+          const router = curi(InMemory, routes, {
+            sideEffects: [logger],
+            history: {
+              locations: ["/"]
+            }
           });
         });
       });
@@ -635,8 +725,11 @@ describe("route matching/response generation", () => {
           }
         ]);
 
-        const history = InMemory({ locations: ["/hello?one=two"] });
-        curi(history, routes);
+        curi(InMemory, routes, {
+          history: {
+            locations: ["/hello?one=two"]
+          }
+        });
       });
 
       it("is called with external provided to router", done => {
@@ -654,9 +747,12 @@ describe("route matching/response generation", () => {
             resolve: spy
           }
         ]);
-
-        const history = InMemory({ locations: ["/hello?one=two"] });
-        curi(history, routes, { external });
+        curi(InMemory, routes, {
+          external,
+          history: {
+            locations: ["/hello?one=two"]
+          }
+        });
       });
     });
 
@@ -696,9 +792,11 @@ describe("route matching/response generation", () => {
             resolve: spy
           }
         ]);
-
-        const history = InMemory({ locations: ["/first"] });
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes, {
+          history: {
+            locations: ["/first"]
+          }
+        });
         router.navigate({ name: "Second" });
       });
 
@@ -714,9 +812,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-
-          const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/hello?one=two"]
+            }
+          });
         });
 
         it("is null when a resolve function throws", () => {
@@ -733,9 +833,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-
-          const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/hello?one=two"]
+            }
+          });
         });
 
         it("is the resolve results", () => {
@@ -753,9 +855,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-
-          const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/hello?one=two"]
+            }
+          });
         });
       });
 
@@ -777,9 +881,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-
-          const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/hello?one=two"]
+            }
+          });
         });
 
         it("is null when all resolve functions succeed", done => {
@@ -799,9 +905,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-
-          const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/hello?one=two"]
+            }
+          });
         });
       });
 
@@ -825,9 +933,11 @@ describe("route matching/response generation", () => {
               }
             }
           ]);
-
-          const history = InMemory({ locations: ["/hello?one=two"] });
-          const router = curi(history, routes);
+          const router = curi(InMemory, routes, {
+            history: {
+              locations: ["/hello?one=two"]
+            }
+          });
         });
       });
     });

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -31,15 +31,17 @@ function PropertyReporter(): Interaction {
 describe("public route properties", () => {
   describe("name", () => {
     it("is the provided value", () => {
-      const history = InMemory({ locations: ["/test"] });
       const routes = prepareRoutes([
         {
           name: "Test",
           path: "test"
         }
       ]);
-      const router = curi(history, routes, {
-        route: [PropertyReporter()]
+      const router = curi(InMemory, routes, {
+        route: [PropertyReporter()],
+        history: {
+          locations: ["/test"]
+        }
       });
       const routeProperties = router.route.properties("Test");
       expect(routeProperties.name).toBe("Test");
@@ -48,15 +50,15 @@ describe("public route properties", () => {
 
   describe("path", () => {
     it("is the provided value", () => {
-      const history = InMemory({ locations: ["/test"] });
       const routes = prepareRoutes([
         {
           name: "Test",
           path: "test"
         }
       ]);
-      const router = curi(history, routes, {
-        route: [PropertyReporter()]
+      const router = curi(InMemory, routes, {
+        route: [PropertyReporter()],
+        history: {}
       });
       const routeProperties = router.route.properties("Test");
       expect(routeProperties.path).toBe("test");
@@ -65,30 +67,34 @@ describe("public route properties", () => {
 
   describe("keys", () => {
     it("is the array of param names parsed from the path", () => {
-      const history = InMemory({ locations: ["/four/five/six"] });
       const routes = prepareRoutes([
         {
           name: "Test",
           path: ":one/:two/:three"
         }
       ]);
-      const router = curi(history, routes, {
-        route: [PropertyReporter()]
+      const router = curi(InMemory, routes, {
+        route: [PropertyReporter()],
+        history: {
+          locations: ["/four/five/six"]
+        }
       });
       const routeProperties = router.route.properties("Test");
       expect(routeProperties.keys).toEqual(["one", "two", "three"]);
     });
 
     it("is an empty array when the path has no params", () => {
-      const history = InMemory({ locations: ["/one/two/three"] });
       const routes = prepareRoutes([
         {
           name: "Test",
           path: "one/two/three"
         }
       ]);
-      const router = curi(history, routes, {
-        route: [PropertyReporter()]
+      const router = curi(InMemory, routes, {
+        route: [PropertyReporter()],
+        history: {
+          locations: ["/one/two/three"]
+        }
       });
       const routeProperties = router.route.properties("Test");
       expect(routeProperties.keys).toEqual([]);
@@ -97,7 +103,6 @@ describe("public route properties", () => {
 
   describe("resolve", () => {
     it("is the resolve function", done => {
-      const history = InMemory({ locations: ["/test"] });
       const routes = prepareRoutes([
         {
           name: "Test",
@@ -110,8 +115,11 @@ describe("public route properties", () => {
           }
         }
       ]);
-      const router = curi(history, routes, {
-        route: [PropertyReporter()]
+      const router = curi(InMemory, routes, {
+        route: [PropertyReporter()],
+        history: {
+          locations: ["/test"]
+        }
       });
       const routeProperties = router.route.properties("Test");
 
@@ -123,15 +131,17 @@ describe("public route properties", () => {
     });
 
     it("is undefined when route.resolve isn't provided", done => {
-      const history = InMemory({ locations: ["/test"] });
       const routes = prepareRoutes([
         {
           name: "Test",
           path: "test"
         }
       ]);
-      const router = curi(history, routes, {
-        route: [PropertyReporter()]
+      const router = curi(InMemory, routes, {
+        route: [PropertyReporter()],
+        history: {
+          locations: ["/test"]
+        }
       });
       const routeProperties = router.route.properties("Test");
       expect(routeProperties.resolve).toBeUndefined();
@@ -141,7 +151,6 @@ describe("public route properties", () => {
 
   describe("extra", () => {
     it("is the provided value", () => {
-      const history = InMemory({ locations: ["/test"] });
       const extra = {
         unofficial: true,
         another: 1
@@ -153,8 +162,11 @@ describe("public route properties", () => {
           extra
         }
       ]);
-      const router = curi(history, routes, {
-        route: [PropertyReporter()]
+      const router = curi(InMemory, routes, {
+        route: [PropertyReporter()],
+        history: {
+          locations: ["/test"]
+        }
       });
       const routeProperties = router.route.properties("Test");
       expect(routeProperties.extra).toBe(extra);

--- a/packages/router/types/curi.d.ts
+++ b/packages/router/types/curi.d.ts
@@ -1,6 +1,4 @@
-import { History, PendingNavigation } from "@hickory/root";
+import { HistoryConstructor } from "@hickory/root";
 import { CompiledRouteArray } from "./types/route";
 import { CuriRouter, RouterOptions } from "./types/curi";
-declare type PendingHistory = (fn: (p: PendingNavigation) => void) => History;
-export default function createRouter(pendingHistory: PendingHistory, routeArray: CompiledRouteArray, options?: RouterOptions): CuriRouter;
-export {};
+export default function createRouter<O>(historyConstructor: HistoryConstructor, routeArray: CompiledRouteArray, options?: RouterOptions<O>): CuriRouter;

--- a/packages/router/types/types/curi.d.ts
+++ b/packages/router/types/types/curi.d.ts
@@ -1,4 +1,4 @@
-import { History, Action, NavType } from "@hickory/root";
+import { History, Action, NavType, HistoryOptions } from "@hickory/root";
 import { PathFunctionOptions } from "path-to-regexp";
 import { Interaction, Interactions } from "./interaction";
 import { CompiledRouteArray } from "./route";
@@ -21,13 +21,14 @@ export declare type RemoveObserver = () => void;
 export declare type CancelActiveNavigation = () => void;
 export declare type Cancellable = (cancelActive?: CancelActiveNavigation) => void;
 export declare type RemoveCancellable = () => void;
-export interface RouterOptions {
+export interface RouterOptions<O = HistoryOptions> {
     route?: Array<Interaction>;
     sideEffects?: Array<Observer>;
     pathnameOptions?: PathFunctionOptions;
     emitRedirects?: boolean;
     automaticRedirects?: boolean;
     external?: any;
+    history?: O;
 }
 export interface CurrentResponse {
     response: Response | null;

--- a/packages/static/.size-snapshot.json
+++ b/packages/static/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/curi-static.js": {
-    "bundled": 8247,
-    "minified": 3244,
-    "gzipped": 1499
+    "bundled": 8244,
+    "minified": 3237,
+    "gzipped": 1496
   }
 }

--- a/packages/static/CHANGELOG.md
+++ b/packages/static/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Use `InMemory` history constructor when creating router.
+
 ## 1.0.0-alpha.6
 
 * Use named `InMemory` import (Hickory v2).

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@curi/router": "file:../router",
-    "@hickory/in-memory": "^2.0.0-alpha.5",
+    "@hickory/in-memory": "^2.0.0-beta.0",
     "@types/express": "^4.16.0",
     "@types/fs-extra": "^5.0.4",
     "fs-extra": "^7.0.0"

--- a/packages/static/src/pathnames.ts
+++ b/packages/static/src/pathnames.ts
@@ -8,8 +8,7 @@ export default function pathnames(
 ): Array<string> {
   const { routes, pages, routerOptions } = config;
 
-  const history = InMemory();
-  const router = curi(history, routes, routerOptions);
+  const router = curi(InMemory, routes, routerOptions);
 
   return pages.map(page => {
     const pathname = router.route.pathname(page.name, page.params);

--- a/packages/static/src/staticFiles.ts
+++ b/packages/static/src/staticFiles.ts
@@ -5,6 +5,7 @@ import { InMemory } from "@hickory/in-memory";
 
 import pathnames from "./pathnames";
 
+import { InMemoryOptions } from "@hickory/in-memory";
 import { Emitted, RouterOptions } from "@curi/router";
 import { StaticConfiguration, Result } from "./types";
 
@@ -50,14 +51,16 @@ export default async function staticFiles(
         try {
           // create a new router for each so we don't run into any issues
           // with overlapping requests
-          const history = InMemory({ locations: [pathname] });
 
-          const router = curi(history, routes, {
+          const router = curi<InMemoryOptions>(InMemory, routes, {
             ...getRouterOptions(),
             // need to emit redirects or will get stuck waiting forever
             emitRedirects: true,
             // and the responses should be for the redirect
-            automaticRedirects: false
+            automaticRedirects: false,
+            history: {
+              locations: [pathname]
+            }
           });
 
           router.once(

--- a/packages/svelte/tests/cases/link/basic-pathname/index.js
+++ b/packages/svelte/tests/cases/link/basic-pathname/index.js
@@ -10,8 +10,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/click/index.js
+++ b/packages/svelte/tests/cases/link/click/index.js
@@ -11,8 +11,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/forward-props/index.js
+++ b/packages/svelte/tests/cases/link/forward-props/index.js
@@ -10,8 +10,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/mod-click/index.js
+++ b/packages/svelte/tests/cases/link/mod-click/index.js
@@ -11,8 +11,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/not-left-click/index.js
+++ b/packages/svelte/tests/cases/link/not-left-click/index.js
@@ -11,8 +11,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/pathname-params/index.js
+++ b/packages/svelte/tests/cases/link/pathname-params/index.js
@@ -10,8 +10,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/prevent-click/index.js
+++ b/packages/svelte/tests/cases/link/prevent-click/index.js
@@ -11,8 +11,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/query-hash/index.js
+++ b/packages/svelte/tests/cases/link/query-hash/index.js
@@ -10,8 +10,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/relative/index.js
+++ b/packages/svelte/tests/cases/link/relative/index.js
@@ -10,8 +10,11 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory({ locations: ["/u/2"] });
-const router = curi(history, routes);
+const router = curi(InMemory, routes, {
+  history: {
+    locations: ["/u/2"]
+  }
+});
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/wrapper-destroy-callbacks/index.js
+++ b/packages/svelte/tests/cases/link/wrapper-destroy-callbacks/index.js
@@ -30,8 +30,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render(done) {

--- a/packages/svelte/tests/cases/link/wrapper-navigating/index.js
+++ b/packages/svelte/tests/cases/link/wrapper-navigating/index.js
@@ -11,8 +11,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/link/wrapper-while-navigating/index.js
+++ b/packages/svelte/tests/cases/link/wrapper-while-navigating/index.js
@@ -21,8 +21,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render(done) {

--- a/packages/svelte/tests/cases/link/wrapper/index.js
+++ b/packages/svelte/tests/cases/link/wrapper/index.js
@@ -11,8 +11,7 @@ const routes = prepareRoutes([
   { name: "Not Found", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/navigating/call/index.js
+++ b/packages/svelte/tests/cases/navigating/call/index.js
@@ -28,8 +28,7 @@ const routes = prepareRoutes([
   { name: "Catch All", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render(done) {

--- a/packages/svelte/tests/cases/navigating/mount/index.js
+++ b/packages/svelte/tests/cases/navigating/mount/index.js
@@ -28,8 +28,7 @@ const routes = prepareRoutes([
   { name: "Catch All", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/cases/navigating/nav-async/index.js
+++ b/packages/svelte/tests/cases/navigating/nav-async/index.js
@@ -28,8 +28,7 @@ const routes = prepareRoutes([
   { name: "Catch All", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render(done) {

--- a/packages/svelte/tests/cases/navigating/nav-sync/index.js
+++ b/packages/svelte/tests/cases/navigating/nav-sync/index.js
@@ -28,8 +28,7 @@ const routes = prepareRoutes([
   { name: "Catch All", path: "(.*)" }
 ]);
 
-const history = InMemory();
-const router = curi(history, routes);
+const router = curi(InMemory, routes);
 const store = curiStore(router);
 
 export default function render() {

--- a/packages/svelte/tests/store.spec.js
+++ b/packages/svelte/tests/store.spec.js
@@ -6,7 +6,7 @@ import { Store } from "svelte/store";
 import { curiStore } from "@curi/svelte";
 
 describe("curiStore", () => {
-  let history, router;
+  let router;
   const routes = prepareRoutes([
     { name: "Home", path: "" },
     { name: "About", path: "about" },
@@ -14,8 +14,7 @@ describe("curiStore", () => {
   ]);
 
   beforeEach(() => {
-    history = InMemory();
-    router = curi(history, routes);
+    router = curi(InMemory, routes);
   });
 
   describe("existing store", () => {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -35,6 +35,6 @@
   },
   "dependencies": {
     "@curi/router": "file:../router",
-    "@hickory/root": "^2.0.0-alpha.5"
+    "@hickory/root": "^2.0.0-beta.0"
   }
 }

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -7,7 +7,7 @@ import { curi, prepareRoutes } from "@curi/router";
 import { CuriPlugin } from "@curi/vue";
 
 describe("<curi-link>", () => {
-  let Vue, node, history, router, wrapper;
+  let Vue, node, router, wrapper;
   const routes = prepareRoutes([
     { name: "Place", path: "place/:name" },
     { name: "Catch All", path: "(.*)" }
@@ -17,8 +17,7 @@ describe("<curi-link>", () => {
     node = document.createElement("div");
     document.body.appendChild(node);
 
-    history = InMemory();
-    router = curi(history, routes);
+    router = curi(InMemory, routes);
 
     Vue = createLocalVue();
     Vue.use(CuriPlugin, { router });
@@ -67,10 +66,11 @@ describe("<curi-link>", () => {
 
     it('re-uses current pathname if "to" prop is not provided', () => {
       const Vue = createLocalVue();
-      const history = InMemory({
-        locations: ["/place/somewhere"]
+      const router = curi(InMemory, routes, {
+        history: {
+          locations: ["/place/somewhere"]
+        }
       });
-      const router = curi(history, routes);
       Vue.use(CuriPlugin, { router });
 
       wrapper = new Vue({
@@ -145,7 +145,6 @@ describe("<curi-link>", () => {
     });
 
     describe("scoped slot", () => {
-      let history;
       const routes = prepareRoutes([
         {
           name: "Test",
@@ -161,12 +160,8 @@ describe("<curi-link>", () => {
         { name: "Catch All", path: "(.*)" }
       ]);
 
-      beforeEach(() => {
-        history = InMemory();
-      });
-
       it("navigating = true after clicking", done => {
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Vue = createLocalVue();
         Vue.use(CuriPlugin, { router });
 
@@ -208,7 +203,7 @@ describe("<curi-link>", () => {
       });
 
       it("navigating = false after navigation completes", done => {
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Vue = createLocalVue();
         Vue.use(CuriPlugin, { router });
 
@@ -268,7 +263,7 @@ describe("<curi-link>", () => {
           },
           { name: "Catch All", path: "(.*)" }
         ]);
-        const router = curi(history, routes);
+        const router = curi(InMemory, routes);
         const Vue = createLocalVue();
         Vue.use(CuriPlugin, { router });
 

--- a/packages/vue/tests/focus.spec.ts
+++ b/packages/vue/tests/focus.spec.ts
@@ -8,13 +8,12 @@ import { CuriPlugin } from "@curi/vue";
 
 describe("curi-focus directive", () => {
   let vueWrapper;
-  const history = InMemory();
 
   const routes = prepareRoutes([
     { name: "Place", path: "place/:name" },
     { name: "Catch All", path: "(.*)" }
   ]);
-  const router = curi(history, routes);
+  const router = curi(InMemory, routes);
 
   const Vue = createLocalVue();
   Vue.use(CuriPlugin, { router });

--- a/packages/vue/tests/plugin.spec.ts
+++ b/packages/vue/tests/plugin.spec.ts
@@ -7,9 +7,8 @@ import { curi, prepareRoutes } from "@curi/router";
 import { CuriPlugin } from "@curi/vue";
 
 describe("CuriPlugin", () => {
-  const history = InMemory();
   const routes = prepareRoutes([{ name: "Catch All", path: "(.*)" }]);
-  const router = curi(history, routes);
+  const router = curi(InMemory, routes);
 
   describe("$router", () => {
     it("Adds the router to global Vue vars as $router", () => {
@@ -65,8 +64,7 @@ describe("CuriPlugin", () => {
       ]);
 
       beforeEach(() => {
-        history = InMemory();
-        router = curi(history, routes);
+        router = curi(InMemory, routes);
       });
 
       it("re-renders when updating curi object", done => {

--- a/website/package.json
+++ b/website/package.json
@@ -31,8 +31,8 @@
     "@curi/static": "file:../packages/static",
     "@emotion/core": "^10.0.6",
     "@emotion/styled": "^10.0.6",
-    "@hickory/browser": "^2.0.0-alpha.5",
-    "@hickory/in-memory": "^2.0.0-alpha.5",
+    "@hickory/browser": "^2.0.0-beta.0",
+    "@hickory/in-memory": "^2.0.0-beta.0",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1"
   }

--- a/website/src/router.js
+++ b/website/src/router.js
@@ -15,9 +15,7 @@ const announce = ariaLiveSideEffect(
   ({ response }) => `Navigated to ${response.title}`
 );
 
-const history = Browser();
-
-const router = curi(history, routes, {
+const router = curi(Browser, routes, {
   route: [active(), prefetch()],
   sideEffects: [setTitle, scrollTo, announce],
   emitRedirects: false


### PR DESCRIPTION
`curi()` takes a Hickory history constructor.

```js
// before
const history = Browser();
const router = curi(history, routes);

// after
const router = curi(Browser, routes);
```

If any options need to be passed to the `history` object, they can be passed with the `history` option.

```js
// before
const history = InMemory({
  locations: ['/one', '/two', '/three']
});
const router = curi(history, routes);

// after
const router = curi(InMemory, routes, {
  history: {
    locations: ['/one', '/two', '/three']
  }
});
```