### PR TITLE
Set focus immediately in effect

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 3782,
-    "minified": 1783,
-    "gzipped": 867,
+    "bundled": 3970,
+    "minified": 1710,
+    "gzipped": 836,
     "treeshaked": {
       "rollup": {
         "code": 829,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 4219,
-    "minified": 2131,
-    "gzipped": 982
+    "bundled": 4407,
+    "minified": 2058,
+    "gzipped": 953
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 10616,
-    "minified": 4144,
-    "gzipped": 1752
+    "bundled": 10804,
+    "minified": 4071,
+    "gzipped": 1726
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 10586,
-    "minified": 4114,
-    "gzipped": 1734
+    "bundled": 10774,
+    "minified": 4041,
+    "gzipped": 1709
   }
 }

--- a/packages/react-dom/src/hooks/useNavigationFocus.ts
+++ b/packages/react-dom/src/hooks/useNavigationFocus.ts
@@ -10,7 +10,13 @@ export default function useNavigationFocus(
   ref: React.MutableRefObject<HTMLElement | null>,
   props: FocusHookProps = {}
 ) {
+  // The response isn't actually used, but the app should only
+  // re-focus when the response changes. The preserve and preventScroll
+  // values are used, but not used in the comparison array because
+  // changing these values would steal the app's focus even though
+  // the location hasn't changed.
   const { response } = useCuri();
+  const { preserve, preventScroll = false } = props;
   React.useEffect(() => {
     const ele = ref.current;
     if (ele === null) {
@@ -22,7 +28,7 @@ export default function useNavigationFocus(
       return;
     }
 
-    if (props.preserve && ele.contains(document.activeElement)) {
+    if (preserve && ele.contains(document.activeElement)) {
       return;
     }
 
@@ -34,13 +40,7 @@ export default function useNavigationFocus(
         );
       }
     }
-    const { preventScroll = false } = props;
-    const timeout = setTimeout(() => {
-      // @ts-ignore
-      ele.focus({ preventScroll });
-    });
-    return () => {
-      clearTimeout(timeout);
-    };
+    // @ts-ignore
+    ele.focus({ preventScroll });
   }, [response]);
 }


### PR DESCRIPTION
`useEffect` is called after the render, so we do not need to delay focusing.