### PR TITLE
Add router.destroy method for deactivating router

### DIFF
--- a/examples/misc/code-splitting/package.json
+++ b/examples/misc/code-splitting/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"
   }

--- a/examples/misc/server-rendering/package.json
+++ b/examples/misc/server-rendering/package.json
@@ -19,8 +19,8 @@
     "@babel/register": "^7.0.0",
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
-    "@hickory/in-memory": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
+    "@hickory/in-memory": "2.0.0-beta.15",
     "express": "^4.16.2",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"

--- a/examples/misc/side-effect/package.json
+++ b/examples/misc/side-effect/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"
   }

--- a/examples/react/accessibility/package.json
+++ b/examples/react/accessibility/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"
   }

--- a/examples/react/active-links/package.json
+++ b/examples/react/active-links/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"
   }

--- a/examples/react/async-nav/package.json
+++ b/examples/react/async-nav/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0",
     "react-spinkit": "^3.0.0"

--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"
   }

--- a/examples/react/breadcrumbs/package.json
+++ b/examples/react/breadcrumbs/package.json
@@ -15,7 +15,7 @@
     "@curi/interactions": "2.0.0-beta.2",
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"
   }

--- a/examples/react/data-loading/package.json
+++ b/examples/react/data-loading/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"
   }

--- a/examples/react/modal/package.json
+++ b/examples/react/modal/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"
   }

--- a/examples/react/multi-body/package.json
+++ b/examples/react/multi-body/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "prop-types": "^15.6.0",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"

--- a/examples/react/redirects/package.json
+++ b/examples/react/redirects/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "qs": "^6.4.0",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0"

--- a/examples/react/transitions/package.json
+++ b/examples/react/transitions/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/react-dom": "2.0.0-beta.16",
     "@curi/router": "2.0.0-beta.21",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "react": "^16.9.0-alpha.0",
     "react-dom": "^16.9.0-alpha.0",
     "react-transition-group": "^2.2.1"

--- a/examples/svelte/active-links/package.json
+++ b/examples/svelte/active-links/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/svelte": "2.0.0-beta.3",
-    "@hickory/browser": "2.0.0-beta.14"
+    "@hickory/browser": "2.0.0-beta.15"
   },
   "devDependencies": {
     "svelte": "^3.2.0"

--- a/examples/svelte/async-nav/package.json
+++ b/examples/svelte/async-nav/package.json
@@ -13,7 +13,7 @@
     "@curi/helpers": "2.0.0-beta.4",
     "@curi/router": "2.0.0-beta.21",
     "@curi/svelte": "2.0.0-beta.3",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "svelte-spinner": "^2.0.0"
   },
   "devDependencies": {

--- a/examples/svelte/basic/package.json
+++ b/examples/svelte/basic/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/svelte": "2.0.0-beta.3",
-    "@hickory/browser": "2.0.0-beta.14"
+    "@hickory/browser": "2.0.0-beta.15"
   },
   "devDependencies": {
     "svelte": "^3.2.0"

--- a/examples/svelte/breadcrumbs/package.json
+++ b/examples/svelte/breadcrumbs/package.json
@@ -14,7 +14,7 @@
     "@curi/interactions": "2.0.0-beta.2",
     "@curi/router": "2.0.0-beta.21",
     "@curi/svelte": "2.0.0-beta.3",
-    "@hickory/browser": "2.0.0-beta.14"
+    "@hickory/browser": "2.0.0-beta.15"
   },
   "devDependencies": {
     "svelte": "^3.2.0"

--- a/examples/svelte/redirects/package.json
+++ b/examples/svelte/redirects/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/svelte": "2.0.0-beta.3",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "qs": "^6.4.0"
   },
   "devDependencies": {

--- a/examples/vue/accessibility/package.json
+++ b/examples/vue/accessibility/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/vue": "2.0.0-alpha.9",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/active-links/package.json
+++ b/examples/vue/active-links/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/vue": "2.0.0-alpha.9",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/async-nav/package.json
+++ b/examples/vue/async-nav/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/vue": "2.0.0-alpha.9",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "epic-spinners": "^1.0.3",
     "vue": "^2.5.22"
   }

