### PR TITLE
Link components spread forward props before native props

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 3969,
-    "minified": 1713,
-    "gzipped": 832,
+    "bundled": 3977,
+    "minified": 1719,
+    "gzipped": 834,
     "treeshaked": {
       "rollup": {
-        "code": 827,
+        "code": 833,
         "import_statements": 129
       },
       "webpack": {
-        "code": 2729
+        "code": 2735
       }
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 4402,
-    "minified": 2057,
-    "gzipped": 949
+    "bundled": 4410,
+    "minified": 2063,
+    "gzipped": 952
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 11226,
-    "minified": 4194,
-    "gzipped": 1764
+    "bundled": 11234,
+    "minified": 4200,
+    "gzipped": 1765
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 11196,
-    "minified": 4164,
-    "gzipped": 1743
+    "bundled": 11204,
+    "minified": 4170,
+    "gzipped": 1746
   }
 }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Spread `forward` props to link elements before "native" props.
+
 ## 2.0.0-beta.6
 
 * Revert snake case. `create_router_component` is now `createRouterComponent`.

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -34,7 +34,7 @@ export const Link = React.forwardRef(
     const { anchor: Anchor = "a", forward, children } = props;
 
     return (
-      <Anchor onClick={eventHandler} href={href} ref={ref} {...forward}>
+      <Anchor {...forward} onClick={eventHandler} href={href} ref={ref}>
         {children}
       </Anchor>
     );
@@ -52,7 +52,7 @@ export const AsyncLink = React.forwardRef(
     const { anchor: Anchor = "a", forward, children } = props;
 
     return (
-      <Anchor onClick={eventHandler} href={href} ref={ref} {...forward}>
+      <Anchor {...forward} onClick={eventHandler} href={href} ref={ref}>
         {children(navigating)}
       </Anchor>
     );

--- a/packages/react-dom/tests/AsyncLink.spec.tsx
+++ b/packages/react-dom/tests/AsyncLink.spec.tsx
@@ -179,6 +179,20 @@ describe("<AsyncLink>", () => {
       const a = node.querySelector("a");
       expect(a.classList.contains("hi")).toBe(true);
     });
+
+    it('does not overwrite "native" props set on the rendered element', () => {
+      ReactDOM.render(
+        <Router>
+          <AsyncLink name="Test" forward={{ href: "/oh-no" }}>
+            {() => <p>Test</p>}
+          </AsyncLink>
+        </Router>,
+        node
+      );
+
+      const a = node.querySelector("a");
+      expect(a.getAttribute("href")).toBe("/");
+    });
   });
 
   describe("ref", () => {

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -177,6 +177,20 @@ describe("<Link>", () => {
       const a = node.querySelector("a");
       expect(a.classList.contains("hi")).toBe(true);
     });
+
+    it('does not overwrite "native" props set on the rendered element', () => {
+      ReactDOM.render(
+        <Router>
+          <Link name="Test" forward={{ href: "/oh-no" }}>
+            Test
+          </Link>
+        </Router>,
+        node
+      );
+
+      const a = node.querySelector("a");
+      expect(a.getAttribute("href")).toBe("/");
+    });
   });
 
   describe("ref", () => {

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 2307,
-    "minified": 977,
-    "gzipped": 469,
+    "bundled": 2315,
+    "minified": 983,
+    "gzipped": 471,
     "treeshaked": {
       "rollup": {
-        "code": 757,
+        "code": 763,
         "import_statements": 166
       },
       "webpack": {
-        "code": 1868
+        "code": 1874
       }
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 2726,
-    "minified": 1280,
-    "gzipped": 588
+    "bundled": 2734,
+    "minified": 1286,
+    "gzipped": 587
   }
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Spread `forward` props to link elements before "native" props.
+
 ## 2.0.0-beta.6
 
 * Revert snake case. `create_router_component` is now `createRouterComponent`.

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TouchableHighlight } from "react-native";
+import { TouchableHighlight, TouchableHighlightProps } from "react-native";
 import {
   useNavigationHandler,
   useStatefulNavigationHandler
@@ -13,7 +13,7 @@ import { NavType } from "@hickory/root";
 export interface BaseLinkProps extends RouteLocation {
   onNav?: (e: GestureResponderEvent) => void;
   anchor?: React.ReactType;
-  forward?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+  forward?: object;
   method?: NavType;
 }
 
@@ -39,7 +39,7 @@ export const Link = React.forwardRef(
     const { anchor: Anchor = TouchableHighlight, forward, children } = props;
 
     return (
-      <Anchor onPress={eventHandler} ref={ref} {...forward}>
+      <Anchor {...forward} onPress={eventHandler} ref={ref}>
         {children}
       </Anchor>
     );
@@ -55,7 +55,7 @@ export const AsyncLink = React.forwardRef(
     const { anchor: Anchor = TouchableHighlight, forward, children } = props;
 
     return (
-      <Anchor onPress={eventHandler} ref={ref} {...forward}>
+      <Anchor {...forward} onPress={eventHandler} ref={ref}>
         {children(navigating)}
       </Anchor>
     );

--- a/packages/react-native/tests/AsyncLink.spec.tsx
+++ b/packages/react-native/tests/AsyncLink.spec.tsx
@@ -225,6 +225,32 @@ describe("<AsyncLink>", () => {
       const anchor = tree.root.findByType(TouchableHighlight);
       expect(anchor.props.style).toMatchObject(style);
     });
+
+    it('does not overwrite "native" props set on the rendered element', () => {
+      const onPress = jest.fn();
+
+      const routes = prepareRoutes([
+        { name: "Test", path: "" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = createRouter(inMemory, routes, {
+        history: {
+          locations: ["/the-initial-location"]
+        }
+      });
+      const Router = createRouterComponent(router);
+
+      const tree = renderer.create(
+        <Router>
+          <AsyncLink name="Test" forward={{ onPress }}>
+            {navigating => <Text>{navigating}</Text>}
+          </AsyncLink>
+        </Router>
+      );
+
+      const anchor = tree.root.findByType(TouchableHighlight);
+      expect(anchor.props.onPress).not.toBe(onPress);
+    });
   });
 
   describe("ref", () => {

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -205,6 +205,32 @@ describe("<Link>", () => {
       const anchor = tree.root.findByType(TouchableHighlight);
       expect(anchor.props.style).toMatchObject(style);
     });
+
+    it('does not overwrite "native" props set on the rendered element', () => {
+      const onPress = jest.fn();
+
+      const routes = prepareRoutes([
+        { name: "Test", path: "" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = createRouter(inMemory, routes, {
+        history: {
+          locations: ["/the-initial-location"]
+        }
+      });
+      const Router = createRouterComponent(router);
+
+      const tree = renderer.create(
+        <Router>
+          <Link name="Test" forward={{ onPress }}>
+            <Text>Test</Text>
+          </Link>
+        </Router>
+      );
+
+      const anchor = tree.root.findByType(TouchableHighlight);
+      expect(anchor.props.onPress).not.toBe(onPress);
+    });
   });
 
   describe("ref", () => {

--- a/packages/react-native/types/Link.d.ts
+++ b/packages/react-native/types/Link.d.ts
@@ -6,7 +6,7 @@ import { NavType } from "@hickory/root";
 export interface BaseLinkProps extends RouteLocation {
     onNav?: (e: GestureResponderEvent) => void;
     anchor?: React.ReactType;
-    forward?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+    forward?: object;
     method?: NavType;
 }
 export interface LinkProps extends BaseLinkProps {

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Spread `forward` props to link elements before "native" props.
+
 ## 1.0.0-beta.20
 
 * Revert snake case. `curi_store` is now `curiStore`.

--- a/packages/svelte/src/Link.html
+++ b/packages/svelte/src/Link.html
@@ -1,4 +1,4 @@
-<a href="{href}" on:click="handleClick(event)" {...forward}>
+<a {...forward} href="{href}" on:click="handleClick(event)">
   {#if wrapper}
   <svelte:component this="{wrapper}" navigating="{navigating}">
     <slot></slot>

--- a/packages/svelte/tests/cases/link/forward-overwrite/app.html
+++ b/packages/svelte/tests/cases/link/forward-overwrite/app.html
@@ -4,6 +4,6 @@
   import Link from "../../../../src/Link.html";
 
   export default {
-    components: { Link: SvelteLink }
+    components: { Link }
   }
 </script>

--- a/packages/svelte/tests/cases/link/forward-overwrite/app.html
+++ b/packages/svelte/tests/cases/link/forward-overwrite/app.html
@@ -1,0 +1,9 @@
+<Link name="Home" forward={{ href: "/oh-no" }}>Home</Link>
+
+<script>
+  import Link from "../../../../src/Link.html";
+
+  export default {
+    components: { Link: SvelteLink }
+  }
+</script>

--- a/packages/svelte/tests/cases/link/forward-overwrite/index.js
+++ b/packages/svelte/tests/cases/link/forward-overwrite/index.js
@@ -1,0 +1,22 @@
+import { inMemory } from "@hickory/in-memory";
+import { createRouter, prepareRoutes } from "@curi/router";
+import { curiStore } from "@curi/svelte";
+
+import app from "./app.html";
+
+const routes = prepareRoutes([
+  { name: "Home", path: "" },
+  { name: "User", path: "u/:id" },
+  { name: "Not Found", path: "(.*)" }
+]);
+
+const router = createRouter(inMemory, routes);
+const store = curiStore(router);
+
+export default function render() {
+  const target = document.createElement("div");
+  new app({ target, store });
+
+  const a = target.querySelector("a");
+  expect(a.getAttribute("href")).toBe("/");
+}

--- a/packages/svelte/tests/cases/link/forward-props/app.html
+++ b/packages/svelte/tests/cases/link/forward-props/app.html
@@ -5,5 +5,5 @@
 
   export default {
     components: { Link }
-  }  
+  }
 </script>

--- a/packages/svelte/tests/link.spec.js
+++ b/packages/svelte/tests/link.spec.js
@@ -25,6 +25,10 @@ describe("<Link>", () => {
     it('forwards "forward" properties to the anchor', () => {
       test("./cases/link/forward-props");
     });
+
+    it('spreads "forward" before native props to avoid overwriting', () => {
+      test("./cases/link/forward-overwrite");
+    });
   });
 
   describe("wrapper prop", () => {


### PR DESCRIPTION
This change prevents the `forward` prop from taking precedence over props set by the components.