### PR TITLE
Move all path-to-regexp options to routes

### DIFF
--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 16933,
-    "minified": 6266,
-    "gzipped": 2405,
+    "bundled": 16573,
+    "minified": 6192,
+    "gzipped": 2377,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17186,
-    "minified": 6474,
-    "gzipped": 2496
+    "bundled": 16826,
+    "minified": 6400,
+    "gzipped": 2461
   },
   "dist/curi-router.umd.js": {
-    "bundled": 28629,
-    "minified": 8874,
-    "gzipped": 3629
+    "bundled": 28247,
+    "minified": 8809,
+    "gzipped": 3628
   },
   "dist/curi-router.min.js": {
-    "bundled": 28579,
-    "minified": 8824,
-    "gzipped": 3610
+    "bundled": 28197,
+    "minified": 8759,
+    "gzipped": 3612
   }
 }

--- a/packages/router/src/create_router.ts
+++ b/packages/router/src/create_router.ts
@@ -40,7 +40,7 @@ export default function create_router<O = HistoryOptions>(
   const route_interactions: Interactions = {};
   (options.route || [])
     // add the pathname interaction to the provided interactions
-    .concat(pathname_interaction(options.pathname_options))
+    .concat(pathname_interaction())
     .forEach(interaction => {
       route_interactions[interaction.name] = interaction.get;
       register_routes(routes, interaction);

--- a/packages/router/src/interactions/pathname.ts
+++ b/packages/router/src/interactions/pathname.ts
@@ -1,30 +1,15 @@
-import PathToRegexp from "path-to-regexp";
-import { with_leading_slash, join } from "../utils/path";
-
-import { PathFunction, PathFunctionOptions } from "path-to-regexp";
 import { Interaction, Route, Params } from "@curi/types";
 
-function generate_pathname(options?: PathFunctionOptions): Interaction {
-  let known_paths: { [key: string]: string } = {};
-  let cache: { [key: string]: PathFunction } = {};
+function generate_pathname(): Interaction {
+  let known: { [key: string]: (params?: Params) => string } = {};
   let already_compiled: { [key: string]: string } = {};
   return {
     name: "pathname",
-    register: (route: Route, parent: string): string => {
-      const { name, path, pathname } = route;
-
-      let base;
-      if (parent && known_paths[parent]) {
-        base = known_paths[parent];
-      }
-      known_paths[name] = with_leading_slash(base ? join(base, path) : path);
-      if (pathname) {
-        cache[name] = pathname;
-      }
-      return name;
+    register: (route: Route) => {
+      known[route.name] = route.pathname;
     },
     get: (name: string, params: Params): string | void => {
-      if (known_paths[name] == null) {
+      if (known[name] == null) {
         if (process.env.NODE_ENV !== "production") {
           console.error(
             `Could not generate pathname for ${name} because it is not registered.`
@@ -37,10 +22,7 @@ function generate_pathname(options?: PathFunctionOptions): Interaction {
         return already_compiled[hash];
       }
 
-      const compile = cache[name]
-        ? cache[name]
-        : (cache[name] = PathToRegexp.compile(known_paths[name]));
-      const output = compile(params, options);
+      const output = known[name](params);
       already_compiled[hash] = output;
       return output;
     }

--- a/packages/router/tests/path.spec.ts
+++ b/packages/router/tests/path.spec.ts
@@ -3,7 +3,7 @@ import { in_memory } from "@hickory/in-memory";
 
 import { create_router, prepare_routes } from "@curi/router";
 
-describe("route.path_options matching", () => {
+describe("route.path_options.match", () => {
   describe("default options", () => {
     it("sensitive = false", () => {
       const routes = prepare_routes([
@@ -72,7 +72,7 @@ describe("route.path_options matching", () => {
         {
           name: "Test",
           path: "here",
-          path_options: { sensitive: true }
+          path_options: { match: { sensitive: true } }
         },
         {
           name: "Not Found",
@@ -93,7 +93,7 @@ describe("route.path_options matching", () => {
         {
           name: "Test",
           path: "here",
-          path_options: { strict: true }
+          path_options: { match: { strict: true } }
         },
         {
           name: "Not Found",
@@ -114,7 +114,7 @@ describe("route.path_options matching", () => {
         {
           name: "Test",
           path: "here",
-          path_options: { end: false }
+          path_options: { match: { end: false } }
         },
         {
           name: "Not Found",

--- a/packages/router/tests/route-matching.spec.ts
+++ b/packages/router/tests/route-matching.spec.ts
@@ -125,12 +125,12 @@ describe("route matching/response generation", () => {
         expect(response.name).toBe("City");
       });
 
-      it("does non-end parent matching when there are child routes, even if path_options.end=true", () => {
+      it("does non-end parent matching when there are child routes, even if path_options.match.end=true", () => {
         const routes = prepare_routes([
           {
             name: "State",
             path: ":state",
-            path_options: { end: true },
+            path_options: { match: { end: true } },
             children: [
               {
                 name: "City",
@@ -177,12 +177,12 @@ describe("route matching/response generation", () => {
       });
     });
 
-    it("matches partial routes if route.path_options.end=false", () => {
+    it("matches partial routes if route.path_options.match.end=false", () => {
       const routes = prepare_routes([
         {
           name: "State",
           path: ":state",
-          path_options: { end: false }
+          path_options: { match: { end: false } }
         },
         {
           name: "Not Found",
@@ -204,7 +204,7 @@ describe("route matching/response generation", () => {
           {
             name: "State",
             path: ":state?/about",
-            path_options: { end: false }
+            path_options: { match: { end: false } }
           },
           {
             name: "Not Found",
@@ -225,7 +225,7 @@ describe("route matching/response generation", () => {
           {
             name: "State",
             path: ":state?/about",
-            path_options: { end: false }
+            path_options: { match: { end: false } }
           },
           {
             name: "Not Found",

--- a/packages/router/types/interactions/pathname.d.ts
+++ b/packages/router/types/interactions/pathname.d.ts
@@ -1,4 +1,3 @@
-import { PathFunctionOptions } from "path-to-regexp";
 import { Interaction } from "@curi/types";
-declare function generate_pathname(options?: PathFunctionOptions): Interaction;
+declare function generate_pathname(): Interaction;
 export default generate_pathname;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,7 +17,7 @@ import {
 export interface RouteDescriptor {
   name: string;
   path: string;
-  path_options?: RegExpOptions;
+  path_options?: PathOptions;
   params?: ParamParsers;
   children?: Array<RouteDescriptor>;
   response?: ResponseFn;
@@ -25,11 +25,15 @@ export interface RouteDescriptor {
   extra?: { [key: string]: any };
 }
 
+export interface PathOptions {
+  match?: RegExpOptions;
+  compile?: PathFunctionOptions;
+}
+
 // third argument to create_router
 export interface RouterOptions<O = HistoryOptions> {
   route?: Array<Interaction>;
   side_effects?: Array<Observer>;
-  pathname_options?: PathFunctionOptions;
   emit_redirects?: boolean;
   external?: any;
   history?: O;

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -3,7 +3,7 @@ import { History, HistoryOptions, SessionLocation, PartialLocation, Action, NavT
 export interface RouteDescriptor {
     name: string;
     path: string;
-    path_options?: RegExpOptions;
+    path_options?: PathOptions;
     params?: ParamParsers;
     children?: Array<RouteDescriptor>;
     response?: ResponseFn;
@@ -12,10 +12,13 @@ export interface RouteDescriptor {
         [key: string]: any;
     };
 }
+export interface PathOptions {
+    match?: RegExpOptions;
+    compile?: PathFunctionOptions;
+}
 export interface RouterOptions<O = HistoryOptions> {
     route?: Array<Interaction>;
     side_effects?: Array<Observer>;
-    pathname_options?: PathFunctionOptions;
     emit_redirects?: boolean;
     external?: any;
     history?: O;

--- a/website/src/pages/Guides/routes.js
+++ b/website/src/pages/Guides/routes.js
@@ -176,7 +176,7 @@ function RoutesGuide() {
 
     // import the User component using the import() API
     const body = import("./components/User");
-    
+
     // get specific data using the route's params
     const data = UserAPI.get(params.id);
     return Promise.all([ authorized, body, data ]);
@@ -392,8 +392,8 @@ const routes = prepare_routes([
         <HashSection meta={optionsMeta} tag="h3">
           <p>
             You can control whether a route does exact or partial matching with{" "}
-            <Link hash="pathOptions">
-              <IJS>pathOptions</IJS>
+            <Link hash="path_options">
+              <IJS>path_options</IJS>
             </Link>{" "}
             property. If you set <IJS>{`{ end: false }`}</IJS>, a route that
             partially matches will consider itself matched.
@@ -407,8 +407,10 @@ const routes = prepare_routes([
 {
   name: 'Album',
   path: 'a/:albumID',
-  pathOptions: {
-    end: false
+  path_options: {
+    parse: {
+      end: false
+    }
   }
 }`}
           </CodeBlock>

--- a/website/src/pages/Packages/router/v2/api/curi.js
+++ b/website/src/pages/Packages/router/v2/api/curi.js
@@ -274,36 +274,6 @@ const router = create_router(browser, routes, {
 // to "/new/2" without emitting a response`}
             </CodeBlock>
           </HashSection>
-
-          <HashSection
-            tag="h6"
-            meta={{
-              title: <IJS>pathnameOptions</IJS>,
-              hash: "options-pathnameOptions"
-            }}
-          >
-            <p>
-              Curi uses{" "}
-              <a href="https://github.com/pillarjs/path-to-regexp">
-                <IJS>path-to-regexp</IJS>
-              </a>{" "}
-              to handle route matching and pathname generation.{" "}
-              <IJS>path-to-regexp</IJS> can take a custom{" "}
-              <a href="https://github.com/pillarjs/path-to-regexp#compile-reverse-path-to-regexp">
-                <IJS>encode</IJS>
-              </a>{" "}
-              function for creating pathnames, which you can specify with this
-              options.
-            </p>
-
-            <CodeBlock>
-              {`const router = create_router(browser, routes, {
-  pathOptions: {
-    encode: (value, token) => { /* ... */ }
-  }
-});`}
-            </CodeBlock>
-          </HashSection>
         </HashSection>
       </HashSection>
 

--- a/website/src/pages/Packages/router/v2/api/route-objects.js
+++ b/website/src/pages/Packages/router/v2/api/route-objects.js
@@ -451,24 +451,58 @@ const user = {
       </HashSection>
 
       <HashSection
-        meta={{ title: "pathOptions", hash: "pathOptions" }}
+        meta={{ title: "path_options", hash: "path_options" }}
         tag="h3"
       >
         <p>
-          If you need to provide different path options than{" "}
-          <a href="https://github.com/pillarjs/path-to-regexp#usage">
-            the defaults
+          Curi uses{" "}
+          <a href="https://github.com/pillarjs/path-to-regexp">
+            <IJS>path-to-regexp</IJS>
           </a>{" "}
-          used by <IJS>path-to-regexp</IJS>, you can provide them with a{" "}
-          <IJS>pathOptions</IJS> object.
+          to handle route matching and pathname generation. Each route can
+          configure both its route matching and pathname generation through its{" "}
+          <IJS>path_options</IJS> property.
         </p>
+
         <Note>
           <p>
             If a route has a children array property, it will{" "}
-            <strong>always</strong> have the <IJS>end</IJS> path option set to
-            false.
+            <strong>always</strong> have the <IJS>end</IJS> path option set to{" "}
+            <IJS>false</IJS>.
           </p>
         </Note>
+
+        <p>
+          For route matching, the options are passed through a <IJS>match</IJS>{" "}
+          object. You can see the options and their default values in the{" "}
+          <a href="https://github.com/pillarjs/path-to-regexp#usage">
+            <IJS>path-to-regexp</IJS> documentation
+          </a>
+          .
+        </p>
+
+        <p>
+          For pathname generation, the options are passed through a{" "}
+          <IJS>compile</IJS> object. There is only one possible option, which is
+          an <IJS>encode</IJS> function for encoding params. The default{" "}
+          <IJS>encode</IJS> function encodes params using{" "}
+          <IJS>encodeURIComponent</IJS>.
+        </p>
+
+        <CodeBlock>
+          {`{
+  name: "My Route",
+  path: "my/:item",
+  path_options: {
+    match: {
+      sensitive: false
+    },
+    compile: {
+      encode: (value, token) => value
+    }
+  }
+}`}
+        </CodeBlock>
       </HashSection>
 
       <HashSection meta={{ title: "extra", hash: "extra" }} tag="h3">


### PR DESCRIPTION
Instead of `route.path_options` taking the options for creating a regexp, it is now an object with two possible properties: `match` and `compile`.

The `match` property is the old `route.path_options`; it is used to pass options for creating a regular expression from the `path`.

The `compile` property is used to pass a custom `encode` function to be used when compiling a `pathname`. This used to be an option passed to `create_router`, but that has been removed. While this new setup is slightly less convenient because it has to be passed to each route, the option should almost never be used.

```js
{
  name: "My Route",
  path: "my/:item",
  path_options: {
    match: {
      sensitive: false
    },
    compile: {
      encode: (value, token) => value
    }
  }
}
```