### PR TITLE
response/navigation start out undefined, not null

### DIFF
--- a/packages/react-universal/CHANGELOG.md
+++ b/packages/react-universal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Initialize `response`/`navigation` values using `router.current`.
+
 ## 2.0.0-beta.13
 
 * Change `use(Stateful)NavigationHandler` props to access `target`, not `forward`.

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 16646,
-    "minified": 6782,
-    "gzipped": 2700,
+    "bundled": 16615,
+    "minified": 6647,
+    "gzipped": 2689,
     "treeshaked": {
       "rollup": {
         "code": 50,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 16959,
-    "minified": 7049,
-    "gzipped": 2795
+    "bundled": 16928,
+    "minified": 6914,
+    "gzipped": 2784
   },
   "dist/curi-router.umd.js": {
-    "bundled": 29807,
-    "minified": 9454,
-    "gzipped": 3927
+    "bundled": 29784,
+    "minified": 9319,
+    "gzipped": 3914
   },
   "dist/curi-router.min.js": {
-    "bundled": 28180,
-    "minified": 8567,
-    "gzipped": 3515
+    "bundled": 28157,
+    "minified": 8432,
+    "gzipped": 3507
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* `response` and `navigation` are `undefined` until initial response is finalized.
+
 ## 2.0.0-beta.20
 
 * Merge the `aria-live` (now `announce`), `scroll`, and `title` side effects into package.

--- a/packages/router/src/side-effects/announce.ts
+++ b/packages/router/src/side-effects/announce.ts
@@ -1,11 +1,11 @@
-import { SideEffect, Emitted } from "@curi/types";
+import { Observer, Emitted } from "@curi/types";
 
 export type AriaLiveValue = "assertive" | "polite" | "off";
 
 export default function announce(
   fmt: (emitted: Emitted) => string,
   mode: AriaLiveValue = "assertive"
-): SideEffect {
+): Observer {
   const announcer = document.createElement("div");
   announcer.setAttribute("aria-live", mode);
   // https://hugogiraudel.com/2016/10/13/css-hide-and-seek/

--- a/packages/router/src/side-effects/scroll.ts
+++ b/packages/router/src/side-effects/scroll.ts
@@ -1,6 +1,6 @@
-import { SideEffect } from "@curi/types";
+import { Observer } from "@curi/types";
 
-export default function scroll(): SideEffect {
+export default function scroll(): Observer {
   return function({ response, navigation }) {
     if (navigation.action === "pop") {
       return;

--- a/packages/router/src/side-effects/title.ts
+++ b/packages/router/src/side-effects/title.ts
@@ -1,8 +1,8 @@
-import { SideEffect, Emitted } from "@curi/types";
+import { Observer, Emitted } from "@curi/types";
 
 export type TitleBuilder = (emitted: Emitted) => string;
 
-export default function title(callback: TitleBuilder): SideEffect {
+export default function title(callback: TitleBuilder): Observer {
   return function(emitted) {
     document.title = callback(emitted);
   };

--- a/packages/router/tests/createRouter.spec.ts
+++ b/packages/router/tests/createRouter.spec.ts
@@ -320,7 +320,7 @@ describe("createRouter", () => {
     });
 
     describe("async", () => {
-      it("initial value is an object with null response and navigation properties", () => {
+      it("initial value is an object with undefined response and navigation properties", () => {
         const routes = prepareRoutes([
           {
             name: "Catch All",
@@ -332,8 +332,8 @@ describe("createRouter", () => {
         ]);
         const router = createRouter(inMemory, routes);
         expect(router.current()).toMatchObject({
-          response: null,
-          navigation: null
+          response: undefined,
+          navigation: undefined
         });
       });
     });

--- a/packages/router/types/router/createRouter.d.ts
+++ b/packages/router/types/router/createRouter.d.ts
@@ -1,7 +1,7 @@
 import { HistoryConstructor, HistoryOptions } from "@hickory/root";
-import { RouteMatcher, CuriRouter, SideEffect } from "@curi/types";
+import { RouteMatcher, CuriRouter, Observer } from "@curi/types";
 export interface RouterOptions<O = HistoryOptions> {
-    sideEffects?: Array<SideEffect>;
+    sideEffects?: Array<Observer>;
     invisibleRedirects?: boolean;
     external?: any;
     history?: O;

--- a/packages/router/types/side-effects/announce.d.ts
+++ b/packages/router/types/side-effects/announce.d.ts
@@ -1,3 +1,3 @@
-import { SideEffect, Emitted } from "@curi/types";
+import { Observer, Emitted } from "@curi/types";
 export declare type AriaLiveValue = "assertive" | "polite" | "off";
-export default function announce(fmt: (emitted: Emitted) => string, mode?: AriaLiveValue): SideEffect;
+export default function announce(fmt: (emitted: Emitted) => string, mode?: AriaLiveValue): Observer;

--- a/packages/router/types/side-effects/scroll.d.ts
+++ b/packages/router/types/side-effects/scroll.d.ts
@@ -1,2 +1,2 @@
-import { SideEffect } from "@curi/types";
-export default function scroll(): SideEffect;
+import { Observer } from "@curi/types";
+export default function scroll(): Observer;

--- a/packages/router/types/side-effects/title.d.ts
+++ b/packages/router/types/side-effects/title.d.ts
@@ -1,3 +1,3 @@
-import { SideEffect, Emitted } from "@curi/types";
+import { Observer, Emitted } from "@curi/types";
 export declare type TitleBuilder = (emitted: Emitted) => string;
-export default function title(callback: TitleBuilder): SideEffect;
+export default function title(callback: TitleBuilder): Observer;

--- a/packages/static/tests/staticFiles.spec.ts
+++ b/packages/static/tests/staticFiles.spec.ts
@@ -250,7 +250,7 @@ describe("staticFiles()", () => {
           name: "Home"
         },
         navigation: {
-          previous: null,
+          previous: undefined,
           action: "push"
         }
       });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -38,7 +38,7 @@ export interface CurrentResponse {
 // information about a navigation
 export interface Navigation {
   action: Action;
-  previous: Response | null;
+  previous: Response | undefined;
 }
 
 // configuration options for router.observe and router.once
@@ -46,9 +46,7 @@ export interface ResponseHandlerOptions {
   initial?: boolean;
 }
 // an observer function that will be called when there is a new navigation
-export type Observer = (props?: Emitted) => void;
-// a SideEffect is like an Observer, but will always be called with an Emitted
-export type SideEffect = (props: Emitted) => void;
+export type Observer = (props: Emitted) => void;
 
 export interface ResponseAndNav {
   response: Response;

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -26,13 +26,12 @@ export interface CurrentResponse {
 }
 export interface Navigation {
     action: Action;
-    previous: Response | null;
+    previous: Response | undefined;
 }
 export interface ResponseHandlerOptions {
     initial?: boolean;
 }
-export declare type Observer = (props?: Emitted) => void;
-export declare type SideEffect = (props: Emitted) => void;
+export declare type Observer = (props: Emitted) => void;
 export interface ResponseAndNav {
     response: Response;
     navigation: Navigation;

--- a/packages/vue/.size-snapshot.json
+++ b/packages/vue/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-vue.es.js": {
-    "bundled": 4766,
-    "minified": 2290,
-    "gzipped": 950,
+    "bundled": 4754,
+    "minified": 2277,
+    "gzipped": 944,
     "treeshaked": {
       "rollup": {
         "code": 12,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-vue.js": {
-    "bundled": 4991,
-    "minified": 2472,
-    "gzipped": 1022
+    "bundled": 4979,
+    "minified": 2459,
+    "gzipped": 1016
   },
   "dist/curi-vue.umd.js": {
-    "bundled": 5478,
-    "minified": 2444,
-    "gzipped": 1030
+    "bundled": 5466,
+    "minified": 2431,
+    "gzipped": 1025
   },
   "dist/curi-vue.min.js": {
-    "bundled": 5077,
-    "minified": 2189,
-    "gzipped": 890
+    "bundled": 5065,
+    "minified": 2176,
+    "gzipped": 884
   }
 }

--- a/packages/vue/src/interface.ts
+++ b/packages/vue/src/interface.ts
@@ -1,8 +1,8 @@
 import { CuriRouter, Response, Navigation } from "@curi/types";
 
 export interface ReactiveResponse {
-  response: Response;
-  navigation: Navigation;
+  response: Response | undefined;
+  navigation: Navigation | undefined;
 }
 
 declare module "vue/types/vue" {

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -21,7 +21,7 @@ const CuriPlugin: PluginObject<CuriPluginOptions> = {
     // create a reactive object so that components will receive
     // the new response/navigation when a new response is emitted
     const reactive: ReactiveResponse = new Vue({
-      data: { response: null, navigation: null }
+      data: options.router.current()
     });
 
     options.router.observe(({ response, navigation }) => {

--- a/packages/vue/types/interface.d.ts
+++ b/packages/vue/types/interface.d.ts
@@ -1,7 +1,7 @@
 import { CuriRouter, Response, Navigation } from "@curi/types";
 export interface ReactiveResponse {
-    response: Response;
-    navigation: Navigation;
+    response: Response | undefined;
+    navigation: Navigation | undefined;
 }
 declare module "vue/types/vue" {
     interface Vue {

--- a/website/src/pages/Guides/sync-or-async.js
+++ b/website/src/pages/Guides/sync-or-async.js
@@ -68,8 +68,8 @@ function SyncAndAsyncGuide() {
           <li>
             <p>
               If the initial route that matches is async and you try to render
-              immediately, the <IJS>response</IJS> will be <IJS>null</IJS>. You
-              can wait to render until the initial response is ready with{" "}
+              immediately, the <IJS>response</IJS> will be <IJS>undefined</IJS>.
+              You can wait to render until the initial response is ready with{" "}
               <IJS>router.once</IJS>.
             </p>
 

--- a/website/src/pages/Packages/v2/router/api/createRouter.js
+++ b/website/src/pages/Packages/v2/router/api/createRouter.js
@@ -573,15 +573,15 @@ stopCancelling();
             <p>
               If you call <IJS>current</IJS> before the initial response has
               been generated, the <IJS>response</IJS> and <IJS>navigation</IJS>{" "}
-              properties will be <IJS>null</IJS>.
+              properties will be <IJS>undefined</IJS>.
             </p>
           </Note>
 
           <CodeBlock>
             {`const router = createRouter(browser, routes);
 const tooSoon = router.current();
-// tooSoon.response === null
-// tooSoon.navigation === null
+// tooSoon.response === undefined
+// tooSoon.navigation === undefined
 
 router.once(({ response, navigation }) => {
   const perfect = router.current();

--- a/website/src/pages/Tutorials/react-advanced.js
+++ b/website/src/pages/Tutorials/react-advanced.js
@@ -229,7 +229,7 @@ const routes = prepareRoutes([
             If you attempt to render immediately after creating a router and the
             initial response is still being created, the <IJS>response</IJS>{" "}
             that will be passed to the <IJS>Router</IJS>'s <IJS>children</IJS>{" "}
-            will be <IJS>null</IJS>.
+            will be <IJS>undefined</IJS>.
           </p>
 
           <p>There are a few possible ways to handle this situation.</p>
@@ -255,15 +255,15 @@ router.once(() => {
 
           <p>
             Alternatively, you can update the root <IJS>App</IJS> component to
-            detect when the <IJS>response</IJS> is <IJS>null</IJS> and render a
-            loading message.
+            detect when the <IJS>response</IJS> is <IJS>undefined</IJS> and
+            render a loading message.
           </p>
 
           <CodeBlock>
             {`// render fallback when response is null
 function App() {
   const { response } = useResponse();
-  if (response == null) {
+  if (response === undefined) {
     return <div>Loading...</div>;
   }
   const { body:Body } = response;


### PR DESCRIPTION
The initial values of `response` and `navigation` are now `undefined` instead of `null`. This only affects calls to `router.current` since observers are not called until a response has been created.