### PR TITLE
Omit undefined optional params from match params

### DIFF
--- a/packages/router/.size-snapshot.json
+++ b/packages/router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/curi-router.es.js": {
-    "bundled": 17377,
-    "minified": 6670,
-    "gzipped": 2742,
+    "bundled": 17449,
+    "minified": 6687,
+    "gzipped": 2748,
     "treeshaked": {
       "rollup": {
         "code": 50,
@@ -14,18 +14,18 @@
     }
   },
   "dist/curi-router.js": {
-    "bundled": 17690,
-    "minified": 6933,
-    "gzipped": 2835
+    "bundled": 17762,
+    "minified": 6950,
+    "gzipped": 2845
   },
   "dist/curi-router.umd.js": {
-    "bundled": 30582,
-    "minified": 9339,
-    "gzipped": 3994
+    "bundled": 30662,
+    "minified": 9356,
+    "gzipped": 4002
   },
   "dist/curi-router.min.js": {
-    "bundled": 28966,
-    "minified": 8465,
-    "gzipped": 3588
+    "bundled": 29046,
+    "minified": 8482,
+    "gzipped": 3595
   }
 }

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Omit undefined optional params from match params
+
 ## 2.0.1
 
 * The `div` inserted by `announce` sets `top: 0;` to prevent overflow on fixed size websites.

--- a/packages/router/src/prepareRoutes.ts
+++ b/packages/router/src/prepareRoutes.ts
@@ -177,7 +177,9 @@ let createMatch = (
     for (let i = 0, len = parsed.length; i < len; i++) {
       let name = keys[i].name;
       let fn = parsers[name] || decodeURIComponent;
-      params[name] = fn(parsed[i]);
+      if (parsed[i] !== undefined) {
+        params[name] = fn(parsed[i]);
+      }
     }
   }
 

--- a/packages/router/tests/createRouter.spec.ts
+++ b/packages/router/tests/createRouter.spec.ts
@@ -1902,6 +1902,24 @@ describe("createRouter", () => {
                 });
               });
 
+              it("does not include optional param if it does not exist", () => {
+                let routes = prepareRoutes([
+                  {
+                    name: "Profile",
+                    path: "user/:firstName/:lastName?"
+                  }
+                ]);
+                let router = createRouter(inMemory, routes, {
+                  history: {
+                    locations: [{ url: "/user/tina" }]
+                  }
+                });
+                let { response } = router.current();
+                expect(response.name).toBe("Profile");
+                expect("firstName" in response.params).toBe(true);
+                expect("lastName" in response.params).toBe(false);
+              });
+
               it("throws if param parser throws", () => {
                 let routes = prepareRoutes([
                   {
@@ -1974,7 +1992,7 @@ describe("createRouter", () => {
                   respond: () => {
                     return {
                       redirect: {
-                        url: "/some-page"
+                        externalURL: "/some-page"
                       }
                     };
                   }
@@ -1987,7 +2005,7 @@ describe("createRouter", () => {
               });
               let { response } = router.current();
               expect(response.redirect).toMatchObject({
-                url: "/some-page"
+                externalURL: "/some-page"
               });
             });
 


### PR DESCRIPTION
https://github.com/pshrmn/curi/issues/249

I elected to omit instead of including the property with an `undefined` value so that passing the params back to be compiled into a URL does not error.