### PR TITLE
useResponse() only returns response and navigation

### DIFF
--- a/examples/react/breadcrumbs/src/components/App.js
+++ b/examples/react/breadcrumbs/src/components/App.js
@@ -2,12 +2,12 @@ import React from "react";
 import { useResponse } from "@curi/react-dom";
 
 export default function App() {
-  const { response, router } = useResponse();
+  const { response } = useResponse();
 
   const { body: Body } = response;
   return (
     <div>
-      <Body response={response} router={router} />
+      <Body response={response} />
     </div>
   );
 }

--- a/examples/react/breadcrumbs/src/components/Category.js
+++ b/examples/react/breadcrumbs/src/components/Category.js
@@ -1,25 +1,28 @@
 import React from "react";
-import { Link } from "@curi/react-dom";
+import { Link, useRouter } from "@curi/react-dom";
 import Breadcrumbs from "./Breadcrumbs";
 
-const Category = ({ router, response: { params, data: products } }) => (
-  <div>
-    <Breadcrumbs name="Category" params={params} />
-    <h1>{params.category}</h1>
-    <p>List of products</p>
-    <ul>
-      {products.map(p => {
-        const productParams = { ...params, productID: p.id };
-        return (
-          <li key={p.id}>
-            <Link name="Product" params={productParams}>
-              {router.route.title("Product", { name: p.name })}
-            </Link>
-          </li>
-        );
-      })}
-    </ul>
-  </div>
-);
+function Category({ response: { params, data: products } }) {
+  const router = useRouter();
+  return (
+    <div>
+      <Breadcrumbs name="Category" params={params} />
+      <h1>{params.category}</h1>
+      <p>List of products</p>
+      <ul>
+        {products.map(p => {
+          const productParams = { ...params, productID: p.id };
+          return (
+            <li key={p.id}>
+              <Link name="Product" params={productParams}>
+                {router.route.title("Product", { name: p.name })}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
 
 export default Category;

--- a/examples/react/breadcrumbs/src/components/Products.js
+++ b/examples/react/breadcrumbs/src/components/Products.js
@@ -1,20 +1,23 @@
 import React from "react";
-import { Link } from "@curi/react-dom";
+import { Link, useRouter } from "@curi/react-dom";
 
-const Products = ({ response: { data }, router }) => (
-  <div>
-    <h1>Products Page</h1>
-    <h2>Categories</h2>
-    <ul>
-      {data.map(category => (
-        <li key={category}>
-          <Link name="Category" params={{ category }}>
-            {router.route.title("Category", { category })}
-          </Link>
-        </li>
-      ))}
-    </ul>
-  </div>
-);
+function Products({ response: { data } }) {
+  const router = useRouter();
+  return (
+    <div>
+      <h1>Products Page</h1>
+      <h2>Categories</h2>
+      <ul>
+        {data.map(category => (
+          <li key={category}>
+            <Link name="Category" params={{ category }}>
+              {router.route.title("Category", { category })}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 export default Products;

--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -19,13 +19,13 @@
     "gzipped": 965
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 11097,
-    "minified": 3847,
-    "gzipped": 1549
+    "bundled": 10989,
+    "minified": 3814,
+    "gzipped": 1534
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 10578,
-    "minified": 3521,
-    "gzipped": 1372
+    "bundled": 10470,
+    "minified": 3488,
+    "gzipped": 1359
   }
 }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `useResponse` only returns `response` and `navigation`.
+
 ## 2.0.0-beta.9
 
 * Fix UMD builds.

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `useResponse` only returns `response` and `navigation`.
+
 ## 2.0.0-beta.7
 
 * Spread `forward` props to link elements before "native" props.

--- a/packages/react-universal/.size-snapshot.json
+++ b/packages/react-universal/.size-snapshot.json
@@ -1,31 +1,31 @@
 {
   "dist/curi-react-universal.es.js": {
-    "bundled": 5495,
-    "minified": 2636,
-    "gzipped": 845,
+    "bundled": 5403,
+    "minified": 2611,
+    "gzipped": 836,
     "treeshaked": {
       "rollup": {
-        "code": 158,
+        "code": 146,
         "import_statements": 21
       },
       "webpack": {
-        "code": 1150
+        "code": 1138
       }
     }
   },
   "dist/curi-react-universal.js": {
-    "bundled": 5979,
-    "minified": 3053,
-    "gzipped": 968
+    "bundled": 5887,
+    "minified": 3028,
+    "gzipped": 955
   },
   "dist/curi-react-universal.umd.js": {
-    "bundled": 6600,
-    "minified": 2480,
-    "gzipped": 956
+    "bundled": 6500,
+    "minified": 2447,
+    "gzipped": 945
   },
   "dist/curi-react-universal.min.js": {
-    "bundled": 6600,
-    "minified": 2480,
-    "gzipped": 956
+    "bundled": 6500,
+    "minified": 2447,
+    "gzipped": 945
   }
 }

--- a/packages/react-universal/CHANGELOG.md
+++ b/packages/react-universal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `useResponse` only returns `response` and `navigation`.
+
 ## 2.0.0-beta.8
 
 * Remove `useMemo` from `useLocation`.

--- a/packages/react-universal/src/Context.tsx
+++ b/packages/react-universal/src/Context.tsx
@@ -1,13 +1,12 @@
 import React from "react";
-import { CuriRouter, Emitted } from "@curi/types";
+import { CuriRouter, ResponseAndNav } from "@curi/types";
 
-const key: Emitted = {
-  router: null,
+const key: ResponseAndNav = {
   response: null,
   navigation: null
 };
 
-const responseContext = React.createContext<Emitted>(key);
+const responseContext = React.createContext<ResponseAndNav>(key);
 const {
   Provider: ResponseProvider,
   Consumer: ResponseConsumer

--- a/packages/react-universal/src/createRouterComponent.tsx
+++ b/packages/react-universal/src/createRouterComponent.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { RouterProvider, ResponseProvider } from "./Context";
 
-import { CuriRouter, Emitted } from "@curi/types";
+import { CuriRouter, ResponseAndNav } from "@curi/types";
 
 export interface RouterProps {
   children: React.ReactNode;
@@ -11,23 +11,20 @@ export default function createRouterComponent(
   router: CuriRouter
 ): React.FunctionComponent<RouterProps> {
   function initialState() {
-    const { response, navigation } = router.current();
-    return {
-      router,
-      response,
-      navigation
-    };
+    return router.current();
   }
 
   return function Router(props: RouterProps) {
-    const [response, setResponse] = React.useState<Emitted>(initialState);
+    const [response, setResponse] = React.useState<ResponseAndNav>(
+      initialState
+    );
 
     React.useEffect(() => {
       let removed = false;
       const stop = router.observe(
-        (emitted: Emitted) => {
+        ({ response, navigation }) => {
           if (!removed) {
-            setResponse(emitted);
+            setResponse({ response, navigation });
           }
         },
         { initial: false }

--- a/packages/react-universal/src/hooks/useActive.ts
+++ b/packages/react-universal/src/hooks/useActive.ts
@@ -1,3 +1,4 @@
+import useRouter from "./useRouter";
 import useResponse from "./useResponse";
 
 import { SessionLocation } from "@hickory/root";
@@ -13,7 +14,8 @@ export interface ActiveHookProps {
 }
 
 export default function useActive(props: ActiveHookProps) {
-  const { router, response } = useResponse();
+  const router = useRouter();
+  const { response } = useResponse();
   return router.route.active(props.name, response, {
     params: props.params,
     partial: props.partial,

--- a/packages/react-universal/src/hooks/useResponse.ts
+++ b/packages/react-universal/src/hooks/useResponse.ts
@@ -1,8 +1,8 @@
 import React from "react";
 import { responseContext } from "../Context";
 
-import { Emitted } from "@curi/types";
+import { ResponseAndNav } from "@curi/types";
 
 export default function useResponse() {
-  return React.useContext<Emitted>(responseContext);
+  return React.useContext<ResponseAndNav>(responseContext);
 }

--- a/packages/react-universal/tests/ResponseConsumer.spec.tsx
+++ b/packages/react-universal/tests/ResponseConsumer.spec.tsx
@@ -25,7 +25,7 @@ describe("ResponseConsumer", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
-  it("returns router, response, and navigation objects", () => {
+  it("returns response and navigation objects", () => {
     const router = createRouter(inMemory, routes);
     const Router = createRouterComponent(router);
     const { response, navigation } = router.current();
@@ -33,7 +33,6 @@ describe("ResponseConsumer", () => {
       return (
         <ResponseConsumer>
           {result => {
-            expect(result.router).toBe(router);
             expect(result.response).toBe(response);
             expect(result.navigation).toBe(navigation);
             return null;

--- a/packages/react-universal/tests/create_router_component.spec.tsx
+++ b/packages/react-universal/tests/create_router_component.spec.tsx
@@ -5,7 +5,11 @@ import { act } from "react-dom/test-utils";
 import { createRouter, prepareRoutes } from "@curi/router";
 import { inMemory } from "@hickory/in-memory";
 
-import { createRouterComponent, useResponse } from "@curi/react-universal";
+import {
+  createRouterComponent,
+  useRouter,
+  useResponse
+} from "@curi/react-universal";
 
 describe("createRouterComponent()", () => {
   let node;
@@ -104,15 +108,15 @@ describe("createRouterComponent()", () => {
   });
 
   describe("context", () => {
-    it("makes response, navigation, and router available on content", () => {
+    it("makes response, navigation, and router available on context", () => {
       const router = createRouter(inMemory, routes);
 
       const ContextLogger: React.ComponentType = () => {
         const {
-          router: ctxRouter,
           response: ctxResponse,
           navigation: ctxNavigation
         } = useResponse();
+        const ctxRouter = useRouter();
         expect(ctxResponse).toBe(emittedResponse);
         expect(ctxRouter).toBe(router);
         expect(ctxNavigation).toBe(emittedNavigation);

--- a/packages/react-universal/tests/useResponse.spec.tsx
+++ b/packages/react-universal/tests/useResponse.spec.tsx
@@ -25,13 +25,12 @@ describe("useResponse", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
-  it("returns router, response, and navigation objects", () => {
+  it("returns response, and navigation objects", () => {
     const router = createRouter(inMemory, routes);
     const Router = createRouterComponent(router);
     const { response, navigation } = router.current();
     function App() {
       const result = useResponse();
-      expect(result.router).toBe(router);
       expect(result.response).toBe(response);
       expect(result.navigation).toBe(navigation);
       return null;

--- a/packages/react-universal/types/Context.d.ts
+++ b/packages/react-universal/types/Context.d.ts
@@ -1,7 +1,7 @@
 import React from "react";
-import { CuriRouter, Emitted } from "@curi/types";
-declare const responseContext: React.Context<Emitted>;
-declare const ResponseProvider: React.ProviderExoticComponent<React.ProviderProps<Emitted>>, ResponseConsumer: React.ExoticComponent<React.ConsumerProps<Emitted>>;
+import { CuriRouter, ResponseAndNav } from "@curi/types";
+declare const responseContext: React.Context<ResponseAndNav>;
+declare const ResponseProvider: React.ProviderExoticComponent<React.ProviderProps<ResponseAndNav>>, ResponseConsumer: React.ExoticComponent<React.ConsumerProps<ResponseAndNav>>;
 declare const routerContext: React.Context<CuriRouter>;
 declare const RouterProvider: React.ProviderExoticComponent<React.ProviderProps<CuriRouter>>, RouterConsumer: React.ExoticComponent<React.ConsumerProps<CuriRouter>>;
 export { ResponseProvider, ResponseConsumer, responseContext, RouterProvider, RouterConsumer, routerContext };

--- a/packages/react-universal/types/hooks/useResponse.d.ts
+++ b/packages/react-universal/types/hooks/useResponse.d.ts
@@ -1,2 +1,2 @@
-import { Emitted } from "@curi/types";
-export default function useResponse(): Emitted;
+import { ResponseAndNav } from "@curi/types";
+export default function useResponse(): ResponseAndNav;

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add `ResponseAndNav` type, which is an object with response and navigation properties.
+
 ## 2.0.0-beta.4
 
 * Rename `route.response` to `route.respond`.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -48,10 +48,13 @@ export interface ResponseHandlerOptions {
 // an observer function that will be called when there is a new navigation
 export type Observer = (props?: Emitted) => void;
 
-// the object emitted to observers
-export interface Emitted {
+export interface ResponseAndNav {
   response: Response;
   navigation: Navigation;
+}
+
+// the object emitted to observers
+export interface Emitted extends ResponseAndNav {
   router: CuriRouter;
 }
 

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -27,9 +27,11 @@ export interface ResponseHandlerOptions {
     initial?: boolean;
 }
 export declare type Observer = (props?: Emitted) => void;
-export interface Emitted {
+export interface ResponseAndNav {
     response: Response;
     navigation: Navigation;
+}
+export interface Emitted extends ResponseAndNav {
     router: CuriRouter;
 }
 export declare type Cancellable = (cancel?: () => void) => void;

--- a/website/src/pages/Guides/migrate-rrv3.js
+++ b/website/src/pages/Guides/migrate-rrv3.js
@@ -446,7 +446,7 @@ const router = createRouter(browser, routes);`}
             application using the <IJS>useResponse</IJS> hook.
           </p>
           <p>
-            The <IJS>useResponse</IJS> hook returns an object with three
+            The <IJS>useResponse</IJS> hook returns an object with two
             properties:
           </p>
           <ol>
@@ -457,11 +457,11 @@ const router = createRouter(browser, routes);`}
               <IJS>navigation</IJS> is an object with additional information
               about the navigation
             </li>
-            <li>
-              <IJS>router</IJS> is your Curi router (mostly useful if the
-              function is defined in a separate file)
-            </li>
           </ol>
+          <p>
+            The router can also be accessed throughout the application using the{" "}
+            <IJS>useRouter</IJS> hook.
+          </p>
           <p>
             Above, we added <IJS>respond</IJS> functions to each route. The
             functions set React components as the <IJS>body</IJS> property of

--- a/website/src/pages/Guides/migrate-rrv4.js
+++ b/website/src/pages/Guides/migrate-rrv4.js
@@ -396,7 +396,7 @@ const Inbox = ({ match }) => (
             application using the <IJS>useResponse</IJS> hook.
           </p>
           <p>
-            The <IJS>useResponse</IJS> hook returns an object with three
+            The <IJS>useResponse</IJS> hook returns an object with two
             properties:
           </p>
           <ol>
@@ -407,11 +407,11 @@ const Inbox = ({ match }) => (
               <IJS>navigation</IJS> is an object with additional information
               about the navigation
             </li>
-            <li>
-              <IJS>router</IJS> is your Curi router (mostly useful if the
-              function is defined in a separate file)
-            </li>
           </ol>
+          <p>
+            The router can also be accessed throughout the application using the{" "}
+            <IJS>useRouter</IJS> hook.
+          </p>
           <p>
             Above, we added <IJS>respond</IJS> functions to each route. The
             functions set React components as the <IJS>body</IJS> property of

--- a/website/src/pages/Guides/react-dom.js
+++ b/website/src/pages/Guides/react-dom.js
@@ -78,11 +78,22 @@ function ReactDOMGuide() {
 
         <p>
           Along with setting up an observer to react to new responses, the{" "}
-          <IJS>Router</IJS> sets up a context for routing values. These values—
-          <IJS>response</IJS>, <IJS>router</IJS>, and <IJS>navigation</IJS>—can
-          be read using the{" "}
-          <Link name="Package" params={{ package: "react-dom", version: "v2" }}>
+          <IJS>Router</IJS> sets up contexts for routing values. The
+          <IJS>response</IJS> and <IJS>navigation</IJS> can be read using the{" "}
+          <Link
+            name="Package"
+            params={{ package: "react-dom", version: "v2" }}
+            hash="useResponse"
+          >
             <IJS>useResponse</IJS> hook
+          </Link>
+          , while the <IJS>router</IJS> can be read using the{" "}
+          <Link
+            name="Package"
+            params={{ package: "react-dom", version: "v2" }}
+            hash="useRouter"
+          >
+            <IJS>useRouter</IJS> hook
           </Link>
           .
         </p>
@@ -96,8 +107,7 @@ const Router = createRouterComponent(router);
 function App() {
   const {
     response,
-    navigation,
-    router
+    navigation
   } = useResponse();
   const { body:Body } = response;
   return <Body />

--- a/website/src/pages/Guides/react-native.js
+++ b/website/src/pages/Guides/react-native.js
@@ -83,23 +83,45 @@ function ReactNativeGuide() {
 
         <p>
           Along with setting up an observer to react to new responses, the{" "}
-          <IJS>Router</IJS> sets up a context for routing values. These values—
-          <IJS>response</IJS>, <IJS>router</IJS>, and <IJS>navigation</IJS>—can
-          be read using the{" "}
+          <IJS>Router</IJS> sets up contexts for routing values. The
+          <IJS>response</IJS> and <IJS>navigation</IJS> can be read using the{" "}
           <Link
             name="Package"
             params={{ package: "react-native", version: "v2" }}
+            hash="useResponse"
           >
             <IJS>useResponse</IJS> hook
+          </Link>
+          , while the <IJS>router</IJS> can be read using the{" "}
+          <Link
+            name="Package"
+            params={{ package: "react-native", version: "v2" }}
+            hash="useRouter"
+          >
+            <IJS>useRouter</IJS> hook
           </Link>
           .
         </p>
 
         <CodeBlock lang="jsx">
-          {`import { createRouterComponent } from '@curi/react-native';
+          {`import {
+  createRouterComponent,
+  useRouter,
+  useResponse
+} from '@curi/react-native';
 
 import router from "./router";
 const Router = createRouterComponent(router);
+
+function App() {
+  const router = userRouter();
+  const {
+    response,
+    navigation
+  } = useResponse();
+  const { body:Body } = response;
+  return <Body />
+}
 
 function MyReactNativeApp = () => (
   <Router>

--- a/website/src/pages/Packages/react-dom/v2/api/responseconsumer.js
+++ b/website/src/pages/Packages/react-dom/v2/api/responseconsumer.js
@@ -31,7 +31,7 @@ class MyComponent {
   render() {
     return (
       <ResponseConsumer>
-        {({ router, response, navigation }) => {
+        {({ response, navigation }) => {
           // pass these props to any components
           // that needs them
           return (
@@ -53,8 +53,8 @@ class MyComponent {
         >
           <p>
             A render-invoked function that returns a React element. This
-            function will receive an object with <IJS>router</IJS>,{" "}
-            <IJS>response</IJS> and <IJS>navigation</IJS> properties.
+            function will receive an object with <IJS>response</IJS> and{" "}
+            <IJS>navigation</IJS> properties.
           </p>
         </HashSection>
       </HashSection>

--- a/website/src/pages/Packages/react-dom/v2/api/useResponse.js
+++ b/website/src/pages/Packages/react-dom/v2/api/useResponse.js
@@ -15,9 +15,9 @@ export function UseResponseAPI() {
   return (
     <HashSection meta={meta}>
       <p>
-        The <IJS>useResponse</IJS> hook reads the current <IJS>response</IJS>,{" "}
-        <IJS>navigation</IJS>, and <IJS>router</IJS> values from React's
-        context. This will be called every time a new response is emitted.
+        The <IJS>useResponse</IJS> hook reads the current <IJS>response</IJS>{" "}
+        and <IJS>navigation</IJS> values from React's context. This will be
+        called every time a new response is emitted.
       </p>
 
       <CodeBlock lang="jsx">
@@ -26,8 +26,7 @@ export function UseResponseAPI() {
 function App() {
   const {
     response,
-    navigation,
-    router
+    navigation
   } = useResponse();
   return (
     <ThingThatNeedsResponse

--- a/website/src/pages/Packages/react-dom/v2/api/useRouter.js
+++ b/website/src/pages/Packages/react-dom/v2/api/useRouter.js
@@ -27,16 +27,6 @@ function App() {
   // ...
 }`}
       </CodeBlock>
-
-      <Note>
-        <p>
-          The <IJS>router</IJS> can also be accessed using the{" "}
-          <IJS>useResponse</IJS> hook. The difference is that{" "}
-          <IJS>useResponse</IJS> is called every time there is a new response.
-          If a component only cares about the <IJS>router</IJS>, the component
-          should use <IJS>useRouter</IJS>, which will not cause extra renders.
-        </p>
-      </Note>
     </HashSection>
   );
 }

--- a/website/src/pages/Packages/react-native/v2/api/responseconsumer.js
+++ b/website/src/pages/Packages/react-native/v2/api/responseconsumer.js
@@ -31,7 +31,7 @@ class MyComponent {
   render() {
     return (
       <ResponseConsumer>
-        {({ router, response, navigation }) => {
+        {({ response, navigation }) => {
           // pass these props to any components
           // that needs them
           return (
@@ -53,8 +53,8 @@ class MyComponent {
         >
           <p>
             A render-invoked function that returns a React element. This
-            function will receive an object with <IJS>router</IJS>,{" "}
-            <IJS>response</IJS> and <IJS>navigation</IJS> properties.
+            function will receive an object with <IJS>response</IJS> and{" "}
+            <IJS>navigation</IJS> properties.
           </p>
         </HashSection>
       </HashSection>

--- a/website/src/pages/Packages/react-native/v2/api/useResponse.js
+++ b/website/src/pages/Packages/react-native/v2/api/useResponse.js
@@ -15,9 +15,9 @@ export function UseResponseAPI() {
   return (
     <HashSection meta={meta}>
       <p>
-        The <IJS>useResponse</IJS> hook reads the current <IJS>response</IJS>,{" "}
-        <IJS>navigation</IJS>, and <IJS>router</IJS> values from React's
-        context. This will be called every time a new response is emitted.
+        The <IJS>useResponse</IJS> hook reads the current <IJS>response</IJS>{" "}
+        and <IJS>navigation</IJS> values from React's context. This will be
+        called every time a new response is emitted.
       </p>
 
       <CodeBlock lang="jsx">
@@ -26,8 +26,7 @@ export function UseResponseAPI() {
 function App() {
   const {
     response,
-    navigation,
-    router
+    navigation
   } = useResponse();
   return (
     <ThingThatNeedsResponse

--- a/website/src/pages/Packages/react-native/v2/api/useRouter.js
+++ b/website/src/pages/Packages/react-native/v2/api/useRouter.js
@@ -27,16 +27,6 @@ function App() {
   // ...
 }`}
       </CodeBlock>
-
-      <Note>
-        <p>
-          The <IJS>router</IJS> can also be accessed using the{" "}
-          <IJS>useResponse</IJS> hook. The difference is that{" "}
-          <IJS>useResponse</IJS> is called every time there is a new response.
-          If a component only cares about the <IJS>router</IJS>, the component
-          should use <IJS>useRouter</IJS>, which will not cause extra renders.
-        </p>
-      </Note>
     </HashSection>
   );
 }

--- a/website/src/pages/Tutorials/react-advanced.js
+++ b/website/src/pages/Tutorials/react-advanced.js
@@ -753,13 +753,15 @@ export default function Home({ response }) {
           array.
         </p>
 
-        <CodeBlock lang="jsx" data-line="7">
+        <CodeBlock lang="jsx" data-line="9">
           {`// src/components/Book.js
 import React from 'react';
+import { useRouter } from '@curi/react-dom';
 
 import cart from '../cart';
 
-export default function Book({ response, router }) {
+export default function Book({ response }) {
+  const router = useRouter();
   const { book } = response.data;
   if (!book) {
     return <div>The requested book could not be found</div>;

--- a/website/src/pages/Tutorials/react-basics.js
+++ b/website/src/pages/Tutorials/react-basics.js
@@ -65,11 +65,14 @@ const navigateMeta = {
   hash: "nav-method"
 };
 const shoppingMeta = {
-  title: "Let's go shopping",
-  hash: "shopping",
+  title: "A Shopping API",
+  hash: "shopping"
+};
+const useRouterMeta = {
+  title: "Using useRouter",
+  hash: "useRouter",
   children: [navigateMeta]
 };
-
 const nextMeta = { title: "What's next?", hash: "next" };
 
 const contents = [
@@ -81,6 +84,7 @@ const contents = [
   renderingMeta,
   navigatingMeta,
   shoppingMeta,
+  useRouterMeta,
   nextMeta
 ];
 
@@ -1092,43 +1096,26 @@ export default {
   }
 };`}
         </CodeBlock>
+      </HashSection>
 
+      <HashSection meta={useRouterMeta} tag="h4">
         <p>
-          Before we edit the <IJS>Book</IJS> component, we should quickly
-          revisit the <IJS>App</IJS> component. In addition to passing the{" "}
-          <IJS>response</IJS> to the <IJS>Body</IJS>, we should also pass it our{" "}
-          <IJS>router</IJS>, which will allow us to do programmatic navigation.
+          The <IJS>useRouter</IJS> hook allows us to access our router from
+          anywhere in our component tree (that is a descendant of the{" "}
+          <Cmp>Router</Cmp>).
         </p>
 
-        <CodeBlock lang="jsx" data-line="8,16">
-          {`// src/App.js
-import React from "react";
-import { useResponse } from "@curi/react-dom";
-
-import NavMenu from './components/NavMenu';
-
-export default function App() {
-  const { response, router } = useResponse();
-  const { body:Body } = response;
-  return (
-    <React.Fragment>
-      <header>
-        <NavMenu />
-      </header>
-      <main>
-        <Body response={response} router={router} />
-      </main>
-    </React.Fragment>
-  );
-}`}
-        </CodeBlock>
+        <p>
+          While links are generally the best way to navigate, sometimes an
+          application should navigate as the result of another action. For
+          instance, after a user login is authenticated, the application may
+          redirect to another page.
+        </p>
 
         <p>
-          We can now access our <IJS>router</IJS> in the <IJS>Book</IJS>{" "}
-          component. The router's <IJS>navigate</IJS> function can be used to
-          navigate to a new location. This means that when the user clicks a
-          button to add a book to their shopping cart, we can automatically
-          navigate to the checkout page.
+          We will implement something similar in the <IJS>Book</IJS> component
+          by having the application navigate to their shopping cart after they
+          add a book to it.
         </p>
 
         <HashSection meta={navigateMeta} className="aside" tag="h3">
@@ -1143,9 +1130,13 @@ export default function App() {
           </p>
 
           <CodeBlock>
-            {`// session = ['/one', '/two', '/three'], index = 1
+            {`// session = ['/one', '/two', '/three']
+// index = 1
+// current = '/two'
 router.navigate({ name: "New", method: "push" });
-// session = ['/one', '/two', '/new'], index = 2`}
+// session = ['/one', '/two', '/new']
+// index = 2
+// current = '/new'`}
           </CodeBlock>
 
           <p>
@@ -1153,9 +1144,13 @@ router.navigate({ name: "New", method: "push" });
           </p>
 
           <CodeBlock>
-            {`// session = ['/one', '/two', '/three'], index = 1
+            {`// session = ['/one', '/two', '/three']
+// index = 1
+// current = '/two'
 router.navigate({ name: "Replace", method: "replace" });
-// session = ['/one', '/replacement', '/three'], index = 1`}
+// session = ['/one', '/replacement', '/three']
+// index = 1
+// current = '/replacement'`}
           </CodeBlock>
 
           <p>
@@ -1170,28 +1165,37 @@ router.navigate({ name: "Replace", method: "replace" });
           </p>
 
           <CodeBlock>
-            {`// session = ['/one', '/two', '/three'], index = 1
+            {`// session = ['/one', '/two', '/three']
+// index = 1
+// current = '/two'
 router.navigate({ name: "Two", method: "anchor" });
-// session = ['/one', '/two', '/three'], index = 1
+// session = ['/one', '/two', '/three']
+// index = 1
+// current = '/two'
 router.navigate({ name: "New", method: "anchor" });
-// session = ['/one', '/two', '/new'], index = 2`}
+// session = ['/one', '/two', '/new']
+// index = 2
+// current = '/new'`}
             `}
           </CodeBlock>
         </HashSection>
 
         <p>
-          We also want to import our shopping cart API so that we can add a book
-          to the cart.
+          In the <IJS>Book</IJS> components module, we should import the{" "}
+          <IJS>useRouter</IJS> hook from <IJS>@curi/react-dom</IJS> as well as
+          our shopping cart API.
         </p>
 
-        <CodeBlock lang="jsx" data-line="5,19-27">
+        <CodeBlock lang="jsx" data-line="3,6,21-29">
           {`// src/components/Book.js
 import React from 'react';
+import { useRouter } from '@curi/react-dom';
 
 import books from '../books';
 import cart from '../cart';
 
-export default function Book({ response, router }) {
+export default function Book({ response }) {
+  const router = useRouter();
   const id = parseInt(response.params.id, 10);
   const book = books.find(b => b.id === id);
   if (!book) {
@@ -1227,16 +1231,21 @@ export default function Book({ response, router }) {
           When a user "buys" the books in their shopping cart, we need to clear
           out the cart. We will also replace the current location with one whose{" "}
           <IJS>location.hash</IJS> is the string "thanks". When that is present
-          in the location, we can render a "Thanks for your purchase" message.
+          in the location, we can render a "Thanks for your purchase" message
+          instead of the cart's contents. Once again, we will use the{" "}
+          <IJS>useRouter</IJS> hook to access the router in order to change
+          locations.
         </p>
 
         <CodeBlock lang="jsx">
           {`// src/components/Checkout.js
 import React from 'react';
+import { useRouter } from '@curi/react-dom';
 
 import cart from '../cart';
 
-export default function Checkout({ router, response }) {
+export default function Checkout({ response }) {
+  const router = useRouter();
   const books = cart.items();
   if (!books.length) {
     return response.location.hash === 'thanks'
@@ -1285,9 +1294,21 @@ export default function Checkout({ router, response }) {
       <HashSection meta={nextMeta}>
         <p>
           We now have a functional website built with React and Curi. What
-          should you do next? Build another site! You can also check out the{" "}
-          <Link name="Guides">guides</Link> for information on advanced
-          techniques.
+          should you do next? Build another site!
+        </p>
+
+        <p>
+          There is an{" "}
+          <Link name="Tutorial" params={{ slug: "react-advanced" }}>
+            advanced React tutorial
+          </Link>{" "}
+          that continues where this tutorial leaves off. The advanced tutorial
+          implements code splitting and data prefetching.
+        </p>
+
+        <p>
+          You can also check out the <Link name="Guides">guides</Link> for
+          information on other advanced techniques.
         </p>
       </HashSection>
     </React.Fragment>


### PR DESCRIPTION
Instead of having two ways to access the `router` through context, the only way to do so now is with `useRouter` (or the `RouterConsumer`). `useResponse` (and the `ResponseConsumer`) now only provide the `response` and `navigation`.

```js
// before
const { router, response, navigation } = useResponse();

// after
const router = useRouter();
const { response, navigation } = useResponse();
```