### PR TITLE
Improve route matching

### DIFF
--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 17486,
-    "minified": 6870,
-    "gzipped": 2608,
+    "bundled": 16904,
+    "minified": 6793,
+    "gzipped": 2593,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17737,
-    "minified": 7076,
-    "gzipped": 2692
+    "bundled": 17155,
+    "minified": 6999,
+    "gzipped": 2675
   },
   "dist/curi-router.umd.js": {
-    "bundled": 29224,
-    "minified": 9433,
-    "gzipped": 3846
+    "bundled": 28614,
+    "minified": 9356,
+    "gzipped": 3827
   },
   "dist/curi-router.min.js": {
-    "bundled": 29174,
-    "minified": 9383,
-    "gzipped": 3827
+    "bundled": 28564,
+    "minified": 9306,
+    "gzipped": 3807
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Improve internal route matching.
+
 ## 2.0.0-beta.9
 
 * `prepareRoutes` returns an object with `match` and `interactions` properties.

--- a/packages/router/src/prepare/createRoute.ts
+++ b/packages/router/src/prepare/createRoute.ts
@@ -35,24 +35,18 @@ export function createRoute(
 
   const { match: matchOptions = {}, compile: compileOptions = {} } =
     props.pathOptions || {};
-  // end defaults to true, so end has to be hardcoded for it to be false
-  // set this before setting pathOptions.end for children
+  // end must be false for routes with children, but we want to track its original value
   const exact = matchOptions.end == null || matchOptions.end;
 
   let children: Array<PreparedRoute> = [];
   if (props.children && props.children.length) {
-    // when we have child routes, we need to perform non-end matching
     matchOptions.end = false;
-
     children = props.children.map((child: RouteDescriptor) => {
       return createRoute(child, usedNames, fullPath);
     });
   }
 
-  // keys is populated by PathToRegexp
   const keys: Array<Key> = [];
-  // path is compiled with a leading slash
-  // for optional initial params
   const re = PathToRegexp(withLeadingSlash(props.path), keys, matchOptions);
 
   const compiled = PathToRegexp.compile(fullPath);

--- a/packages/router/src/router/createRouter.ts
+++ b/packages/router/src/router/createRouter.ts
@@ -34,7 +34,6 @@ export default function createRouter<O = HistoryOptions>(
   routes: RouteMatcher,
   options: RouterOptions<O> = {}
 ): CuriRouter {
-  // the last finished response & navigation
   const mostRecent: CurrentResponse = {
     response: null,
     navigation: null
@@ -47,7 +46,6 @@ export default function createRouter<O = HistoryOptions>(
     };
 
     const matched = routes.match(pendingNav.location);
-    // if no routes match, do nothing
     if (!matched) {
       if (process.env.NODE_ENV !== "production") {
         console.warn(

--- a/packages/router/tests/path.spec.ts
+++ b/packages/router/tests/path.spec.ts
@@ -4,8 +4,8 @@ import { inMemory } from "@hickory/in-memory";
 import { createRouter, prepareRoutes } from "@curi/router";
 
 describe("route.pathOptions.match", () => {
-  describe("default options", () => {
-    it("sensitive = false", () => {
+  describe("sensitive", () => {
+    it("does case-insensitive matching when false (default)", () => {
       const routes = prepareRoutes({
         routes: [
           {
@@ -27,53 +27,7 @@ describe("route.pathOptions.match", () => {
       expect(response.name).toBe("Test");
     });
 
-    it("strict = false", () => {
-      const routes = prepareRoutes({
-        routes: [
-          {
-            name: "Test",
-            path: "here"
-          },
-          {
-            name: "Not Found",
-            path: "(.*)"
-          }
-        ]
-      });
-      const router = createRouter(inMemory, routes, {
-        history: {
-          locations: ["/here/"]
-        }
-      });
-      const { response } = router.current();
-      expect(response.name).toBe("Test");
-    });
-
-    it("end = true", () => {
-      const routes = prepareRoutes({
-        routes: [
-          {
-            name: "Test",
-            path: "here"
-          },
-          {
-            name: "Not Found",
-            path: "(.*)"
-          }
-        ]
-      });
-      const router = createRouter(inMemory, routes, {
-        history: {
-          locations: ["/here/again"]
-        }
-      });
-      const { response } = router.current();
-      expect(response.name).toBe("Not Found");
-    });
-  });
-
-  describe("user provided options", () => {
-    it("sensitive = true", () => {
+    it("does case sensitive matchign when true", () => {
       const routes = prepareRoutes({
         routes: [
           {
@@ -95,8 +49,32 @@ describe("route.pathOptions.match", () => {
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
     });
+  });
 
-    it("strict = true", () => {
+  describe("strict", () => {
+    it("will match a trailing delimiter when false", () => {
+      const routes = prepareRoutes({
+        routes: [
+          {
+            name: "Test",
+            path: "here"
+          },
+          {
+            name: "Not Found",
+            path: "(.*)"
+          }
+        ]
+      });
+      const router = createRouter(inMemory, routes, {
+        history: {
+          locations: ["/here/"]
+        }
+      });
+      const { response } = router.current();
+      expect(response.name).toBe("Test");
+    });
+
+    it("will not match a trailing delimiter when true", () => {
       const routes = prepareRoutes({
         routes: [
           {
@@ -118,8 +96,32 @@ describe("route.pathOptions.match", () => {
       const { response } = router.current();
       expect(response.name).toBe("Not Found");
     });
+  });
 
-    it("end = false", () => {
+  describe("end", () => {
+    it("does not match if there are segments after the path when true", () => {
+      const routes = prepareRoutes({
+        routes: [
+          {
+            name: "Test",
+            path: "here"
+          },
+          {
+            name: "Not Found",
+            path: "(.*)"
+          }
+        ]
+      });
+      const router = createRouter(inMemory, routes, {
+        history: {
+          locations: ["/here/again"]
+        }
+      });
+      const { response } = router.current();
+      expect(response.name).toBe("Not Found");
+    });
+
+    it("matches when there are segments after the path when false", () => {
       const routes = prepareRoutes({
         routes: [
           {
@@ -140,6 +142,125 @@ describe("route.pathOptions.match", () => {
       });
       const { response } = router.current();
       expect(response.name).toBe("Test");
+    });
+
+    describe("with children routes", () => {
+      it("matches if path matches exactly", () => {
+        const routes = prepareRoutes({
+          routes: [
+            {
+              name: "Test",
+              path: "test",
+              children: [
+                {
+                  name: "Ing",
+                  path: "ing"
+                }
+              ]
+            },
+            {
+              name: "Not Found",
+              path: "(.*)"
+            }
+          ]
+        });
+        const router = createRouter(inMemory, routes, {
+          history: {
+            locations: ["/test"]
+          }
+        });
+        const { response } = router.current();
+        expect(response.name).toBe("Test");
+      });
+
+      it("acts as if end is false in order to match children routes", () => {
+        const routes = prepareRoutes({
+          routes: [
+            {
+              name: "Test",
+              path: "test",
+              children: [
+                {
+                  name: "Ing",
+                  path: "ing"
+                }
+              ]
+            },
+            {
+              name: "Not Found",
+              path: "(.*)"
+            }
+          ]
+        });
+        const router = createRouter(inMemory, routes, {
+          history: {
+            locations: ["/test/ing"]
+          }
+        });
+        const { response } = router.current();
+        expect(response.name).toBe("Ing");
+      });
+
+      it("when end is true, path doesn't match exactly, and no children match, it does not match", () => {
+        const routes = prepareRoutes({
+          routes: [
+            {
+              name: "Test",
+              path: "test",
+              children: [
+                {
+                  name: "Ing",
+                  path: "ing"
+                }
+              ]
+            },
+            {
+              name: "Not Found",
+              path: "(.*)"
+            }
+          ]
+        });
+        const router = createRouter(inMemory, routes, {
+          history: {
+            locations: ["/test/ed"]
+          }
+        });
+        const { response } = router.current();
+        expect(response.name).toBe("Not Found");
+      });
+
+      it("when end is false, path doesn't match exactly, and no children match, it matches", () => {
+        const routes = prepareRoutes({
+          routes: [
+            {
+              name: "Test",
+              path: "test",
+              pathOptions: {
+                match: {
+                  end: false
+                }
+              },
+              children: [
+                {
+                  name: "Ing",
+                  path: "ing"
+                }
+              ]
+            },
+            {
+              name: "Not Found",
+              path: "(.*)"
+            }
+          ]
+        });
+        const router = createRouter(inMemory, routes, {
+          history: {
+            locations: ["/test/ed"]
+          }
+        });
+        const { response } = router.current();
+        expect(response.name).toBe("Test");
+      });
     });
   });
 });


### PR DESCRIPTION
The new path matching code should be easier to understand as well as faster. Param mapping is delayed until we know that it is necessary.

The path matching tests are also expanded to ensure that routes with children routes work correctly.