### PR TITLE
Fix React Link types

### DIFF
--- a/packages/react-dom/.size-snapshot.json
+++ b/packages/react-dom/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/curi-react-dom.es.js": {
-    "bundled": 5282,
+    "bundled": 5283,
     "minified": 2474,
     "gzipped": 1113,
     "treeshaked": {
@@ -14,17 +14,17 @@
     }
   },
   "dist/curi-react-dom.js": {
-    "bundled": 5716,
+    "bundled": 5717,
     "minified": 2819,
     "gzipped": 1230
   },
   "dist/curi-react-dom.umd.js": {
-    "bundled": 12901,
+    "bundled": 12902,
     "minified": 4713,
     "gzipped": 1892
   },
   "dist/curi-react-dom.min.js": {
-    "bundled": 12382,
+    "bundled": 12383,
     "minified": 4387,
     "gzipped": 1719
   }

--- a/packages/react-dom/CHANGELOG.md
+++ b/packages/react-dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Fix `Link` and `AsyncLink` types.
+
 ## 2.0.0
 
 Consolidated CHANGELOG for v2:

--- a/packages/react-dom/src/Link.tsx
+++ b/packages/react-dom/src/Link.tsx
@@ -7,21 +7,24 @@ import {
 import { canNavigate } from "./utils";
 
 import { RouteLocation } from "@curi/types";
-import { NavigatingChildren, NavigationHookProps } from "@curi/react-universal";
+import { NavType } from "@hickory/root";
+import { NavigatingChildren } from "@curi/react-universal";
 
-interface BaseLinkProps extends RouteLocation {
-  anchor?: React.ReactType;
+type BaseLinkProps = RouteLocation &
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    anchor?: React.ReactType;
+    onNav?: (e: React.MouseEvent<HTMLElement>) => void;
+    method?: NavType;
+    target?: string;
+  };
+
+export interface LinkProps extends BaseLinkProps {
+  children: React.ReactNode;
 }
 
-export type LinkProps = BaseLinkProps &
-  NavigationHookProps<React.MouseEvent<HTMLElement>> & {
-    children: React.ReactNode;
-  };
-
-export type AsyncLinkProps = BaseLinkProps &
-  NavigationHookProps<React.MouseEvent<HTMLElement>> & {
-    children: NavigatingChildren;
-  };
+export interface AsyncLinkProps extends BaseLinkProps {
+  children: NavigatingChildren;
+}
 
 export let Link = React.forwardRef((props: LinkProps, ref: React.Ref<any>) => {
   let {

--- a/packages/react-dom/types/Link.d.ts
+++ b/packages/react-dom/types/Link.d.ts
@@ -1,19 +1,19 @@
 import React from "react";
 import { RouteLocation } from "@curi/types";
-import { NavigatingChildren, NavigationHookProps } from "@curi/react-universal";
-interface BaseLinkProps extends RouteLocation {
+import { NavType } from "@hickory/root";
+import { NavigatingChildren } from "@curi/react-universal";
+declare type BaseLinkProps = RouteLocation & React.AnchorHTMLAttributes<HTMLAnchorElement> & {
     anchor?: React.ReactType;
+    onNav?: (e: React.MouseEvent<HTMLElement>) => void;
+    method?: NavType;
+    target?: string;
+};
+export interface LinkProps extends BaseLinkProps {
+    children: React.ReactNode;
 }
-export declare type LinkProps = BaseLinkProps & NavigationHookProps<React.MouseEvent<HTMLElement>> & {
-    children: React.ReactNode;
-};
-export declare type AsyncLinkProps = BaseLinkProps & NavigationHookProps<React.MouseEvent<HTMLElement>> & {
+export interface AsyncLinkProps extends BaseLinkProps {
     children: NavigatingChildren;
-};
-export declare let Link: React.ForwardRefExoticComponent<BaseLinkProps & NavigationHookProps<React.MouseEvent<HTMLElement, MouseEvent>> & {
-    children: React.ReactNode;
-} & React.RefAttributes<any>>;
-export declare let AsyncLink: React.ForwardRefExoticComponent<BaseLinkProps & NavigationHookProps<React.MouseEvent<HTMLElement, MouseEvent>> & {
-    children: NavigatingChildren;
-} & React.RefAttributes<any>>;
+}
+export declare let Link: React.ForwardRefExoticComponent<LinkProps & React.RefAttributes<any>>;
+export declare let AsyncLink: React.ForwardRefExoticComponent<AsyncLinkProps & React.RefAttributes<any>>;
 export {};

--- a/packages/react-native/.size-snapshot.json
+++ b/packages/react-native/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/curi-react-native.es.js": {
-    "bundled": 3667,
+    "bundled": 3668,
     "minified": 1748,
     "gzipped": 748,
     "treeshaked": {
@@ -14,7 +14,7 @@
     }
   },
   "dist/curi-react-native.js": {
-    "bundled": 4108,
+    "bundled": 4109,
     "minified": 2074,
     "gzipped": 866
   }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Fix `Link` and `AsyncLink` types.
+
 ## 2.0.0
 
 Consolidated CHANGELOG for v2:

--- a/packages/react-native/src/Link.tsx
+++ b/packages/react-native/src/Link.tsx
@@ -6,23 +6,26 @@ import {
   useURL
 } from "@curi/react-universal";
 
-import { GestureResponderEvent } from "react-native";
+import { GestureResponderEvent, TouchableHighlightProps } from "react-native";
+import { NavType } from "@hickory/root";
 import { RouteLocation } from "@curi/types";
-import { NavigatingChildren, NavigationHookProps } from "@curi/react-universal";
+import { NavigatingChildren } from "@curi/react-universal";
 
-interface BaseLinkProps extends RouteLocation {
-  anchor?: React.ReactType;
+type BaseLinkProps = RouteLocation &
+  TouchableHighlightProps & {
+    anchor?: React.ReactType;
+    onNav?: (e: GestureResponderEvent) => void;
+    method?: NavType;
+    target?: string;
+  };
+
+export interface LinkProps extends BaseLinkProps {
+  children: React.ReactNode;
 }
 
-export type LinkProps = BaseLinkProps &
-  NavigationHookProps<GestureResponderEvent> & {
-    children: React.ReactNode;
-  };
-
-export type AsyncLinkProps = BaseLinkProps &
-  NavigationHookProps<GestureResponderEvent> & {
-    children: NavigatingChildren;
-  };
+export interface AsyncLinkProps extends BaseLinkProps {
+  children: NavigatingChildren;
+}
 
 function canNavigate(event: GestureResponderEvent) {
   return !event.defaultPrevented;

--- a/packages/react-native/types/Link.d.ts
+++ b/packages/react-native/types/Link.d.ts
@@ -1,20 +1,20 @@
 import React from "react";
-import { GestureResponderEvent } from "react-native";
+import { GestureResponderEvent, TouchableHighlightProps } from "react-native";
+import { NavType } from "@hickory/root";
 import { RouteLocation } from "@curi/types";
-import { NavigatingChildren, NavigationHookProps } from "@curi/react-universal";
-interface BaseLinkProps extends RouteLocation {
+import { NavigatingChildren } from "@curi/react-universal";
+declare type BaseLinkProps = RouteLocation & TouchableHighlightProps & {
     anchor?: React.ReactType;
+    onNav?: (e: GestureResponderEvent) => void;
+    method?: NavType;
+    target?: string;
+};
+export interface LinkProps extends BaseLinkProps {
+    children: React.ReactNode;
 }
-export declare type LinkProps = BaseLinkProps & NavigationHookProps<GestureResponderEvent> & {
-    children: React.ReactNode;
-};
-export declare type AsyncLinkProps = BaseLinkProps & NavigationHookProps<GestureResponderEvent> & {
+export interface AsyncLinkProps extends BaseLinkProps {
     children: NavigatingChildren;
-};
-export declare let Link: React.ForwardRefExoticComponent<BaseLinkProps & NavigationHookProps<GestureResponderEvent> & {
-    children: React.ReactNode;
-} & React.RefAttributes<any>>;
-export declare let AsyncLink: React.ForwardRefExoticComponent<BaseLinkProps & NavigationHookProps<GestureResponderEvent> & {
-    children: NavigatingChildren;
-} & React.RefAttributes<any>>;
+}
+export declare let Link: React.ForwardRefExoticComponent<LinkProps & React.RefAttributes<any>>;
+export declare let AsyncLink: React.ForwardRefExoticComponent<AsyncLinkProps & React.RefAttributes<any>>;
 export {};


### PR DESCRIPTION
Fixes #237

The previous types included props that get passed to `useNavigationHandler` by the `Link` that the user doesn't actually provide themselves.