### PR TITLE
Fix UMD builds

### DIFF
--- a/packages/helpers/rollup.config.js
+++ b/packages/helpers/rollup.config.js
@@ -41,6 +41,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/interactions/route-ancestors/rollup.config.js
+++ b/packages/interactions/route-ancestors/rollup.config.js
@@ -47,6 +47,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/interactions/route-prefetch/rollup.config.js
+++ b/packages/interactions/route-prefetch/rollup.config.js
@@ -47,6 +47,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 965
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 11183,
-    "minified": 3923,
-    "gzipped": 1582
+    "bundled": 11097,
+    "minified": 3847,
+    "gzipped": 1549
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 11163,
-    "minified": 3903,
-    "gzipped": 1565
+    "bundled": 10578,
+    "minified": 3521,
+    "gzipped": 1372
   }
 }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Fix UMD builds.
+
 ## 2.0.0-beta.7
 
 * Spread `forward` props to link elements before "native" props.

--- a/packages/react-dom/rollup.config.js
+++ b/packages/react-dom/rollup.config.js
@@ -52,6 +52,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/react-universal/rollup.config.js
+++ b/packages/react-universal/rollup.config.js
@@ -52,6 +52,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 2655
   },
   "dist/curi-router.umd.js": {
-    "bundled": 28503,
-    "minified": 9359,
-    "gzipped": 3823
+    "bundled": 28288,
+    "minified": 9170,
+    "gzipped": 3781
   },
   "dist/curi-router.min.js": {
-    "bundled": 28453,
-    "minified": 9309,
-    "gzipped": 3805
+    "bundled": 26688,
+    "minified": 8275,
+    "gzipped": 3362
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Fix UMD builds.
 * Rename `route.response` to `route.respond`.
 * `meta`, `body`, and `data` properties always exist on response objects. They are `undefined` if not set by a route's `response()` function.
 * Add `meta` property to response/settable response properties.

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -47,6 +47,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/side-effects/side-effect-aria-live/rollup.config.js
+++ b/packages/side-effects/side-effect-aria-live/rollup.config.js
@@ -47,6 +47,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/side-effects/side-effect-scroll/rollup.config.js
+++ b/packages/side-effects/side-effect-scroll/rollup.config.js
@@ -47,6 +47,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/side-effects/side-effect-title/rollup.config.js
+++ b/packages/side-effects/side-effect-title/rollup.config.js
@@ -47,6 +47,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/vue/.size-snapshot.json
+++ b/packages/vue/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 1049
   },
   "dist/curi-vue.umd.js": {
-    "bundled": 4944,
-    "minified": 2284,
-    "gzipped": 1087
+    "bundled": 4901,
+    "minified": 2245,
+    "gzipped": 1058
   },
   "dist/curi-vue.min.js": {
-    "bundled": 4934,
-    "minified": 2274,
-    "gzipped": 1071
+    "bundled": 4500,
+    "minified": 1990,
+    "gzipped": 915
   }
 }

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Fix UMD builds.
+
 ## 2.0.0-alpha.0
 
 * Bump to `v2` alpha since it uses `@curi/router` v2.

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -52,6 +52,7 @@ module.exports = [
     plugins: [
       plugins.typescript,
       plugins.replacePure,
+      plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/utils/rollup-plugins.js
+++ b/utils/rollup-plugins.js
@@ -12,7 +12,10 @@ exports.replacePure = replace({
   delimiters: ["", ""]
 });
 exports.replaceWithProduction = replace({
-  "process.env.NODE_ENV": "production"
+  "process.env.NODE_ENV": `"production"`
+});
+exports.replaceWithDevelopment = replace({
+  "process.env.NODE_ENV": `"development"`
 });
 
 exports.resolveNode = resolve();


### PR DESCRIPTION
For minified UMD builds, properly escape `"production"` so that the code is actually removed.

For non-minified UMD builds, replace `process.env.NODE_ENV` with `"development"`.