### PR TITLE
Automatically decode params if no fn is provided

### DIFF
--- a/packages/router/src/match_location.ts
+++ b/packages/router/src/match_location.ts
@@ -119,14 +119,12 @@ function parse_params(params: RawParams, fns?: ParamParsers): Params {
   // fails, fall back to the string value.
   for (let key in params) {
     let value = params[key];
-    let fn = fns[key];
-    if (fn) {
-      try {
-        value = fn(value);
-      } catch (e) {
-        console.error(e);
-        value = params[key];
-      }
+    let fn = fns[key] || decodeURIComponent;
+    try {
+      value = fn(value);
+    } catch (e) {
+      console.error(e);
+      value = params[key];
     }
     output[key] = value;
   }

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -562,7 +562,7 @@ describe("route matching/response generation", () => {
             });
           });
 
-          it("uses string for any params not in route.params", () => {
+          it("decodes param using decodeURIComponent if param has no function", () => {
             const routes = prepare_routes([
               {
                 name: "combo",
@@ -574,13 +574,13 @@ describe("route matching/response generation", () => {
             ]);
             const router = create_router(in_memory, routes, {
               history: {
-                locations: ["/123/456"]
+                locations: ["/123/test%20ing"]
               }
             });
             const { response } = router.current();
             expect(response.params).toEqual({
               first: 123,
-              second: "456"
+              second: "test ing"
             });
           });
 

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -35,6 +35,10 @@ describe("public route properties", () => {
         {
           name: "Test",
           path: "test"
+        },
+        {
+          name: "Not Found",
+          path: "(.*)"
         }
       ]);
       const router = create_router(in_memory, routes, {
@@ -54,6 +58,10 @@ describe("public route properties", () => {
         {
           name: "Test",
           path: "test"
+        },
+        {
+          name: "Not Found",
+          path: "(.*)"
         }
       ]);
       const router = create_router(in_memory, routes, {
@@ -71,6 +79,10 @@ describe("public route properties", () => {
         {
           name: "Test",
           path: ":one/:two/:three"
+        },
+        {
+          name: "Not Found",
+          path: "(.*)"
         }
       ]);
       const router = create_router(in_memory, routes, {
@@ -88,6 +100,10 @@ describe("public route properties", () => {
         {
           name: "Test",
           path: "one/two/three"
+        },
+        {
+          name: "Not Found",
+          path: "(.*)"
         }
       ]);
       const router = create_router(in_memory, routes, {
@@ -135,6 +151,10 @@ describe("public route properties", () => {
         {
           name: "Test",
           path: "test"
+        },
+        {
+          name: "Not Found",
+          path: "(.*)"
         }
       ]);
       const router = create_router(in_memory, routes, {
@@ -160,6 +180,10 @@ describe("public route properties", () => {
           name: "Test",
           path: "test",
           extra
+        },
+        {
+          name: "Not Found",
+          path: "(.*)"
         }
       ]);
       const router = create_router(in_memory, routes, {


### PR DESCRIPTION
If no function is provided for parsing a param, assume that it should be parsed using `decodeURIComponent`.

```js
{
  name: "Example",
  path: "e/:one/:two",
  params: {
    two: n => n
  }
}
// location.pathname === "/e/Beyonc%C3%A9/Beyonc%C3%A9"
params = {
  one: "Beyoncé", // no parser provided, so decodeURIComponent was used
  two: "Beyonc%C3%A9"
}
```