### PR TITLE
Add meta property to responses & always set body/data/meta

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -2,7 +2,7 @@
   "dist/curi-react-dom.es.js": {
     "bundled": 4056,
     "minified": 1778,
-    "gzipped": 849,
+    "gzipped": 848,
     "treeshaked": {
       "rollup": {
         "code": 892,
@@ -16,7 +16,7 @@
   "dist/curi-react-dom.js": {
     "bundled": 4489,
     "minified": 2122,
-    "gzipped": 964
+    "gzipped": 965
   },
   "dist/curi-react-dom.umd.js": {
     "bundled": 11183,

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 16904,
-    "minified": 6793,
-    "gzipped": 2593,
+    "bundled": 16790,
+    "minified": 6753,
+    "gzipped": 2572,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17155,
-    "minified": 6999,
-    "gzipped": 2675
+    "bundled": 17041,
+    "minified": 6959,
+    "gzipped": 2655
   },
   "dist/curi-router.umd.js": {
-    "bundled": 28614,
-    "minified": 9356,
-    "gzipped": 3827
+    "bundled": 28490,
+    "minified": 9316,
+    "gzipped": 3806
   },
   "dist/curi-router.min.js": {
-    "bundled": 28564,
-    "minified": 9306,
-    "gzipped": 3807
+    "bundled": 28440,
+    "minified": 9266,
+    "gzipped": 3786
   }
 }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 16790,
-    "minified": 6753,
-    "gzipped": 2572,
+    "bundled": 16813,
+    "minified": 6685,
+    "gzipped": 2566,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17041,
-    "minified": 6959,
-    "gzipped": 2655
+    "bundled": 17064,
+    "minified": 6891,
+    "gzipped": 2652
   },
   "dist/curi-router.umd.js": {
-    "bundled": 28490,
-    "minified": 9316,
-    "gzipped": 3806
+    "bundled": 28507,
+    "minified": 9363,
+    "gzipped": 3822
   },
   "dist/curi-router.min.js": {
-    "bundled": 28440,
-    "minified": 9266,
-    "gzipped": 3786
+    "bundled": 28457,
+    "minified": 9313,
+    "gzipped": 3804
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Add `meta` property to response/settable response properties.
+* Remove `title`, `status`, and `error` types from response/settable response properties.
 * Add and export `RouterOptions` type.
 
 ## 2.0.0-beta.11

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* `meta`, `body`, and `data` properties always exist on response objects. They are `undefined` if not set by a route's `response()` function.
 * Add `meta` property to response/settable response properties.
 * Remove `title`, `status`, and `error` types from response/settable response properties.
 * Add and export `RouterOptions` type.

--- a/packages/router/src/router/finishResponse.ts
+++ b/packages/router/src/router/finishResponse.ts
@@ -69,11 +69,9 @@ export default function finishResponse(
 const validProperties: {
   [key in keyof SettableResponseProperties]: boolean
 } = {
-  status: true,
-  error: true,
+  meta: true,
   body: true,
   data: true,
-  title: true,
   redirect: true
 };
 

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -1678,7 +1678,6 @@ describe("curi", () => {
             path: "",
             response: () => {
               return {
-                status: 301,
                 redirect: {
                   name: "B Route"
                 }

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -842,7 +842,7 @@ describe("routes", () => {
           });
         });
 
-        describe("status", () => {
+        describe("meta", () => {
           it("is undefined if not set by route.response()", () => {
             const routes = prepareRoutes({
               routes: [
@@ -862,10 +862,10 @@ describe("routes", () => {
               }
             });
             const { response } = router.current();
-            expect(response.status).toBeUndefined();
+            expect(response.meta).toBeUndefined();
           });
 
-          it("is the status value of object returned by route.response()", () => {
+          it("is the meta value of object returned by route.response()", () => {
             const routes = prepareRoutes({
               routes: [
                 {
@@ -873,7 +873,10 @@ describe("routes", () => {
                   path: "",
                   response: () => {
                     return {
-                      status: 451
+                      meta: {
+                        title: "A Route",
+                        status: 451
+                      }
                     };
                   }
                 }
@@ -885,7 +888,10 @@ describe("routes", () => {
               }
             });
             const { response } = router.current();
-            expect(response.status).toBe(451);
+            expect(response.meta).toMatchObject({
+              title: "A Route",
+              status: 451
+            });
           });
         });
 
@@ -931,51 +937,6 @@ describe("routes", () => {
             });
             const { response } = router.current();
             expect(response.data).toMatchObject({ test: "value" });
-          });
-        });
-
-        describe("title", () => {
-          it("is undefined if not set by route.response()", () => {
-            const routes = prepareRoutes({
-              routes: [
-                {
-                  name: "State",
-                  path: ":state"
-                }
-              ]
-            });
-            const router = createRouter(inMemory, routes, {
-              history: {
-                locations: ["/AZ"]
-              }
-            });
-
-            const { response } = router.current();
-            expect(response.title).toBeUndefined();
-          });
-
-          it("is the title value of the object returned by route.response()", () => {
-            const routes = prepareRoutes({
-              routes: [
-                {
-                  name: "State",
-                  path: ":state",
-                  response: () => {
-                    return {
-                      title: "A State"
-                    };
-                  }
-                }
-              ]
-            });
-            const router = createRouter(inMemory, routes, {
-              history: {
-                locations: ["/VA"]
-              }
-            });
-
-            const { response } = router.current();
-            expect(response.title).toBe("A State");
           });
         });
 
@@ -1171,44 +1132,6 @@ describe("routes", () => {
           });
         });
 
-        describe("error", () => {
-          it("is undefined for good responses", () => {
-            const routes = prepareRoutes({
-              routes: [{ name: "Contact", path: "contact" }]
-            });
-            const router = createRouter(inMemory, routes, {
-              history: {
-                locations: ["/contact"]
-              }
-            });
-            const { response } = router.current();
-            expect(response.error).toBeUndefined();
-          });
-
-          it("is the error value on the object returned by route.response()", () => {
-            const routes = prepareRoutes({
-              routes: [
-                {
-                  name: "A Route",
-                  path: "",
-                  response: () => {
-                    return {
-                      error: "woops"
-                    };
-                  }
-                }
-              ]
-            });
-            const router = createRouter(inMemory, routes, {
-              history: {
-                locations: ["/"]
-              }
-            });
-            const { response } = router.current();
-            expect(response.error).toBe("woops");
-          });
-        });
-
         describe("redirect", () => {
           it("contains the expected properties", () => {
             const routes = prepareRoutes({
@@ -1329,7 +1252,7 @@ describe("routes", () => {
                   response: () => {
                     return {
                       body: "body",
-                      status: undefined
+                      meta: undefined
                     };
                   }
                 }
@@ -1339,7 +1262,7 @@ describe("routes", () => {
             const { response } = router.current();
             expect(response.name).toBe("A Route");
             expect(response.hasOwnProperty("body")).toBe(true);
-            expect(response.hasOwnProperty("status")).toBe(false);
+            expect(response.hasOwnProperty("meta")).toBe(false);
           });
         });
 

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -799,7 +799,7 @@ describe("routes", () => {
         });
 
         describe("body", () => {
-          it("is undefined if not set by route.response()", () => {
+          it("exists on response as undefined if not set by route.response()", () => {
             const routes = prepareRoutes({
               routes: [
                 {
@@ -814,6 +814,7 @@ describe("routes", () => {
               }
             });
             const { response } = router.current();
+            expect(response.hasOwnProperty("body")).toBe(true);
             expect(response.body).toBeUndefined();
           });
 
@@ -843,7 +844,7 @@ describe("routes", () => {
         });
 
         describe("meta", () => {
-          it("is undefined if not set by route.response()", () => {
+          it("exists on the response as undefined if not set by route.response()", () => {
             const routes = prepareRoutes({
               routes: [
                 {
@@ -862,6 +863,7 @@ describe("routes", () => {
               }
             });
             const { response } = router.current();
+            expect(response.hasOwnProperty("meta")).toBe(true);
             expect(response.meta).toBeUndefined();
           });
 
@@ -896,7 +898,7 @@ describe("routes", () => {
         });
 
         describe("data", () => {
-          it("is undefined if not set by route.response()", () => {
+          it("exists on response as undefined if not set by route.response()", () => {
             const routes = prepareRoutes({
               routes: [
                 {
@@ -911,6 +913,7 @@ describe("routes", () => {
               }
             });
             const { response } = router.current();
+            expect(response.hasOwnProperty("data")).toBe(true);
             expect(response.data).toBeUndefined();
           });
 
@@ -1243,7 +1246,7 @@ describe("routes", () => {
         });
 
         describe("[undefined properties]", () => {
-          it("doesn't merge properties whose values is undefined", () => {
+          it("are set to undefined on the response", () => {
             const routes = prepareRoutes({
               routes: [
                 {
@@ -1262,7 +1265,8 @@ describe("routes", () => {
             const { response } = router.current();
             expect(response.name).toBe("A Route");
             expect(response.hasOwnProperty("body")).toBe(true);
-            expect(response.hasOwnProperty("meta")).toBe(false);
+            expect(response.hasOwnProperty("meta")).toBe(true);
+            expect(response.meta).toBeUndefined();
           });
         });
 

--- a/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
+++ b/packages/side-effects/side-effect-title/tests/createTitleSideEffect.spec.ts
@@ -5,12 +5,12 @@ import createTitleSideEffect from "@curi/side-effect-title";
 
 describe("createTitleSideEffect", () => {
   const fakeResponse = {
-    response: { title: "Test Title; Please Ignore" }
+    response: { meta: { title: "Test Title; Please Ignore" } }
   } as Emitted;
 
   it("sets document.title to value returned by provided callback", () => {
     const sideEffect = createTitleSideEffect(({ response }) => {
-      return `My Site | ${response.title}`;
+      return `My Site | ${response.meta.title}`;
     });
     sideEffect(fakeResponse);
     expect(document.title).toBe("My Site | Test Title; Please Ignore");

--- a/packages/static/.size-snapshot.json
+++ b/packages/static/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "dist/curi-static.js": {
-    "bundled": 7260,
-    "minified": 2976,
-    "gzipped": 1421
+    "bundled": 7234,
+    "minified": 2958,
+    "gzipped": 1416
   }
 }

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Add `meta` property to response/settable response properties.
+* Remove `title`, `status`, and `error` types from response/settable response properties.
 * Remove `() => void` wrapper types.
 * Remove `RouterOptions` type.
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -96,11 +96,9 @@ export interface ExternalRedirect {
 
 // full interface of response properties
 export interface Response extends IntrinsicResponse {
-  status?: number;
-  error?: any;
+  meta?: any;
   body?: any;
   data?: any;
-  title?: string;
   redirect?: RedirectLocation | ExternalRedirect;
 }
 
@@ -169,11 +167,9 @@ export interface RedirectProps extends RouteLocation {
 }
 
 export interface SettableResponseProperties {
-  status?: number;
-  error?: any;
+  meta?: any;
   body?: any;
   data?: any;
-  title?: string;
   redirect?: RedirectProps | ExternalRedirect;
 }
 

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -62,11 +62,9 @@ export interface ExternalRedirect {
     externalURL: string;
 }
 export interface Response extends IntrinsicResponse {
-    status?: number;
-    error?: any;
+    meta?: any;
     body?: any;
     data?: any;
-    title?: string;
     redirect?: RedirectLocation | ExternalRedirect;
 }
 export interface RouteDescriptor {
@@ -119,11 +117,9 @@ export interface RedirectProps extends RouteLocation {
     name: string;
 }
 export interface SettableResponseProperties {
-    status?: number;
-    error?: any;
+    meta?: any;
     body?: any;
     data?: any;
-    title?: string;
     redirect?: RedirectProps | ExternalRedirect;
 }
 export interface ResolveResults {


### PR DESCRIPTION
This PR removes the `title`, `status`, and `error` properties from a response and adds a `meta` property.

The `meta` property is intended for non-rendered data, whereas the `data` property is intended for content that will be rendered by the application. This isn't a hard and fast rule, but a means of organizing information.

For example, a page's `title` and `status` would probably be put in a `meta` object. Additional properties, like a page's description (for use with `<meta name="Description">` for server-side/static-content rendering) would also be put on the `meta`.

Data loaded from a database would be put on the `data` object.

The `error` could either be put on the `data` or the `meta` depending on what you plan to do with it. If it will be rendered within the application as an error message, it makes sense to add it to the `data`. If it will be logged during a server render but otherwise ignored, it may make more sense to add it to the `meta`.

Additionally, response objects now always include `meta`, `body`, and `data` properties. If the route has no `response` function or if these values are not included in the `response` function's return object, they will be `undefined`.