### PR TITLE
router.url with no name returns relative URL

### DIFF
--- a/packages/react-dom/tests/AsyncLink.spec.tsx
+++ b/packages/react-dom/tests/AsyncLink.spec.tsx
@@ -73,7 +73,7 @@ describe("<AsyncLink>", () => {
         expect(a.getAttribute("href")).toBe("/");
       });
 
-      it("inherits pathname from current location is name is not provided", () => {
+      it("has no pathname component if name is not provided", () => {
         const routes = prepareRoutes({
           routes: [{ name: "Catch All", path: "(.*)" }]
         });
@@ -90,7 +90,7 @@ describe("<AsyncLink>", () => {
           node
         );
         const a = node.querySelector("a");
-        expect(a.getAttribute("href")).toBe("/the-initial-location#test");
+        expect(a.getAttribute("href")).toBe("#test");
       });
     });
 

--- a/packages/react-dom/tests/Link.spec.tsx
+++ b/packages/react-dom/tests/Link.spec.tsx
@@ -71,7 +71,7 @@ describe("<Link>", () => {
         expect(a.getAttribute("href")).toBe("/");
       });
 
-      it("inherits pathname from current location is name is not provided", () => {
+      it("has no pathname component if name is not provided", () => {
         const routes = prepareRoutes({
           routes: [{ name: "Catch All", path: "(.*)" }]
         });
@@ -88,7 +88,7 @@ describe("<Link>", () => {
           node
         );
         const a = node.querySelector("a");
-        expect(a.getAttribute("href")).toBe("/the-initial-location#test");
+        expect(a.getAttribute("href")).toBe("#test");
       });
     });
 

--- a/packages/react-native/tests/AsyncLink.spec.tsx
+++ b/packages/react-native/tests/AsyncLink.spec.tsx
@@ -73,7 +73,7 @@ describe("<AsyncLink>", () => {
 
   describe("navigation location", () => {
     describe("name", () => {
-      it("inherits pathname from current location if 'name' is not provided", async () => {
+      it("has no pathname component if name is not provided", async () => {
         const mockNavigate = jest.fn();
         const routes = prepareRoutes({
           routes: [{ name: "Catch All", path: "(.*)" }]
@@ -98,7 +98,7 @@ describe("<AsyncLink>", () => {
           anchor.props.onPress(fakeEvent());
         });
         expect(mockNavigate.mock.calls[0][0]).toMatchObject({
-          url: "/the-initial-location#test"
+          url: "#test"
         });
       });
     });

--- a/packages/react-native/tests/Link.spec.tsx
+++ b/packages/react-native/tests/Link.spec.tsx
@@ -69,7 +69,7 @@ describe("<Link>", () => {
 
   describe("navigation location", () => {
     describe("name", () => {
-      it("inherits pathname from current location if 'name' is not provided", () => {
+      it("has no pathname component if name is not provided", () => {
         const mockNavigate = jest.fn();
         const routes = prepareRoutes({
           routes: [{ name: "Catch All", path: "(.*)" }]
@@ -92,7 +92,7 @@ describe("<Link>", () => {
         const anchor = tree.root.findByType(TouchableHighlight);
         anchor.props.onPress(fakeEvent());
         expect(mockNavigate.mock.calls[0][0]).toMatchObject({
-          url: "/the-initial-location#test"
+          url: "#test"
         });
       });
     });

--- a/packages/react-universal/tests/useURL.spec.tsx
+++ b/packages/react-universal/tests/useURL.spec.tsx
@@ -58,7 +58,7 @@ describe("useURL", () => {
       );
     });
 
-    it("inherits current location's pathname if route name is not provided", () => {
+    it("has no pathname component if name is not provided", () => {
       const router = createRouter(inMemory, routes, {
         history: {
           locations: [{ url: "/example" }]
@@ -66,8 +66,8 @@ describe("useURL", () => {
       });
       const Router = createRouterComponent(router);
       function App() {
-        const result = useURL({});
-        expect(result).toBe("/example");
+        const result = useURL({ hash: "test" });
+        expect(result).toBe("#test");
         return null;
       }
       ReactDOM.render(

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 16824,
-    "minified": 6674,
-    "gzipped": 2571,
+    "bundled": 16808,
+    "minified": 6661,
+    "gzipped": 2570,
     "treeshaked": {
       "rollup": {
         "code": 23,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17075,
-    "minified": 6880,
-    "gzipped": 2649
+    "bundled": 17059,
+    "minified": 6867,
+    "gzipped": 2648
   },
   "dist/curi-router.umd.js": {
-    "bundled": 28313,
-    "minified": 9171,
-    "gzipped": 3774
+    "bundled": 28297,
+    "minified": 9158,
+    "gzipped": 3772
   },
   "dist/curi-router.min.js": {
-    "bundled": 26713,
-    "minified": 8276,
-    "gzipped": 3358
+    "bundled": 26697,
+    "minified": 8263,
+    "gzipped": 3350
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `router.url` returns relative URL string when `name` is not provided.
+
 ## 2.0.0-beta.14
 
 * Add `router.url` method for generating a URL string.

--- a/packages/router/src/router/createRouter.ts
+++ b/packages/router/src/router/createRouter.ts
@@ -178,9 +178,7 @@ export default function createRouter<O = HistoryOptions>(
   function url(details: RouteLocation): string {
     let { name, params, hash, query } = details;
     const pathname =
-      name != null
-        ? routes.interactions.pathname(name, params)
-        : history.location.pathname;
+      name != null ? routes.interactions.pathname(name, params) : undefined;
     return history.url({ pathname, hash, query });
   }
 

--- a/packages/router/tests/curi.spec.ts
+++ b/packages/router/tests/curi.spec.ts
@@ -1119,38 +1119,36 @@ describe("curi", () => {
     });
     const router = createRouter(inMemory, routes);
 
-    describe("navigation location", () => {
-      it("generates the expected pathname", () => {
-        const url = router.url({ name: "Contact" });
-        router.navigate({ url });
-        expect(url).toEqual("/contact");
-      });
+    it("generates the expected pathname", () => {
+      const url = router.url({ name: "Contact" });
+      router.navigate({ url });
+      expect(url).toEqual("/contact");
+    });
 
-      it("uses params to create pathname", () => {
-        const url = router.url({ name: "Method", params: { method: "fax" } });
-        router.navigate({ url });
-        expect(url).toEqual("/contact/fax");
-      });
+    it("uses params to create pathname", () => {
+      const url = router.url({ name: "Method", params: { method: "fax" } });
+      router.navigate({ url });
+      expect(url).toEqual("/contact/fax");
+    });
 
-      it("inherits pathname from current response's location if no name is provided", () => {
-        const router = createRouter(inMemory, routes, {
-          history: {
-            locations: [{ url: "/test" }]
-          }
-        });
-        const url = router.url({ hash: "test" });
-        expect(url).toEqual("/test#test");
+    it("returns URL with no pathname if name is not provided", () => {
+      const router = createRouter(inMemory, routes, {
+        history: {
+          locations: [{ url: "/test" }]
+        }
       });
+      const url = router.url({ hash: "test" });
+      expect(url).toEqual("#test");
+    });
 
-      it("includes the provided hash", () => {
-        const url = router.url({ name: "Home", hash: "trending" });
-        expect(url).toEqual("/#trending");
-      });
+    it("includes the provided hash", () => {
+      const url = router.url({ name: "Home", hash: "trending" });
+      expect(url).toEqual("/#trending");
+    });
 
-      it("includes the provided query", () => {
-        const url = router.url({ name: "Home", query: "key=value" });
-        expect(url).toEqual("/?key=value");
-      });
+    it("includes the provided query", () => {
+      const url = router.url({ name: "Home", query: "key=value" });
+      expect(url).toEqual("/?key=value");
     });
   });
 
@@ -1216,6 +1214,31 @@ describe("curi", () => {
       router.navigate({ url, state });
       expect(mockNavigate.mock.calls[0][0]).toMatchObject({
         state
+      });
+    });
+
+    it("location inherits pathname when navigating to URL with no pathname", () => {
+      const routes = prepareRoutes({
+        routes: [
+          { name: "Home", path: "" },
+          {
+            name: "Contact",
+            path: "contact",
+            children: [{ name: "Method", path: ":method" }]
+          },
+          { name: "Catch All", path: "(.*)" }
+        ]
+      });
+      const router = createRouter(inMemory, routes, {
+        history: {
+          locations: [{ url: "/contact/phone" }]
+        }
+      });
+      const url = router.url({ hash: "test" });
+      router.navigate({ url });
+      const { response } = router.current();
+      expect(response.location).toMatchObject({
+        pathname: "/contact/phone"
       });
     });
 

--- a/packages/svelte/tests/cases/link/relative/index.js
+++ b/packages/svelte/tests/cases/link/relative/index.js
@@ -23,5 +23,5 @@ export default function render() {
   const target = document.createElement("div");
   new app({ target, store });
   const a = target.querySelector("a");
-  expect(a.getAttribute("href")).toBe("/u/2#is-a-band");
+  expect(a.getAttribute("href")).toBe("#is-a-band");
 }

--- a/packages/svelte/tests/link.spec.js
+++ b/packages/svelte/tests/link.spec.js
@@ -12,7 +12,7 @@ describe("<Link>", () => {
       test("./cases/link/pathname-params");
     });
 
-    it("inherits current location's pathname if \"name\" isn't provided", () => {
+    it("has no pathname component if name is not provided", () => {
       test("./cases/link/relative");
     });
 

--- a/packages/vue/tests/AsyncLink.spec.ts
+++ b/packages/vue/tests/AsyncLink.spec.ts
@@ -82,7 +82,7 @@ describe("<curi-async-link>", () => {
       expect(a.getAttribute("href")).toBe("/place/Jamaica?two=2#island-life");
     });
 
-    it("if name is not provided, pathname is inherited from current location", () => {
+    it("has no pathname component if name is not provided", () => {
       const Vue = createLocalVue();
       const router = createRouter(inMemory, routes, {
         history: {
@@ -95,12 +95,12 @@ describe("<curi-async-link>", () => {
         el: node,
         template: `
           <div>
-            <curi-async-link>somewhere</curi-async-link>
+            <curi-async-link hash="test">somewhere</curi-async-link>
           </div>
         `
       });
       const a = document.querySelector("a");
-      expect(a.getAttribute("href")).toBe("/place/somewhere");
+      expect(a.getAttribute("href")).toBe("#test");
     });
 
     it("sets the slots as the link's children", () => {

--- a/packages/vue/tests/Link.spec.ts
+++ b/packages/vue/tests/Link.spec.ts
@@ -65,7 +65,7 @@ describe("<curi-link>", () => {
       expect(a.getAttribute("href")).toBe("/place/Jamaica?two=2#island-life");
     });
 
-    it("if name is not provided, pathname is inherited from current location", () => {
+    it("has no pathname component if name is not provided", () => {
       const Vue = createLocalVue();
       const router = createRouter(inMemory, routes, {
         history: {
@@ -78,12 +78,12 @@ describe("<curi-link>", () => {
         el: node,
         template: `
           <div>
-            <curi-link>somewhere</curi-link>
+            <curi-link hash="test">somewhere</curi-link>
           </div>
         `
       });
       const a = document.querySelector("a");
-      expect(a.getAttribute("href")).toBe("/place/somewhere");
+      expect(a.getAttribute("href")).toBe("#test");
     });
 
     it("sets the slots as the link's children", () => {


### PR DESCRIPTION
When using `router.url` with no name property, the URL returned will have no `pathname` component. If the history is configured with a `base`, that will not be included either.

```js
const url = router.url({ hash: "comments" });
// url = "#comments"
```

When navigating using a URL with no `pathname` component, the corresponding location will re-use the current location's `pathname`.

```js
const router = createRouter(inMemory, routes, {
  history: {
    locations: [{ url: "/initial-location" }]
  }
});
const url = router.url({ hash: "comments" });
router.navigate({ url });
const { response } = router.current();
// response.location = { pathname: "/initial-location", hash: "comments", ... }
```