--- a/examples/vue/basic/package.json
+++ b/examples/vue/basic/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/vue": "2.0.0-alpha.9",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/breadcrumbs/package.json
+++ b/examples/vue/breadcrumbs/package.json
@@ -15,7 +15,7 @@
     "@curi/interactions": "2.0.0-beta.2",
     "@curi/router": "2.0.0-beta.21",
     "@curi/vue": "2.0.0-alpha.9",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/modal/package.json
+++ b/examples/vue/modal/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/vue": "2.0.0-alpha.9",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "vue": "^2.5.22"
   }
 }

--- a/examples/vue/redirects/package.json
+++ b/examples/vue/redirects/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/vue": "2.0.0-alpha.9",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "qs": "^6.4.0",
     "vue": "^2.5.22",
     "vuex": "^3.0.1"

--- a/examples/vue/transitions/package.json
+++ b/examples/vue/transitions/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@curi/router": "2.0.0-beta.21",
     "@curi/vue": "2.0.0-alpha.9",
-    "@hickory/browser": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
     "vue": "^2.5.22"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1106,225 +1106,807 @@
         "@curi/static": "file:packages/static",
         "@emotion/core": "^10.0.6",
         "@emotion/styled": "^10.0.6",
-        "@hickory/browser": "2.0.0-beta.14",
-        "@hickory/in-memory": "2.0.0-beta.14",
+        "@hickory/browser": "2.0.0-beta.15",
+        "@hickory/in-memory": "2.0.0-beta.15",
         "react": "16.9.0-alpha.0",
         "react-dom": "16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/in-memory": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/accessibility": {
       "version": "file:examples/vue/accessibility",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
-        "@curi/vue": "2.0.0-alpha.8",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/router": "2.0.0-beta.21",
+        "@curi/vue": "2.0.0-alpha.9",
+        "@hickory/browser": "2.0.0-beta.15",
         "vue": "^2.5.22"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/accessibility-react": {
       "version": "file:examples/react/accessibility",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/active-links-react": {
       "version": "file:examples/react/active-links",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/active-links-svelte": {
       "version": "file:examples/svelte/active-links",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
+        "@curi/router": "2.0.0-beta.21",
         "@curi/svelte": "2.0.0-beta.3",
-        "@hickory/browser": "2.0.0-beta.14"
+        "@hickory/browser": "2.0.0-beta.15"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/active-links-vue": {
       "version": "file:examples/vue/active-links",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
