### PR TITLE
Use RTL-friendly hide for aria-live announcer

### DIFF
--- a/packages/side-effects/side-effect-aria-live/.size-snapshot.json
+++ b/packages/side-effects/side-effect-aria-live/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-side-effect-aria-live.es.js": {
-    "bundled": 446,
-    "minified": 300,
-    "gzipped": 220,
+    "bundled": 915,
+    "minified": 600,
+    "gzipped": 330,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-side-effect-aria-live.js": {
-    "bundled": 463,
-    "minified": 313,
-    "gzipped": 228
+    "bundled": 932,
+    "minified": 613,
+    "gzipped": 338
   },
   "dist/curi-side-effect-aria-live.umd.js": {
-    "bundled": 764,
-    "minified": 449,
-    "gzipped": 296
+    "bundled": 1257,
+    "minified": 749,
+    "gzipped": 410
   },
   "dist/curi-side-effect-aria-live.min.js": {
-    "bundled": 764,
-    "minified": 449,
-    "gzipped": 296
+    "bundled": 1257,
+    "minified": 749,
+    "gzipped": 410
   }
 }

--- a/packages/side-effects/side-effect-aria-live/CHANGELOG.md
+++ b/packages/side-effects/side-effect-aria-live/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Update CSS for hiding element to be RTL-friendly.
+
 ## 2.0.0-alpha.2
 
 * Import common Curi types from `@curi/types`.

--- a/packages/side-effects/side-effect-aria-live/src/index.ts
+++ b/packages/side-effects/side-effect-aria-live/src/index.ts
@@ -8,7 +8,12 @@ export default function createAriaLiveSideEffect(
 ): Observer {
   const announcer = document.createElement("div");
   announcer.setAttribute("aria-live", mode);
-  announcer.setAttribute("style", "position: absolute; left: -999em");
+  // https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+  announcer.setAttribute(
+    "style",
+    "position: absolute !important; height: 1px; " +
+      "width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);"
+  );
   document.body.appendChild(announcer);
 
   return function(emitted: Emitted): void {

--- a/packages/side-effects/side-effect-aria-live/src/index.ts
+++ b/packages/side-effects/side-effect-aria-live/src/index.ts
@@ -8,11 +8,21 @@ export default function createAriaLiveSideEffect(
 ): Observer {
   const announcer = document.createElement("div");
   announcer.setAttribute("aria-live", mode);
-  // https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+  // https://hugogiraudel.com/2016/10/13/css-hide-and-seek/
   announcer.setAttribute(
     "style",
-    "position: absolute !important; height: 1px; " +
-      "width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);"
+    [
+      "border: 0 !important;",
+      "clip: rect(1px, 1px, 1px, 1px) !important;",
+      "-webkit-clip-path: inset(50%) !important;",
+      "clip-path: inset(50%) !important;",
+      "height: 1px !important;",
+      "overflow: hidden !important;",
+      "padding: 0 !important;",
+      "position: absolute !important;",
+      "width: 1px !important;",
+      "white-space: nowrap !important;"
+    ].join(" ")
   );
   document.body.appendChild(announcer);
 


### PR DESCRIPTION
Use the hiding technique from https://hugogiraudel.com/2016/10/13/css-hide-and-seek/ for the `aria-live` element inserted by a `@curi/side-effect-aria-live` announcer.

Fixes #193.