### PR TITLE
emitRedirects -> invisibleRedirects

### DIFF
--- a/examples/misc/server-rendering/src/index.js
+++ b/examples/misc/server-rendering/src/index.js
@@ -8,7 +8,7 @@ import routes from "./routes";
 import App from "./components/App";
 
 const router = createRouter(browser, routes, {
-  emitRedirects: false
+  invisibleRedirects: true
 });
 const Router = createRouterComponent(router);
 

--- a/examples/react/redirects/src/index.js
+++ b/examples/react/redirects/src/index.js
@@ -9,7 +9,7 @@ import routes from "./routes";
 import App from "./components/App";
 
 const router = createRouter(browser, routes, {
-  emitRedirects: false,
+  invisibleRedirects: true,
   history: {
     query: { parse, stringify }
   }

--- a/examples/svelte/redirects/src/index.js
+++ b/examples/svelte/redirects/src/index.js
@@ -1,14 +1,13 @@
 import { browser } from "@hickory/browser";
 import { createRouter } from "@curi/router";
 import { curiStore } from "@curi/svelte";
-import { Store } from "svelte/store";
 import { parse, stringify } from "qs";
 
 import routes from "./routes";
 import app from "./components/App.html";
 
 const router = createRouter(browser, routes, {
-  emitRedirects: false,
+  invisibleRedirects: true,
   history: {
     query: { parse, stringify }
   }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 16208,
-    "minified": 6126,
-    "gzipped": 2381,
+    "bundled": 16225,
+    "minified": 6130,
+    "gzipped": 2385,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 16459,
-    "minified": 6332,
-    "gzipped": 2464
+    "bundled": 16476,
+    "minified": 6336,
+    "gzipped": 2469
   },
   "dist/curi-router.umd.js": {
-    "bundled": 27880,
-    "minified": 8796,
-    "gzipped": 3628
+    "bundled": 27897,
+    "minified": 8800,
+    "gzipped": 3632
   },
   "dist/curi-router.min.js": {
-    "bundled": 27830,
-    "minified": 8746,
-    "gzipped": 3608
+    "bundled": 27847,
+    "minified": 8750,
+    "gzipped": 3611
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Change `emitRedirects` (default `true`) to `invisibleRedirects` (default `false`).
+
 ## 2.0.0-beta.7
 
 * `route.path_options` is an object with `match` (for matching location) and `compile` (for generating pathnames) properties.

--- a/packages/router/src/createRouter.ts
+++ b/packages/router/src/createRouter.ts
@@ -112,10 +112,10 @@ export default function createRouter<O = HistoryOptions>(
     emitImmediate(response, navigation);
   }
 
-  const { emitRedirects = true } = options;
+  const { invisibleRedirects = false } = options;
 
   function emitImmediate(response: Response, navigation: Navigation) {
-    if (!response.redirect || emitRedirects) {
+    if (!response.redirect || !invisibleRedirects) {
       mostRecent.response = response;
       mostRecent.navigation = navigation;
 

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -201,7 +201,7 @@ describe("curi", () => {
         });
       });
 
-      describe("emitRedirects", () => {
+      describe("invisibleRedirects", () => {
         it("emits redirects by default", () => {
           const routes = prepareRoutes([
             {
@@ -232,7 +232,7 @@ describe("curi", () => {
           });
         });
 
-        it("does not emit redirects when emitRedirects = false", done => {
+        it("does not emit redirects when invisibleRedirects = true", done => {
           const routes = prepareRoutes([
             {
               name: "Start",
@@ -252,7 +252,7 @@ describe("curi", () => {
           ]);
 
           const router = createRouter(inMemory, routes, {
-            emitRedirects: false
+            invisibleRedirects: true
           });
           // the first emitted response is the location that was redirected to
           router.once(({ response }) => {

--- a/packages/static/.size-snapshot.json
+++ b/packages/static/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/curi-static.js": {
-    "bundled": 8095,
-    "minified": 3187,
-    "gzipped": 1492
+    "bundled": 8101,
+    "minified": 3192,
+    "gzipped": 1494
   }
 }

--- a/packages/static/src/staticFiles.ts
+++ b/packages/static/src/staticFiles.ts
@@ -54,7 +54,7 @@ export default async function staticFiles(
           const router = createRouter<LocationOptions>(reusable, routes, {
             ...routerOptions(),
             // need to emit redirects or will get stuck waiting forever
-            emitRedirects: true,
+            invisibleRedirects: false,
             history: {
               location: pathname
             }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,7 +34,7 @@ export interface PathOptions {
 export interface RouterOptions<O = HistoryOptions> {
   route?: Array<Interaction>;
   sideEffects?: Array<Observer>;
-  emitRedirects?: boolean;
+  invisibleRedirects?: boolean;
   external?: any;
   history?: O;
 }

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -19,7 +19,7 @@ export interface PathOptions {
 export interface RouterOptions<O = HistoryOptions> {
     route?: Array<Interaction>;
     sideEffects?: Array<Observer>;
-    emitRedirects?: boolean;
+    invisibleRedirects?: boolean;
     external?: any;
     history?: O;
 }

--- a/website/src/pages/Examples/react/redirects.js
+++ b/website/src/pages/Examples/react/redirects.js
@@ -38,7 +38,7 @@ function AuthenticationExample() {
 
         <p>
           A <IJS>response</IJS> function can modify the response by setting a{" "}
-          <IJS>redirectTo</IJS> property on its return object. Curi will
+          <IJS>redirect</IJS> property on its return object. Curi will
           automatically (unless configured not to) redirect to that location.
         </p>
 
@@ -52,7 +52,7 @@ function AuthenticationExample() {
       if (!store.userIsAuthenticated) {
         // tell Curi to redirect to the Login route
         return {
-          redirectTo: { name: "Login" },
+          redirect: { name: "Login" },
           status: 302
         };
       }

--- a/website/src/pages/Examples/svelte/redirects.js
+++ b/website/src/pages/Examples/svelte/redirects.js
@@ -38,7 +38,7 @@ function AuthenticationExample() {
 
         <p>
           A <IJS>response</IJS> function can modify the response by setting a{" "}
-          <IJS>redirectTo</IJS> property on its return object. Curi will
+          <IJS>redirect</IJS> property on its return object. Curi will
           automatically (unless configured not to) redirect to that location.
         </p>
 
@@ -51,7 +51,7 @@ function AuthenticationExample() {
     response: () => {
       if (!store.userIsAuthenticated) {
         return {
-          redirectTo: { name: "Login" },
+          redirect: { name: "Login" },
           status: 302
         };
       }

--- a/website/src/pages/Examples/vue/redirects.js
+++ b/website/src/pages/Examples/vue/redirects.js
@@ -38,7 +38,7 @@ function AuthenticationExample() {
 
         <p>
           A <IJS>response</IJS> function can modify the response by setting a{" "}
-          <IJS>redirectTo</IJS> property on its return object. Curi will
+          <IJS>redirect</IJS> property on its return object. Curi will
           automatically (unless configured not to) redirect to that location.
         </p>
 

--- a/website/src/pages/Guides/loading.js
+++ b/website/src/pages/Guides/loading.js
@@ -135,7 +135,7 @@ function LoadingGuide() {
         </p>
 
         <p>
-          You can specify the route to redirect to with <IJS>redirectTo</IJS>.
+          You can specify the route to redirect to with <IJS>redirect</IJS>.
           This takes the <IJS>name</IJS> of the route to redirect to,{" "}
           <IJS>params</IJS> if the route (or ancestor routes) have route params.{" "}
           <IJS>hash</IJS>, <IJS>query</IJS>, and <IJS>state</IJS> can also be
@@ -154,7 +154,7 @@ function LoadingGuide() {
     // destructure the current location to preserve
     // query/hash values
     return {
-      redirectTo: {
+      redirect: {
         name: 'Recipe',
         params: params,
         hash: location.hash

--- a/website/src/pages/Guides/responses.js
+++ b/website/src/pages/Guides/responses.js
@@ -120,7 +120,7 @@ function ResponsesGuide() {
               <td>A convenient place to attach any errors to the response.</td>
             </tr>
             <tr>
-              <td>redirectTo</td>
+              <td>redirect</td>
               <td>
                 An object describing a route that Curi should automatically
                 redirect to.
@@ -149,7 +149,7 @@ function ResponsesGuide() {
 
   error: undefined,
 
-  redirectTo: {...}
+  redirect: {...}
 }`}
         </CodeBlock>
       </HashSection>
@@ -207,10 +207,10 @@ const routes = prepareRoutes([
           When a route's <IJS>response</IJS> function returns an object with a{" "}
           <Link
             name="Package"
-            params={{ package: "router", version: "v1" }}
+            params={{ package: "router", version: "v2" }}
             hash="response"
           >
-            <IJS>redirectTo</IJS> property
+            <IJS>redirect</IJS> property
           </Link>
           , the router will use it to generate a location object that Curi will
           automatically redirect to.
@@ -218,22 +218,22 @@ const routes = prepareRoutes([
 
         <CodeBlock>
           {`{
-  // The redirectTo property provides information on
+  // The redirect property provides information on
   // where you should redirect to
-  redirectTo: { name: "Login" }
+  redirect: { name: "Login" }
 }`}
         </CodeBlock>
 
         <p>
-          When creating a router, you can set the <IJS>emitRedirects</IJS>{" "}
-          option to <IJS>false</IJS> and the response will not be sent to
+          When creating a router, you can set the <IJS>invisibleRedirects</IJS>{" "}
+          option to <IJS>true</IJS> and the response will not be sent to
           observers and one time functions. Redirect responses don't usually
           have anything to render, so setting this option is usually ideal.
         </p>
 
         <CodeBlock>
           {`const router = createRouter(browser, routes, {
-  emitRedirects: false
+  invisibleRedirects: false
 });`}
         </CodeBlock>
       </HashSection>

--- a/website/src/pages/Guides/ssr.js
+++ b/website/src/pages/Guides/ssr.js
@@ -590,9 +590,9 @@ function renderHandler(req, res) {
           <p>
             If a route matches and it redirects, you can handle it without
             rendering the application. A <IJS>response</IJS> is a redirect if it
-            has a <IJS>redirectTo</IJS> property. <IJS>redirectTo.url</IJS> is
-            that full URL (<IJS>pathname</IJS>, <IJS>query</IJS>, and{" "}
-            <IJS>hash</IJS>).
+            has a <IJS>redirect</IJS> property. <IJS>redirect.url</IJS> is that
+            full URL (<IJS>pathname</IJS>, <IJS>query</IJS>, and <IJS>hash</IJS>
+            ).
           </p>
 
           <CodeBlock data-line="9-12">
@@ -604,7 +604,7 @@ function renderHandler(req, res) {
     history: { location: req.url }
   });
   router.once(({ response }) => {
-    if (response.redirectTo) {
+    if (response.redirect) {
       res.redirect(301);
       return;
     }

--- a/website/src/pages/Packages/router/v1/api/curi.js
+++ b/website/src/pages/Packages/router/v1/api/curi.js
@@ -222,7 +222,7 @@ const router = curi(history, routes, {
           >
             <p>
               When <IJS>false</IJS> (default is <IJS>true</IJS>), response
-              objects with the <IJS>redirectTo</IJS> property{" "}
+              objects with the <IJS>redirect</IJS> property{" "}
               <strong>will not be emitted</strong> to observers. This can be
               useful for avoiding an extra render, but should not be used on the
               server.
@@ -236,7 +236,7 @@ const router = curi(history, routes, {
     response({ params }) {
       // setup a redirect to the "New" route
       return {
-        redirectTo: {
+        redirect: {
           name: "New",
           params
         }

--- a/website/src/pages/Packages/router/v2/api/curi.js
+++ b/website/src/pages/Packages/router/v2/api/curi.js
@@ -210,8 +210,8 @@ const router = createRouter(browser, routes, {
           <HashSection
             tag="h6"
             meta={{
-              title: <IJS>emitRedirects</IJS>,
-              hash: "options-emitRedirects"
+              title: <IJS>invisibleRedirects</IJS>,
+              hash: "options-invisibleRedirects"
             }}
           >
             <p>
@@ -221,20 +221,20 @@ const router = createRouter(browser, routes, {
             </p>
 
             <p>
-              If the <IJS>emitRedirects</IJS> property is <IJS>true</IJS> (the
-              default), Curi will emit the redirect response (any observers will
-              be called with the response).
+              If the <IJS>invisibleRedirects</IJS> property is <IJS>false</IJS>{" "}
+              (the default), Curi will emit the redirect response (any observers
+              will be called with the response).
             </p>
 
             <p>
-              If <IJS>emitRedirects</IJS> is set to <IJS>false</IJS>, Curi will
-              skip emitting the redirect; this effectively makes the redirect
-              invisible to the application.
+              If <IJS>invisibleRedirects</IJS> is set to <IJS>true</IJS>, Curi
+              will skip emitting the redirect; this effectively makes the
+              redirect invisible to the application.
             </p>
 
             <p>
-              <IJS>emitRedirects</IJS> should always be <IJS>true</IJS> for
-              server-side rendering, otherwise the application will render
+              <IJS>invisibleRedirects</IJS> should always be <IJS>false</IJS>{" "}
+              for server-side rendering, otherwise the application will render
               content for the incorrect location.
             </p>
 
@@ -260,7 +260,7 @@ const router = createRouter(browser, routes, {
 ]);
 
 const router = createRouter(browser, routes, {
-  emitRedirects: false
+  invisibleRedirects: false
 });
 // navigating to "/old/2" will automatically redirect
 // to "/new/2" without emitting a response for the Old route`}

--- a/website/src/pages/Packages/static/v1/api/staticFiles.js
+++ b/website/src/pages/Packages/static/v1/api/staticFiles.js
@@ -338,8 +338,8 @@ staticFiles({
               <p>
                 If you do create HTML files for redirects, be sure that your
                 application knows how to render redirect responses. If you are
-                using setting <IJS>emitRedirects</IJS> to <IJS>false</IJS> in
-                your client side code, your application probably doesn't know
+                using setting <IJS>invisibleRedirects</IJS> to <IJS>true</IJS>{" "}
+                in your client side code, your application probably doesn't know
                 how to render redirects.
               </p>
             </Note>

--- a/website/src/router.js
+++ b/website/src/router.js
@@ -18,7 +18,7 @@ const announce = ariaLiveSideEffect(
 const router = createRouter(browser, routes, {
   route: [active(), prefetch()],
   sideEffects: [setTitle, scrollTo, announce],
-  emitRedirects: false
+  invisibleRedirects: true
 });
 
 export default router;

--- a/website/src/routes/packages/index.js
+++ b/website/src/routes/packages/index.js
@@ -34,7 +34,7 @@ export default {
           return Promise.reject({
             type: UNKNOWN_VERSION,
             returns: {
-              redirectTo: {
+              redirect: {
                 name: "Package",
                 params: {
                   package: params.package,


### PR DESCRIPTION
Same behavior, but swapping defaults (`emitRedirects` defaulted to `true` while `invisibleRedirects` defaults to `false`).