-        "@curi/vue": "2.0.0-alpha.8",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/router": "2.0.0-beta.21",
+        "@curi/vue": "2.0.0-alpha.9",
+        "@hickory/browser": "2.0.0-beta.15",
         "vue": "^2.5.22"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/async-nav-react": {
       "version": "file:examples/react/async-nav",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0",
         "react-spinkit": "^3.0.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/async-nav-svelte": {
       "version": "file:examples/svelte/async-nav",
       "requires": {
         "@curi/helpers": "2.0.0-beta.4",
-        "@curi/router": "2.0.0-beta.19",
+        "@curi/router": "2.0.0-beta.21",
         "@curi/svelte": "2.0.0-beta.3",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@hickory/browser": "2.0.0-beta.15",
         "svelte-spinner": "^2.0.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/async-nav-vue": {
       "version": "file:examples/vue/async-nav",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
-        "@curi/vue": "2.0.0-alpha.8",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/router": "2.0.0-beta.21",
+        "@curi/vue": "2.0.0-alpha.9",
+        "@hickory/browser": "2.0.0-beta.15",
         "epic-spinners": "^1.0.3",
         "vue": "^2.5.22"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/authentication-react": {
       "version": "file:examples/react/redirects",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "qs": "^6.4.0",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/authentication-svelte": {
       "version": "file:examples/svelte/redirects",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
+        "@curi/router": "2.0.0-beta.21",
         "@curi/svelte": "2.0.0-beta.3",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@hickory/browser": "2.0.0-beta.15",
         "qs": "^6.4.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/authentication-vue": {
       "version": "file:examples/vue/redirects",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
-        "@curi/vue": "2.0.0-alpha.8",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/router": "2.0.0-beta.21",
+        "@curi/vue": "2.0.0-alpha.9",
+        "@hickory/browser": "2.0.0-beta.15",
         "qs": "^6.4.0",
         "vue": "^2.5.22",
         "vuex": "^3.0.1"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/basic-react": {
       "version": "file:examples/react/basic",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/basic-svelte": {
       "version": "file:examples/svelte/basic",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
+        "@curi/router": "2.0.0-beta.21",
         "@curi/svelte": "2.0.0-beta.3",
-        "@hickory/browser": "2.0.0-beta.14"
+        "@hickory/browser": "2.0.0-beta.15"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/basic-vue": {
       "version": "file:examples/vue/basic",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
-        "@curi/vue": "2.0.0-alpha.8",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/router": "2.0.0-beta.21",
+        "@curi/vue": "2.0.0-alpha.9",
+        "@hickory/browser": "2.0.0-beta.15",
         "vue": "^2.5.22"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/breadcrumbs-react": {
       "version": "file:examples/react/breadcrumbs",
       "requires": {
-        "@curi/interactions": "2.0.0-beta.1",
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/interactions": "2.0.0-beta.2",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/breadcrumbs-svelte": {
       "version": "file:examples/svelte/breadcrumbs",
       "requires": {
-        "@curi/interactions": "2.0.0-beta.1",
-        "@curi/router": "2.0.0-beta.19",
+        "@curi/interactions": "2.0.0-beta.2",
+        "@curi/router": "2.0.0-beta.21",
         "@curi/svelte": "2.0.0-beta.3",
-        "@hickory/browser": "2.0.0-beta.14"
+        "@hickory/browser": "2.0.0-beta.15"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/breadcrumbs-vue": {
       "version": "file:examples/vue/breadcrumbs",
       "requires": {
-        "@curi/interactions": "2.0.0-beta.1",
-        "@curi/router": "2.0.0-beta.19",
-        "@curi/vue": "2.0.0-alpha.8",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/interactions": "2.0.0-beta.2",
+        "@curi/router": "2.0.0-beta.21",
+        "@curi/vue": "2.0.0-alpha.9",
+        "@hickory/browser": "2.0.0-beta.15",
         "vue": "^2.5.22"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/code-splitting": {
       "version": "file:examples/misc/code-splitting",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/data-loading-react": {
       "version": "file:examples/react/data-loading",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/modal-react": {
       "version": "file:examples/react/modal",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/modal-vue": {
       "version": "file:examples/vue/modal",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
-        "@curi/vue": "2.0.0-alpha.8",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/router": "2.0.0-beta.21",
+        "@curi/vue": "2.0.0-alpha.9",
+        "@hickory/browser": "2.0.0-beta.15",
         "vue": "^2.5.22"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/multi-body-react": {
       "version": "file:examples/react/multi-body",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "prop-types": "^15.6.0",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/serve-examples": {
@@ -1337,43 +1919,150 @@
       "version": "file:examples/misc/server-rendering",
       "requires": {
         "@babel/register": "^7.0.0",
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
-        "@hickory/in-memory": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
+        "@hickory/in-memory": "2.0.0-beta.15",
         "express": "^4.16.2",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/in-memory": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/side-effect": {
       "version": "file:examples/misc/side-effect",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/transitions-react": {
       "version": "file:examples/react/transitions",
       "requires": {
-        "@curi/react-dom": "2.0.0-beta.15",
-        "@curi/router": "2.0.0-beta.19",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/react-dom": "2.0.0-beta.16",
+        "@curi/router": "2.0.0-beta.21",
+        "@hickory/browser": "2.0.0-beta.15",
         "react": "^16.9.0-alpha.0",
         "react-dom": "^16.9.0-alpha.0",
         "react-transition-group": "^2.2.1"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi-example/transitions-vue": {
       "version": "file:examples/vue/transitions",
       "requires": {
-        "@curi/router": "2.0.0-beta.19",
-        "@curi/vue": "2.0.0-alpha.8",
-        "@hickory/browser": "2.0.0-beta.14",
+        "@curi/router": "2.0.0-beta.21",
+        "@curi/vue": "2.0.0-alpha.9",
+        "@hickory/browser": "2.0.0-beta.15",
         "vue": "^2.5.22"
+      },
+      "dependencies": {
+        "@hickory/browser": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/dom-utils": "^2.0.0-beta.15",
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/dom-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi/helpers": {
@@ -1383,7 +2072,20 @@
       "version": "file:packages/interactions",
       "requires": {
         "@curi/types": "file:packages/types",
-        "@hickory/root": "2.0.0-beta.14"
+        "@hickory/root": "2.0.0-beta.15"
+      },
+      "dependencies": {
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi/react-dom": {
@@ -1399,9 +2101,22 @@
       "requires": {
         "@curi/react-universal": "file:packages/react-universal",
         "@curi/types": "file:packages/types",
-        "@hickory/root": "2.0.0-beta.14",
+        "@hickory/root": "2.0.0-beta.15",
         "@types/react": "^16.7.18",
         "@types/react-native": "^0.57.32"
+      },
+      "dependencies": {
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi/react-universal": {
@@ -1409,8 +2124,21 @@
       "requires": {
         "@curi/interactions": "file:packages/interactions",
         "@curi/types": "file:packages/types",
-        "@hickory/root": "2.0.0-beta.14",
+        "@hickory/root": "2.0.0-beta.15",
         "@types/react": "^16.7.18"
+      },
+      "dependencies": {
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi/router": {
@@ -1418,8 +2146,21 @@
       "requires": {
         "@curi/interactions": "file:packages/interactions",
         "@curi/types": "file:packages/types",
-        "@hickory/root": "2.0.0-beta.14",
+        "@hickory/root": "2.0.0-beta.15",
         "path-to-regexp": "^2.1.0"
+      },
+      "dependencies": {
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi/static": {
@@ -1428,10 +2169,30 @@
         "@curi/interactions": "file:packages/interactions",
         "@curi/router": "file:packages/router",
         "@curi/types": "file:packages/types",
-        "@hickory/in-memory": "2.0.0-beta.14",
+        "@hickory/in-memory": "2.0.0-beta.15",
         "@types/express": "^4.16.0",
         "@types/fs-extra": "^5.0.4",
         "fs-extra": "^7.0.0"
+      },
+      "dependencies": {
+        "@hickory/in-memory": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/root": "^2.0.0-beta.15"
+          }
+        },
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi/svelte": {
@@ -1443,15 +2204,41 @@
     "@curi/types": {
       "version": "file:packages/types",
       "requires": {
-        "@hickory/root": "2.0.0-beta.14",
+        "@hickory/root": "2.0.0-beta.15",
         "path-to-regexp": "^2.1.0"
+      },
+      "dependencies": {
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@curi/vue": {
       "version": "file:packages/vue",
       "requires": {
         "@curi/types": "file:packages/types",
-        "@hickory/root": "2.0.0-beta.14"
+        "@hickory/root": "2.0.0-beta.15"
+      },
+      "dependencies": {
+        "@hickory/location-utils": {
+          "version": "2.0.0-beta.15",
+          "bundled": true
+        },
+        "@hickory/root": {
+          "version": "2.0.0-beta.15",
+          "bundled": true,
+          "requires": {
+            "@hickory/location-utils": "^2.0.0-beta.15"
+          }
+        }
       }
     },
     "@emotion/cache": {
@@ -1562,39 +2349,28 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz",
       "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA=="
     },
-    "@hickory/browser": {
-      "version": "2.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@hickory/browser/-/browser-2.0.0-beta.14.tgz",
-      "integrity": "sha512-i3bZBfXK3BnPFNGYOfMgPNJwdWOXYchrop20903se6AvJx+0zH9HcNrY5Y4lzLmQPZrUvl0NHF9UyO7lw1Lziw==",
-      "requires": {
-        "@hickory/dom-utils": "^2.0.0-beta.14",
-        "@hickory/root": "^2.0.0-beta.14"
-      }
-    },
-    "@hickory/dom-utils": {
-      "version": "2.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@hickory/dom-utils/-/dom-utils-2.0.0-beta.14.tgz",
-      "integrity": "sha512-8K2xzWktQB0A5qmOHP1xjhP2Tyg61muYF5H39CAook3qChubWfNQMw9b8ypZJiCHiNdvQdGUEFctT3Zua81hwQ=="
-    },
     "@hickory/in-memory": {
-      "version": "2.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-2.0.0-beta.14.tgz",
-      "integrity": "sha512-8fmIANcvek49yOCHQNnIyyW93Q3gjJw+9gJfh1mtwj6wHbXfcmWF1AlD9az90SG1OhbEXvindtSB7Oy4GCb6hw==",
+      "version": "2.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@hickory/in-memory/-/in-memory-2.0.0-beta.15.tgz",
+      "integrity": "sha512-BgMqsHVSh30hbF1SAbM8pBEsrX55P6rB8NFMIsH+kgxWUa6F7lZ8hhbT3l8WXVYkanPzY/7N820hoHbhLxUpvg==",
+      "dev": true,
       "requires": {
-        "@hickory/root": "^2.0.0-beta.14"
+        "@hickory/root": "^2.0.0-beta.15"
       }
     },
     "@hickory/location-utils": {
-      "version": "2.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-2.0.0-beta.14.tgz",
-      "integrity": "sha512-+/lOqpKkoT0RoucRXHEDJPGgeETstvxXp6VdrQlDb+QheBi0p7LtQM4soOfbdXY1N1Y9c0Ne3hhhIqP4m7FN6g=="
+      "version": "2.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@hickory/location-utils/-/location-utils-2.0.0-beta.15.tgz",
+      "integrity": "sha512-S7+IQg0b2anbDO9vrUNscQPnc7rs3FURjlUvmML2ouz2p56szEON4gWn9xkGJTswjqgViQkaKIBotTVOVL16Kg==",
+      "dev": true
     },
     "@hickory/root": {
-      "version": "2.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@hickory/root/-/root-2.0.0-beta.14.tgz",
-      "integrity": "sha512-E6YhtIehPv73+r5l7hRWJl5ZocMOCjkg9Gr8q7mAHWRMFsvWSkAs2ej13HKj0HKfi8u03ktjBHa3NA77lqDy/A==",
+      "version": "2.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@hickory/root/-/root-2.0.0-beta.15.tgz",
+      "integrity": "sha512-gWSS44CaPZSeK94qSQmHMdlnoQrH1x5PTIQEMUb01RtpAfcyn3UJzScO/2+2lIjnwmPZ5hr5l5k5kVZDADbAjw==",
+      "dev": true,
       "requires": {
-        "@hickory/location-utils": "^2.0.0-beta.14"
+        "@hickory/location-utils": "^2.0.0-beta.15"
       }
     },
     "@jest/console": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
-    "@hickory/in-memory": "2.0.0-beta.14",
+    "@hickory/in-memory": "2.0.0-beta.15",
     "@types/fs-extra": "^5.0.4",
     "@types/jest": "^23.3.13",
     "@types/node": "^10.12.18",

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "@curi/types": "file:../types",
-    "@hickory/root": "2.0.0-beta.14"
+    "@hickory/root": "2.0.0-beta.15"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@curi/react-universal": "file:../react-universal",
     "@curi/types": "file:../types",
-    "@hickory/root": "2.0.0-beta.14",
+    "@hickory/root": "2.0.0-beta.15",
     "@types/react": "^16.7.18",
     "@types/react-native": "^0.57.32"
   },

--- a/packages/react-universal/package.json
+++ b/packages/react-universal/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@curi/interactions": "file:../interactions",
     "@curi/types": "file:../types",
-    "@hickory/root": "2.0.0-beta.14",
+    "@hickory/root": "2.0.0-beta.15",
     "@types/react": "^16.7.18"
   }
 }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 16571,
-    "minified": 6750,
-    "gzipped": 2688,
+    "bundled": 16646,
+    "minified": 6782,
+    "gzipped": 2700,
     "treeshaked": {
       "rollup": {
         "code": 50,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 16884,
-    "minified": 7017,
-    "gzipped": 2782
+    "bundled": 16959,
+    "minified": 7049,
+    "gzipped": 2795
   },
   "dist/curi-router.umd.js": {
-    "bundled": 29720,
-    "minified": 9422,
-    "gzipped": 3914
+    "bundled": 29807,
+    "minified": 9454,
+    "gzipped": 3927
   },
   "dist/curi-router.min.js": {
-    "bundled": 28093,
-    "minified": 8535,
-    "gzipped": 3500
+    "bundled": 28180,
+    "minified": 8567,
+    "gzipped": 3515
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@curi/interactions": "file:../interactions",
     "@curi/types": "file:../types",
-    "@hickory/root": "2.0.0-beta.14",
+    "@hickory/root": "2.0.0-beta.15",
     "path-to-regexp": "^2.1.0"
   }
 }

--- a/packages/router/src/router/createRouter.ts
+++ b/packages/router/src/router/createRouter.ts
@@ -286,6 +286,9 @@ export default function createRouter<O = HistoryOptions>(
     navigate,
     current() {
       return mostRecent;
+    },
+    destroy() {
+      history.destroy();
     }
   };
 

--- a/packages/router/tests/createRouter.spec.ts
+++ b/packages/router/tests/createRouter.spec.ts
@@ -1565,4 +1565,27 @@ describe("createRouter", () => {
       });
     });
   });
+
+  describe("destroy", () => {
+    it("doesn't navigate after destroyed", () => {
+      const routes = prepareRoutes([
+        { name: "Home", path: "" },
+        { name: "About", path: "about" },
+        { name: "Catch All", path: "(.*)" }
+      ]);
+      const router = createRouter(inMemory, routes);
+
+      expect(router.current()).toMatchObject({
+        response: { name: "Home" }
+      });
+
+      router.destroy();
+
+      router.navigate({ url: "/about" });
+
+      expect(router.current()).toMatchObject({
+        response: { name: "Home" }
+      });
+    });
+  });
 });

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -34,7 +34,7 @@
     "@curi/interactions": "file:../interactions",
     "@curi/router": "file:../router",
     "@curi/types": "file:../types",
-    "@hickory/in-memory": "2.0.0-beta.14",
+    "@hickory/in-memory": "2.0.0-beta.15",
     "@types/express": "^4.16.0",
     "@types/fs-extra": "^5.0.4",
     "fs-extra": "^7.0.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -21,7 +21,7 @@
   "author": "Paul Sherman",
   "license": "MIT",
   "dependencies": {
-    "@hickory/root": "2.0.0-beta.14",
+    "@hickory/root": "2.0.0-beta.15",
     "path-to-regexp": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,6 +13,7 @@ export interface CuriRouter {
   current(): CurrentResponse;
   url(details: RouteLocation): string;
   navigate(options: NavigationDetails): () => void;
+  destroy(): void;
   route: RouteGetter;
   history: History;
   external: any;

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -7,6 +7,7 @@ export interface CuriRouter {
     current(): CurrentResponse;
     url(details: RouteLocation): string;
     navigate(options: NavigationDetails): () => void;
+    destroy(): void;
     route: RouteGetter;
     history: History;
     external: any;

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "@curi/types": "file:../types",
-    "@hickory/root": "2.0.0-beta.14"
+    "@hickory/root": "2.0.0-beta.15"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -26,8 +26,8 @@
     "@curi/static": "file:../packages/static",
     "@emotion/core": "^10.0.6",
     "@emotion/styled": "^10.0.6",
-    "@hickory/browser": "2.0.0-beta.14",
-    "@hickory/in-memory": "2.0.0-beta.14",
+    "@hickory/browser": "2.0.0-beta.15",
+    "@hickory/in-memory": "2.0.0-beta.15",
     "react": "16.9.0-alpha.0",
     "react-dom": "16.9.0-alpha.0"
   }


### PR DESCRIPTION
`router.destroy` stops a router from responding to navigation by "destroying" its `history` instance.

This should almost never be necessary since an application only needs a single router; the primary use case for this method is apps in development that use hot module replacement.

```js
if (module.hot) {
  router.destroy();
  router = require("./router").default;
}
```