### PR TITLE
Rename route.response to route.respond

### DIFF
--- a/packages/react-dom/tests/useNavigationFocus.spec.tsx
+++ b/packages/react-dom/tests/useNavigationFocus.spec.tsx
@@ -196,14 +196,14 @@ describe("useNavigationFocus", () => {
             {
               name: "Home",
               path: "",
-              response() {
+              respond() {
                 return { body: Home };
               }
             },
             {
               name: "About",
               path: "about",
-              response() {
+              respond() {
                 return { body: About };
               }
             }
@@ -262,14 +262,14 @@ describe("useNavigationFocus", () => {
             {
               name: "Home",
               path: "",
-              response() {
+              respond() {
                 return { body: Home };
               }
             },
             {
               name: "About",
               path: "about",
-              response() {
+              respond() {
                 return { body: About };
               }
             }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 16813,
-    "minified": 6685,
-    "gzipped": 2566,
+    "bundled": 16809,
+    "minified": 6681,
+    "gzipped": 2569,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17064,
-    "minified": 6891,
-    "gzipped": 2652
+    "bundled": 17060,
+    "minified": 6887,
+    "gzipped": 2655
   },
   "dist/curi-router.umd.js": {
-    "bundled": 28507,
-    "minified": 9363,
-    "gzipped": 3822
+    "bundled": 28503,
+    "minified": 9359,
+    "gzipped": 3823
   },
   "dist/curi-router.min.js": {
-    "bundled": 28457,
-    "minified": 9313,
-    "gzipped": 3804
+    "bundled": 28453,
+    "minified": 9309,
+    "gzipped": 3805
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Rename `route.response` to `route.respond`.
 * `meta`, `body`, and `data` properties always exist on response objects. They are `undefined` if not set by a route's `response()` function.
 * Add `meta` property to response/settable response properties.
 * Remove `title`, `status`, and `error` types from response/settable response properties.

--- a/packages/router/src/prepare/createRoute.ts
+++ b/packages/router/src/prepare/createRoute.ts
@@ -57,7 +57,7 @@ export function createRoute(
       path: props.path,
       keys: keys.map(key => key.name),
       resolve: props.resolve,
-      response: props.response,
+      respond: props.respond,
       extra: props.extra,
       pathname(params?: Params) {
         return compiled(params, compileOptions);

--- a/packages/router/src/router/finishResponse.ts
+++ b/packages/router/src/router/finishResponse.ts
@@ -32,11 +32,11 @@ export default function finishResponse(
     response[key as keyof Response] = match[key as keyof IntrinsicResponse];
   }
 
-  if (!route.response) {
+  if (!route.respond) {
     return response;
   }
 
-  const responseModifiers = route.response({
+  const responseModifiers = route.respond({
     resolved,
     error,
     match,

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -111,7 +111,7 @@ describe("curi", () => {
               {
                 name: "Start",
                 path: "",
-                response: () => {
+                respond: () => {
                   return {
                     redirect: {
                       name: "Other"
@@ -144,7 +144,7 @@ describe("curi", () => {
               {
                 name: "Start",
                 path: "",
-                response: () => {
+                respond: () => {
                   return {
                     redirect: {
                       name: "Other"
@@ -175,7 +175,7 @@ describe("curi", () => {
               {
                 name: "Start",
                 path: "",
-                response: () => {
+                respond: () => {
                   return {
                     redirect: {
                       externalURL: "https://example.com"
@@ -237,7 +237,7 @@ describe("curi", () => {
               {
                 name: "Start",
                 path: "",
-                response({ external: e }) {
+                respond({ external: e }) {
                   expect(e).toBe(external);
                   return {};
                 }
@@ -1676,7 +1676,7 @@ describe("curi", () => {
           {
             name: "A Route",
             path: "",
-            response: () => {
+            respond: () => {
               return {
                 redirect: {
                   name: "B Route"

--- a/packages/router/tests/route.spec.ts
+++ b/packages/router/tests/route.spec.ts
@@ -799,7 +799,7 @@ describe("routes", () => {
         });
 
         describe("body", () => {
-          it("exists on response as undefined if not set by route.response()", () => {
+          it("exists on response as undefined if not set by route.respond()", () => {
             const routes = prepareRoutes({
               routes: [
                 {
@@ -818,14 +818,14 @@ describe("routes", () => {
             expect(response.body).toBeUndefined();
           });
 
-          it("is the body value of the object returned by route.response()", () => {
+          it("is the body value of the object returned by route.respond()", () => {
             const body = () => "anybody out there?";
             const routes = prepareRoutes({
               routes: [
                 {
                   name: "Test",
                   path: "test",
-                  response: () => {
+                  respond: () => {
                     return {
                       body: body
                     };
@@ -844,7 +844,7 @@ describe("routes", () => {
         });
 
         describe("meta", () => {
-          it("exists on the response as undefined if not set by route.response()", () => {
+          it("exists on the response as undefined if not set by route.respond()", () => {
             const routes = prepareRoutes({
               routes: [
                 {
@@ -867,13 +867,13 @@ describe("routes", () => {
             expect(response.meta).toBeUndefined();
           });
 
-          it("is the meta value of object returned by route.response()", () => {
+          it("is the meta value of object returned by route.respond()", () => {
             const routes = prepareRoutes({
               routes: [
                 {
                   name: "A Route",
                   path: "",
-                  response: () => {
+                  respond: () => {
                     return {
                       meta: {
                         title: "A Route",
@@ -898,7 +898,7 @@ describe("routes", () => {
         });
 
         describe("data", () => {
-          it("exists on response as undefined if not set by route.response()", () => {
+          it("exists on response as undefined if not set by route.respond()", () => {
             const routes = prepareRoutes({
               routes: [
                 {
@@ -917,13 +917,13 @@ describe("routes", () => {
             expect(response.data).toBeUndefined();
           });
 
-          it("is the data value of the object returned by route.response()", () => {
+          it("is the data value of the object returned by route.respond()", () => {
             const routes = prepareRoutes({
               routes: [
                 {
                   name: "A Route",
                   path: "",
-                  response: () => {
+                  respond: () => {
                     return {
                       data: {
                         test: "value"
@@ -1142,7 +1142,7 @@ describe("routes", () => {
                 {
                   name: "A Route",
                   path: "",
-                  response: () => {
+                  respond: () => {
                     return {
                       redirect: {
                         name: "B Route",
@@ -1190,7 +1190,7 @@ describe("routes", () => {
                 {
                   name: "A Route",
                   path: "",
-                  response: () => {
+                  respond: () => {
                     return {
                       redirect: {
                         externalURL: "https://example.com"
@@ -1222,7 +1222,7 @@ describe("routes", () => {
                   name: "Contact",
                   path: "contact",
                   // @ts-ignore
-                  response() {
+                  respond() {
                     return {
                       bad: "property"
                     };
@@ -1252,7 +1252,7 @@ describe("routes", () => {
                 {
                   name: "A Route",
                   path: "",
-                  response: () => {
+                  respond: () => {
                     return {
                       body: "body",
                       meta: undefined
@@ -1281,7 +1281,7 @@ describe("routes", () => {
                   name: "A Route",
                   path: "",
                   // @ts-ignore
-                  response: () => {}
+                  respond: () => {}
                 }
               ]
             });
@@ -1357,7 +1357,7 @@ describe("routes", () => {
         });
       });
 
-      describe("response", () => {
+      describe("respond", () => {
         it("is not called if the navigation has been cancelled", done => {
           const responseSpy = jest.fn();
           let firstHasResolved = false;
@@ -1376,12 +1376,12 @@ describe("routes", () => {
                 name: "First",
                 path: "first",
                 resolve: spy,
-                response: responseSpy
+                respond: responseSpy
               },
               {
                 name: "Second",
                 path: "second",
-                response: () => {
+                respond: () => {
                   expect(firstHasResolved).toBe(true);
                   expect(spy.mock.calls.length).toBe(2);
                   expect(responseSpy.mock.calls.length).toBe(0);
@@ -1410,7 +1410,7 @@ describe("routes", () => {
                 {
                   name: "Catch All",
                   path: ":anything",
-                  response: ({ resolved }) => {
+                  respond: ({ resolved }) => {
                     expect(resolved).toBe(null);
                     return {};
                   }
@@ -1433,7 +1433,7 @@ describe("routes", () => {
                   resolve() {
                     return Promise.reject("woops!");
                   },
-                  response: ({ resolved }) => {
+                  respond: ({ resolved }) => {
                     expect(resolved).toBe(null);
                     return {};
                   }
@@ -1453,7 +1453,7 @@ describe("routes", () => {
                 {
                   name: "Catch All",
                   path: ":anything",
-                  response: ({ resolved }) => {
+                  respond: ({ resolved }) => {
                     expect(resolved.test).toBe(1);
                     expect(resolved.yo).toBe("yo!");
                     return {};
@@ -1485,7 +1485,7 @@ describe("routes", () => {
                 {
                   name: "Catch All",
                   path: ":anything",
-                  response: spy,
+                  respond: spy,
                   resolve() {
                     return Promise.reject("rejected");
                   }
@@ -1511,7 +1511,7 @@ describe("routes", () => {
                 {
                   name: "Catch All",
                   path: ":anything",
-                  response: spy,
+                  respond: spy,
                   resolve() {
                     return Promise.resolve("hurray!");
                   }
@@ -1533,7 +1533,7 @@ describe("routes", () => {
                 {
                   name: "Catch All",
                   path: ":anything",
-                  response: props => {
+                  respond: props => {
                     expect(props.match).toMatchObject({
                       name: "Catch All",
                       params: { anything: "hello" },
@@ -1571,7 +1571,7 @@ describe("routes", () => {
             {
               name: "Redirects",
               path: "redirects",
-              response: () => {
+              respond: () => {
                 return {
                   redirect: {
                     name: "Other"
@@ -1610,7 +1610,7 @@ describe("routes", () => {
             {
               name: "Redirects",
               path: "redirects",
-              response: () => {
+              respond: () => {
                 return {
                   redirect: {
                     externalURL: "https://example.com"

--- a/packages/static/tests/staticFiles.spec.ts
+++ b/packages/static/tests/staticFiles.spec.ts
@@ -26,14 +26,14 @@ describe("staticFiles()", () => {
           {
             name: "Home",
             path: "",
-            response() {
+            respond() {
               return { body: "Home" };
             }
           },
           {
             name: "About",
             path: "about",
-            response() {
+            respond() {
               return { body: "About" };
             }
           }
@@ -70,21 +70,21 @@ describe("staticFiles()", () => {
             {
               name: "Home",
               path: "",
-              response() {
+              respond() {
                 return { body: "Home" };
               }
             },
             {
               name: "About",
               path: "about",
-              response() {
+              respond() {
                 return { body: "About" };
               }
             },
             {
               name: "Catch All",
               path: "(.*)",
-              response() {
+              respond() {
                 return { body: "404" };
               }
             }
@@ -135,14 +135,14 @@ describe("staticFiles()", () => {
           {
             name: "Home",
             path: "",
-            response() {
+            respond() {
               return { redirect: { name: "About" } };
             }
           },
           {
             name: "About",
             path: "about",
-            response() {
+            respond() {
               return { body: "About" };
             }
           }
@@ -189,7 +189,7 @@ describe("staticFiles()", () => {
           {
             name: "Home",
             path: "",
-            response() {
+            respond() {
               return {
                 body: "Home",
                 redirect: { name: "About" }
@@ -199,7 +199,7 @@ describe("staticFiles()", () => {
           {
             name: "About",
             path: "about",
-            response() {
+            respond() {
               return { body: "About" };
             }
           }
@@ -237,7 +237,7 @@ describe("staticFiles()", () => {
           {
             name: "Home",
             path: "",
-            response() {
+            respond() {
               return { body: "Home" };
             }
           }
@@ -278,7 +278,7 @@ describe("staticFiles()", () => {
           {
             name: "Home",
             path: "",
-            response({ external }) {
+            respond({ external }) {
               expect(external).toBe(providedExternal);
               return { body: "Home" };
             }
@@ -316,7 +316,7 @@ describe("staticFiles()", () => {
           {
             name: "Home",
             path: "",
-            response() {
+            respond() {
               return { body: "Home" };
             }
           }
@@ -365,7 +365,7 @@ describe("staticFiles()", () => {
               resolve() {
                 return Promise.resolve(true);
               },
-              response() {
+              respond() {
                 return { body: "Home" };
               }
             }

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Rename `route.response` to `route.respond`.
 * Add `meta` property to response/settable response properties.
 * Remove `title`, `status`, and `error` types from response/settable response properties.
 * Remove `() => void` wrapper types.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -112,7 +112,7 @@ export interface RouteDescriptor {
   };
   params?: ParamParsers;
   children?: Array<RouteDescriptor>;
-  response?: ResponseFn;
+  respond?: RespondFn;
   resolve?: Resolver;
   extra?: { [key: string]: any };
 }
@@ -124,7 +124,7 @@ export interface Route<R = unknown> {
   keys: Array<string | number>;
   pathname: PathFunction;
   resolve: R;
-  response?: ResponseFn;
+  respond?: RespondFn;
   extra?: {
     [key: string]: any;
   };
@@ -148,13 +148,13 @@ export interface RouteMatcher {
   interactions: Interactions;
 }
 
-// a route's response function is used to return properties to add
+// a route's respond function is used to return properties to add
 // to the intrinsic response properites
-export type ResponseFn = (
+export type RespondFn = (
   props: Readonly<ResponseBuilder>
 ) => SettableResponseProperties;
 
-// the properties that will be passed to a route's response function
+// the properties that will be passed to a route's respond function
 export interface ResponseBuilder {
   resolved: any;
   error: any;

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -76,7 +76,7 @@ export interface RouteDescriptor {
     };
     params?: ParamParsers;
     children?: Array<RouteDescriptor>;
-    response?: ResponseFn;
+    respond?: RespondFn;
     resolve?: Resolver;
     extra?: {
         [key: string]: any;
@@ -88,7 +88,7 @@ export interface Route<R = unknown> {
     keys: Array<string | number>;
     pathname: PathFunction;
     resolve: R;
-    response?: ResponseFn;
+    respond?: RespondFn;
     extra?: {
         [key: string]: any;
     };
@@ -106,7 +106,7 @@ export interface RouteMatcher {
     match(l: SessionLocation): Match | undefined;
     interactions: Interactions;
 }
-export declare type ResponseFn = (props: Readonly<ResponseBuilder>) => SettableResponseProperties;
+export declare type RespondFn = (props: Readonly<ResponseBuilder>) => SettableResponseProperties;
 export interface ResponseBuilder {
     resolved: any;
     error: any;


### PR DESCRIPTION
This gets rid of the confusing `response` function and `response` object wording. `respond` is also an action verb, like `resolve`, which describes what the function does.

```js
// before
{
  name: "Home",
  path: "",
  response() {
    return { body: Home };
  }
}

// after
{
  name: "Home",
  path: "",
  respond() {
    return { body: Home };
  }
}
```