### PR TITLE
Allow redirect: { url }

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 5223,
+    "bundled": 5282,
     "minified": 2474,
     "gzipped": 1113,
     "treeshaked": {
@@ -14,17 +14,17 @@
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 5657,
+    "bundled": 5716,
     "minified": 2819,
     "gzipped": 1230
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 12814,
+    "bundled": 12901,
     "minified": 4713,
     "gzipped": 1892
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 12295,
+    "bundled": 12382,
     "minified": 4387,
     "gzipped": 1719
   }

--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 16712,
-    "minified": 6684,
-    "gzipped": 2702,
+    "bundled": 16851,
+    "minified": 6759,
+    "gzipped": 2718,
     "treeshaked": {
       "rollup": {
         "code": 50,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17025,
-    "minified": 6951,
-    "gzipped": 2795
+    "bundled": 17164,
+    "minified": 7026,
+    "gzipped": 2811
   },
   "dist/curi-router.umd.js": {
-    "bundled": 29893,
-    "minified": 9356,
-    "gzipped": 3927
+    "bundled": 30052,
+    "minified": 9394,
+    "gzipped": 3939
   },
   "dist/curi-router.min.js": {
-    "bundled": 28266,
-    "minified": 8469,
-    "gzipped": 3521
+    "bundled": 28425,
+    "minified": 8507,
+    "gzipped": 3533
   }
 }

--- a/packages/router/src/router/finishResponse.ts
+++ b/packages/router/src/router/finishResponse.ts
@@ -1,4 +1,4 @@
-import { isExternalRedirect } from "./typeGuards";
+import { isExternalRedirect, isRedirectLocation } from "./typeGuards";
 
 import {
   CuriRouter,
@@ -81,14 +81,16 @@ export default function finishResponse(
 }
 
 function createRedirect(
-  redirect: RedirectProps | ExternalRedirect,
+  redirect: RedirectProps | RedirectLocation | ExternalRedirect,
   router: CuriRouter
 ): RedirectLocation | ExternalRedirect {
   if (isExternalRedirect(redirect)) {
     return redirect;
   }
   let { name, params, query, hash, state } = redirect;
-  let url = router.url({ name, params, query, hash });
+  let url = isRedirectLocation(redirect)
+    ? redirect.url
+    : router.url({ name, params, query, hash });
   return {
     name,
     params,

--- a/packages/router/src/router/typeGuards.ts
+++ b/packages/router/src/router/typeGuards.ts
@@ -15,3 +15,9 @@ export function isExternalRedirect(
 ): redirect is ExternalRedirect {
   return "externalURL" in redirect;
 }
+
+export function isRedirectLocation(
+  redirect: ExternalRedirect | RedirectLocation | RedirectProps
+): redirect is RedirectLocation {
+  return "url" in redirect;
+}

--- a/packages/router/tests/createRouter.spec.ts
+++ b/packages/router/tests/createRouter.spec.ts
@@ -1966,6 +1966,31 @@ describe("createRouter", () => {
               });
             });
 
+            it("works with redirect that provides URL", () => {
+              let routes = prepareRoutes([
+                {
+                  name: "A Route",
+                  path: "",
+                  respond: () => {
+                    return {
+                      redirect: {
+                        url: "/some-page"
+                      }
+                    };
+                  }
+                }
+              ]);
+              let router = createRouter(inMemory, routes, {
+                history: {
+                  locations: [{ url: "/" }]
+                }
+              });
+              let { response } = router.current();
+              expect(response.redirect).toMatchObject({
+                url: "/some-page"
+              });
+            });
+
             it("works with external redirects", () => {
               let routes = prepareRoutes([
                 {

--- a/packages/router/types/router/typeGuards.d.ts
+++ b/packages/router/types/router/typeGuards.d.ts
@@ -1,3 +1,4 @@
 import { Route, AsyncRoute, ExternalRedirect, RedirectLocation, RedirectProps } from "@curi/types";
 export declare function isAsyncRoute(route: Route): route is AsyncRoute;
 export declare function isExternalRedirect(redirect: ExternalRedirect | RedirectLocation | RedirectProps): redirect is ExternalRedirect;
+export declare function isRedirectLocation(redirect: ExternalRedirect | RedirectLocation | RedirectProps): redirect is RedirectLocation;


### PR DESCRIPTION
This PR allows a user to provide a redirect `url` string instead of specifying the location to redirect to with a name/params. The user is expected to include any hash/query segments in the `url` string.