### PR TITLE
Remove replacing TS @class with #__PURE__

### DIFF
--- a/packages/helpers/rollup.config.js
+++ b/packages/helpers/rollup.config.js
@@ -8,7 +8,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -24,7 +23,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -40,7 +38,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -58,7 +55,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/packages/interactions/route-ancestors/rollup.config.js
+++ b/packages/interactions/route-ancestors/rollup.config.js
@@ -13,7 +13,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -30,7 +29,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -46,7 +44,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -64,7 +61,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/packages/interactions/route-prefetch/rollup.config.js
+++ b/packages/interactions/route-prefetch/rollup.config.js
@@ -13,7 +13,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -30,7 +29,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -46,7 +44,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -64,7 +61,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/packages/react-dom/rollup.config.js
+++ b/packages/react-dom/rollup.config.js
@@ -15,7 +15,6 @@ module.exports = [
     external: [...deps, "react"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -33,7 +32,6 @@ module.exports = [
     external: [...deps, "react"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -51,7 +49,6 @@ module.exports = [
     external: ["react"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -71,7 +68,6 @@ module.exports = [
     external: ["react"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/packages/react-native/rollup.config.js
+++ b/packages/react-native/rollup.config.js
@@ -15,7 +15,6 @@ module.exports = [
     external: [...deps, "react", "react-native"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -33,7 +32,6 @@ module.exports = [
     external: [...deps, "react", "react-native"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/react-universal/rollup.config.js
+++ b/packages/react-universal/rollup.config.js
@@ -15,7 +15,6 @@ module.exports = [
     external: [...deps, "react"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -33,7 +32,6 @@ module.exports = [
     external: [...deps, "react"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -51,7 +49,6 @@ module.exports = [
     external: ["react"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -71,7 +68,6 @@ module.exports = [
     external: ["react"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -13,7 +13,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -30,7 +29,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -46,7 +44,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -64,7 +61,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/packages/side-effects/side-effect-aria-live/rollup.config.js
+++ b/packages/side-effects/side-effect-aria-live/rollup.config.js
@@ -13,7 +13,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -30,7 +29,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -46,7 +44,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -64,7 +61,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/packages/side-effects/side-effect-scroll/rollup.config.js
+++ b/packages/side-effects/side-effect-scroll/rollup.config.js
@@ -13,7 +13,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -30,7 +29,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -46,7 +44,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -64,7 +61,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/packages/side-effects/side-effect-title/rollup.config.js
+++ b/packages/side-effects/side-effect-title/rollup.config.js
@@ -13,7 +13,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -30,7 +29,6 @@ module.exports = [
     external: deps,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -46,7 +44,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -64,7 +61,6 @@ module.exports = [
     input,
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/packages/static/rollup.config.js
+++ b/packages/static/rollup.config.js
@@ -13,7 +13,6 @@ module.exports = [
     external: [...deps, "path"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/svelte/rollup.config.js
+++ b/packages/svelte/rollup.config.js
@@ -23,7 +23,6 @@ module.exports = [
     plugins: [
       svelte,
       babel,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -41,7 +40,6 @@ module.exports = [
     plugins: [
       svelte,
       babel,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -15,7 +15,6 @@ module.exports = [
     external: [...deps, "vue"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -33,7 +32,6 @@ module.exports = [
     external: [...deps, "vue"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.resolveNode,
       plugins.commonjs,
       plugins.sizeSnapshot
@@ -51,7 +49,6 @@ module.exports = [
     external: ["vue"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithDevelopment,
       plugins.resolveNode,
       plugins.commonjs,
@@ -71,7 +68,6 @@ module.exports = [
     external: ["vue"],
     plugins: [
       plugins.typescript,
-      plugins.replacePure,
       plugins.replaceWithProduction,
       plugins.resolveNode,
       plugins.commonjs,

--- a/utils/rollup-plugins.js
+++ b/utils/rollup-plugins.js
@@ -5,12 +5,6 @@ const resolve = require("rollup-plugin-node-resolve");
 const { sizeSnapshot } = require("rollup-plugin-size-snapshot");
 const typescript = require("rollup-plugin-typescript2");
 
-exports.replacePure = replace({
-  values: {
-    "@class": "#__PURE__"
-  },
-  delimiters: ["", ""]
-});
 exports.replaceWithProduction = replace({
   "process.env.NODE_ENV": `"production"`
 });


### PR DESCRIPTION
This Rollup plugin is no longer necessary.